### PR TITLE
IBMQExperiment and FreeformDesign quality-of-life updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ jupyter_notebooks/Tutorials/tutorial_files/exampleBriefReport
 jupyter_notebooks/Tutorials/tutorial_files/*.ipynb
 jupyter_notebooks/Tutorials/tutorial_files/tempTest
 jupyter_notebooks/Tutorials/tutorial_files/*checkpoints
+jupyter_notebooks/Tutorials/objects/advanced/test_ibmq
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ jupyter_notebooks/Tutorials/tutorial_files/exampleBriefReport
 jupyter_notebooks/Tutorials/tutorial_files/*.ipynb
 jupyter_notebooks/Tutorials/tutorial_files/tempTest
 jupyter_notebooks/Tutorials/tutorial_files/*checkpoints
-jupyter_notebooks/Tutorials/objects/advanced/test_ibmq
+jupyter_notebooks/Tutorials/objects/advanced/test_ibmq*
 
 
 

--- a/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb
+++ b/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "nbval-skip"
@@ -45,66 +45,6 @@
    "outputs": [],
    "source": [
     "from qiskit_ibm_provider import IBMProvider"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/sserita/Documents/repos/subcirc-vb/src/pygsti/pygsti/extras/ibmq/ibmqcore.py:468: UserWarning: Failed to load ibmqexperiment, falling back to old serialization format logic\n",
-      "  _warnings.warn(\"Failed to load ibmqexperiment, falling back to old serialization format logic\")\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading job 1/7...\n",
-      "Loading job 2/7...\n",
-      "Loading job 3/7...\n",
-      "Loading job 4/7...\n",
-      "Loading job 5/7...\n",
-      "Loading job 6/7...\n",
-      "Loading job 7/7...\n"
-     ]
-    }
-   ],
-   "source": [
-    "exp2 = ibmq.IBMQExperiment.from_dir('test_ibmq_experiment', regen_qiskit_circs=True, regen_runtime_jobs=True, provider=provider)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Already retrieved results of 7/7 circuit batches\n"
-     ]
-    },
-    {
-     "ename": "AttributeError",
-     "evalue": "'IBMQExperiment' object has no attribute 'edesign'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[1;32m/Users/sserita/Documents/repos/subcirc-vb/src/pygsti/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb Cell 6\u001b[0m line \u001b[0;36m1\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/sserita/Documents/repos/subcirc-vb/src/pygsti/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb#Y303sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m exp2\u001b[39m.\u001b[39;49mretrieve_results()\n",
-      "File \u001b[0;32m~/Documents/repos/subcirc-vb/src/pygsti/pygsti/extras/ibmq/ibmqcore.py:394\u001b[0m, in \u001b[0;36mIBMQExperiment.retrieve_results\u001b[0;34m(self, dirname)\u001b[0m\n\u001b[1;32m    391\u001b[0m         counts_data \u001b[39m=\u001b[39m partial_trace(ordered_target_indices, reverse_dict_key_bits(batch_result\u001b[39m.\u001b[39mget_counts(i)))\n\u001b[1;32m    392\u001b[0m         ds\u001b[39m.\u001b[39madd_count_dict(circ, counts_data)\n\u001b[0;32m--> 394\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata \u001b[39m=\u001b[39m _ProtocolData(\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49medesign, ds)\n\u001b[1;32m    396\u001b[0m \u001b[39mif\u001b[39;00m dirname \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    397\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata\u001b[39m.\u001b[39mwrite(dirname, edesign_already_written\u001b[39m=\u001b[39m\u001b[39mTrue\u001b[39;00m)\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'IBMQExperiment' object has no attribute 'edesign'"
-     ]
-    }
-   ],
-   "source": [
-    "exp2.retrieve_results()"
    ]
   },
   {
@@ -127,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "nbval-skip"

--- a/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb
+++ b/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb
@@ -11,7 +11,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "qiskit.__qiskit_version__ = {'qiskit-terra': '0.25.3', 'qiskit': '0.44.3', 'qiskit-aer': None, 'qiskit-ignis': None, 'qiskit-ibmq-provider': '0.20.2', 'qiskit-nature': None, 'qiskit-finance': None, 'qiskit-optimization': None, 'qiskit-machine-learning': None}\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "nbval-skip"
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "nbval-skip"
@@ -90,8 +90,14 @@
    },
    "outputs": [],
    "source": [
-    "dev_name = 'ibm_lagos'\n",
-    "backend = provider.get_backend(dev_name)"
+    "# Use backends() to see what backends you have access to\n",
+    "#provider.backends()\n",
+    "\n",
+    "# Can use a physical device...\n",
+    "backend = provider.get_backend('ibm_hanoi')\n",
+    "\n",
+    "# ... or can use a simulator\n",
+    "sim_backend = provider.get_backend('ibmq_qasm_simulator')"
    ]
   },
   {
@@ -112,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "nbval-skip"
@@ -226,9 +232,9 @@
    "metadata": {},
    "source": [
     "## Running on IBM Q\n",
-    "We're now ready to run on the IBM Q processor. We do this using an `IBMQExperiment` object, which \n",
+    "We're now ready to run on the IBM Q processor. We do this using an `IBMQExperiment` object.\n",
     "\n",
-    "First it converts pyGSTi circuits into jobs that can be submitted to IBM Q. **This step includes transpiling of the pyGSTi circuits into OpenQASM** (and then into QisKit objects)."
+    "We can enable checkpointing for `IBMQExperiment` objects by writing the object to disk now, and then providing the directory name in downstream calls."
    ]
   },
   {
@@ -239,14 +245,64 @@
    },
    "outputs": [],
    "source": [
-    "exp = ibmq.IBMQExperiment(combined_edesign, pspec, circuits_per_batch=75, num_shots=1024)"
+    "exp = ibmq.IBMQExperiment(combined_edesign, pspec, circuits_per_batch=75, num_shots=1024, seed=20231201)\n",
+    "exp.write('test_ibmq')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're now ready to submit this experiment to IBM Q."
+    "First we convert pyGSTi circuits into jobs that can be submitted to IBM Q. **This step includes transpiling of the pyGSTi circuits into OpenQASM** (and then into QisKit objects)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Provide the directory name to enable transpilation checkpointing\n",
+    "exp.transpile(dirname='test_ibmq')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can simulate having been interrupted by removing the last few transpiled batches\n",
+    "del exp.qasm_circuit_batches[4:]\n",
+    "del exp.qiskit_circuit_batches[4:]\n",
+    "\n",
+    "# And now transpilation should only redo the missing batches\n",
+    "exp.transpile(dirname='test_ibmq')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the `IBMQExperiment` object is lost and needs to be reloaded (i.e. notebook restarts), it can be loaded from file now.\n",
+    "\n",
+    "However, the Qiskit circuits are not automatically regenerated from the transpiled QASM during loading for speed. They can (and need to be regenerated if calling `submit()`) by passing in the `regen_qiskit_circs=True` flag to `from_dir()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp2 = ibmq.IBMQExperiment.from_dir('test_ibmq', regen_qiskit_circs=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We're now ready to submit this experiment to IBM Q.Note that we can submit using a different backend than what was used to generate the experiment design. In general, it is not a good idea to mix and match backends for physical devices unless they have the exact same connectivity and qubit labeling; however, it **is** often useful for debugging purposes to use the simulator backend rather than a physical device."
    ]
   },
   {
@@ -259,14 +315,15 @@
    },
    "outputs": [],
    "source": [
-    "exp.submit(backend)"
+    "# Again, we can checkpoint by passing in dirname\n",
+    "exp2.submit(sim_backend, dirname='test_ibmq')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can then monitor the jobs. If get an error message, you can query the error using `exp['qjob'][i].error_message()` for batch `i`."
+    "You can then monitor the jobs. If get an error message, you can query the error using `exp.qjobs[i].error_message()` for batch `i`."
    ]
   },
   {
@@ -279,7 +336,32 @@
    },
    "outputs": [],
    "source": [
-    "exp.monitor()"
+    "exp2.monitor()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, the `IBMQExperiment` can be loaded from file if checkpointing is being used. The Qiskit RuntimeJobs are not serialized; however, they can be retrieved from the IBMQ service from their job ids. In order to do this, pass `regen_runtime_jobs=True` and a `provider` to the `from_dir()` call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp3 = ibmq.IBMQExperiment.from_dir('test_ibmq', regen_runtime_jobs=True, provider=provider)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp3.monitor()"
    ]
   },
   {
@@ -299,7 +381,7 @@
    },
    "outputs": [],
    "source": [
-    "exp.retrieve_results()"
+    "exp3.retrieve_results(dirname='test_ibmq')"
    ]
   },
   {
@@ -317,7 +399,7 @@
    },
    "outputs": [],
    "source": [
-    "print(exp.keys())"
+    "print(exp3.keys())"
    ]
   },
   {
@@ -337,70 +419,14 @@
    },
    "outputs": [],
    "source": [
-    "data = exp['data']"
+    "data = exp3.data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can write this data to disk, which saves the `ProtocolData` in the standard pyGSTi format. It also pickles (or JSONs) up all of the additional information contained then `IBMQExperiment` object, e.g., the job IDs, in a subfolder `ibmqexperiment`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "exp.write('test_ibmq_experiment')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you only want to load the `ProtocolData` you can do this using pyGSTi's standard `io` functions. We can also load the `IBMQExperiment` object, which will skip unpickling any objects when the unpickling fails (e.g., due to changes in `QisKit`).\n",
-    "\n",
-    "New in '0.9.12': IBM jobs are no longer pickle-able. Instead, they will be retrieved from the server. However, this requires the provider to be passed in at load time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "loaded_exp = ibmq.IBMQExperiment.from_dir('test_ibmq_experiment', provider)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "nbval-skip"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# Now we can run as before\n",
-    "loaded_exp.monitor()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Analzing the results\n",
+    "## Analyzing the results\n",
     "Because `retrieve_results()` has formatted the data into a `ProctocolData` object, we can just hand this to the analysis protocol(s) that are designed for analyzing this type of data. Here we'll analyze this data using a standard RB curve-fitting analysis."
    ]
   },
@@ -473,7 +499,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb
+++ b/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb
@@ -11,16 +11,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "qiskit.__qiskit_version__ = {'qiskit-terra': '0.25.3', 'qiskit': '0.44.3', 'qiskit-aer': None, 'qiskit-ignis': None, 'qiskit-ibmq-provider': '0.20.2', 'qiskit-nature': None, 'qiskit-finance': None, 'qiskit-optimization': None, 'qiskit-machine-learning': None}\n",
-    "qiskit_ibm_provider.__version__ = '0.7.2'"
+    "#qiskit.__qiskit_version__ = {'qiskit-terra': '0.25.3', 'qiskit': '0.44.3', 'qiskit-aer': None, 'qiskit-ignis': None, 'qiskit-ibmq-provider': '0.20.2', 'qiskit-nature': None, 'qiskit-finance': None, 'qiskit-optimization': None, 'qiskit-machine-learning': None}\n",
+    "#qiskit_ibm_provider.__version__ = '0.7.2'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -34,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "nbval-skip"
@@ -43,6 +45,66 @@
    "outputs": [],
    "source": [
     "from qiskit_ibm_provider import IBMProvider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sserita/Documents/repos/subcirc-vb/src/pygsti/pygsti/extras/ibmq/ibmqcore.py:468: UserWarning: Failed to load ibmqexperiment, falling back to old serialization format logic\n",
+      "  _warnings.warn(\"Failed to load ibmqexperiment, falling back to old serialization format logic\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading job 1/7...\n",
+      "Loading job 2/7...\n",
+      "Loading job 3/7...\n",
+      "Loading job 4/7...\n",
+      "Loading job 5/7...\n",
+      "Loading job 6/7...\n",
+      "Loading job 7/7...\n"
+     ]
+    }
+   ],
+   "source": [
+    "exp2 = ibmq.IBMQExperiment.from_dir('test_ibmq_experiment', regen_qiskit_circs=True, regen_runtime_jobs=True, provider=provider)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Already retrieved results of 7/7 circuit batches\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "'IBMQExperiment' object has no attribute 'edesign'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m/Users/sserita/Documents/repos/subcirc-vb/src/pygsti/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb Cell 6\u001b[0m line \u001b[0;36m1\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/sserita/Documents/repos/subcirc-vb/src/pygsti/jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb#Y303sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m exp2\u001b[39m.\u001b[39;49mretrieve_results()\n",
+      "File \u001b[0;32m~/Documents/repos/subcirc-vb/src/pygsti/pygsti/extras/ibmq/ibmqcore.py:394\u001b[0m, in \u001b[0;36mIBMQExperiment.retrieve_results\u001b[0;34m(self, dirname)\u001b[0m\n\u001b[1;32m    391\u001b[0m         counts_data \u001b[39m=\u001b[39m partial_trace(ordered_target_indices, reverse_dict_key_bits(batch_result\u001b[39m.\u001b[39mget_counts(i)))\n\u001b[1;32m    392\u001b[0m         ds\u001b[39m.\u001b[39madd_count_dict(circ, counts_data)\n\u001b[0;32m--> 394\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata \u001b[39m=\u001b[39m _ProtocolData(\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49medesign, ds)\n\u001b[1;32m    396\u001b[0m \u001b[39mif\u001b[39;00m dirname \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    397\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata\u001b[39m.\u001b[39mwrite(dirname, edesign_already_written\u001b[39m=\u001b[39m\u001b[39mTrue\u001b[39;00m)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'IBMQExperiment' object has no attribute 'edesign'"
+     ]
+    }
+   ],
+   "source": [
+    "exp2.retrieve_results()"
    ]
   },
   {
@@ -65,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "tags": [
      "nbval-skip"

--- a/pygsti/io/metadir.py
+++ b/pygsti/io/metadir.py
@@ -10,6 +10,7 @@ Serialization routines to/from a meta.json based directory
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+import datetime as _dt
 import numpy as _np
 import scipy.sparse as _sps
 import importlib as _importlib
@@ -22,6 +23,13 @@ try:
     from bson.objectid import ObjectId as _ObjectId
 except ImportError:
     _ObjectId = None
+
+try:
+    # If available, use bson's JSON converter utilities
+    # Allows us to serialize datetime objects, for example
+    from bson import json_util as _json_util
+except ImportError:
+    _json_util=None
 
 from pygsti.io import readers as _load
 from pygsti.io import writers as _write
@@ -146,7 +154,10 @@ def load_meta_based_dir(root_dir, auxfile_types_member='auxfile_types',
     ret = {}
 
     with open(str(root_dir / 'meta.json'), 'r') as f:
-        meta = _json.load(f)
+        if _json_util is not None:
+            meta = _json.load(f, object_hook=_json_util.object_hook)
+        else:
+            meta = _json.load(f)
 
         #Convert lists => tuples, as we prefer immutable tuples
         #for key in meta:
@@ -302,7 +313,10 @@ def _load_auxfile_member(root_dir, filenm, typ, metadata, quick_load):
             val = _np.load(pth)
         elif typ == 'json':
             with open(str(pth), 'r') as f:
-                val = _json.load(f)
+                if _json_util is not None:
+                    val = _json.load(f, object_hook=_json_util.object_hook)
+                else:
+                    val = _json.load(f)
         elif typ == 'pickle':
             with open(str(pth), 'rb') as f:
                 val = _pickle.load(f)
@@ -386,7 +400,10 @@ def write_meta_based_dir(root_dir, valuedict, auxfile_types=None, init_meta=None
 
     with open(str(root_dir / 'meta.json'), 'w') as f:
         _check_jsonable(meta)
-        _json.dump(meta, f)
+        if _json_util is not None:
+            _json.dump(meta, f, indent=4, default=_json_util.default)
+        else:
+            _json.dump(meta, f, indent=4)
 
 
 def _write_auxfile_member(root_dir, filenm, typ, val):
@@ -451,7 +468,10 @@ def _write_auxfile_member(root_dir, filenm, typ, val):
         elif typ == 'json':
             with open(str(pth), 'w') as f:
                 _check_jsonable(val)
-                _json.dump(val, f, indent=4)
+                if _json_util is not None:
+                    _json.dump(val, f, indent=4, default=_json_util.default)
+                else:
+                    _json.dump(val, f, indent=4)
         elif typ == 'pickle':
             with open(str(pth), 'wb') as f:
                 _pickle.dump(val, f)
@@ -475,7 +495,10 @@ def _cls_from_meta_json(dirname):
     class
     """
     with open(str(_pathlib.Path(dirname) / 'meta.json'), 'r') as f:
-        meta = _json.load(f)
+        if _json_util is not None:
+            meta = _json.load(f, object_hook=_json_util.object_hook)
+        else:
+            meta = _json.load(f)
     return _class_for_name(meta['type'])  # class of object to create
 
 
@@ -501,7 +524,10 @@ def _obj_to_meta_json(obj, dirname):
     meta = {'type': _full_class_name(obj)}
     with open(str(_pathlib.Path(dirname) / 'meta.json'), 'w') as f:
         _check_jsonable(meta)
-        _json.dump(meta, f)
+        if _json_util is not None:
+            _json.dump(meta, f, indent=4, default=_json_util.default)
+        else:
+            _json.dump(meta, f, indent=4)
 
 
 def write_obj_to_meta_based_dir(obj, dirname, auxfile_types_member, omit_attributes=(),
@@ -633,7 +659,10 @@ def write_dict_to_json_or_pkl_files(d, dirname):
             jsonable = _to_jsonable(val)
             _check_jsonable(jsonable)
             with open(dirname / (key + '.json'), 'w') as f:
-                _json.dump(jsonable, f)
+                if _json_util is not None:
+                    _json.dump(jsonable, f, indent=4, default=_json_util.default)
+                else:
+                    _json.dump(jsonable, f, indent=4)
         except Exception as e:
             fn = str(dirname / (key + '.json'))
             _warnings.warn("Could not write %s (falling back on pickle format):\n" % fn + str(e))
@@ -673,6 +702,8 @@ def _check_jsonable(x):
         doesn't contain dicts with non-string-valued keys """
     if x is None or isinstance(x, (float, int, str)):
         pass  # no problem
+    elif _json_util is not None and isinstance(x, _dt.datetime):
+        pass # No problem for datetime.datetime so long as we have bson.json_utils
     elif isinstance(x, (tuple, list)):
         for i, v in enumerate(x):
             try:

--- a/pygsti/protocols/protocol.py
+++ b/pygsti/protocols/protocol.py
@@ -1658,12 +1658,9 @@ class FreeformDesign(ExperimentDesign):
         edesign = ExperimentDesign.from_dir(dirname, parent=parent, name=name, quick_load=quick_load)
 
         # Convert back to circuits
-        edesign.aux_info = {_circuits.Circuit(k, check=False, expand_subcircuits=False): v for k,v in edesign.aux_info.items()}
+        edesign.aux_info = {_circuits.Circuit(k, check=False): v for k,v in edesign.aux_info.items()}
         
-        # Reset all_circuits_needing_data (which were not saved for space savings) from aux_info keys
-        edesign.all_circuits_needing_data = list(edesign.aux_info.keys())
-
-        return cls.from_edesign(edesign)
+        return cls(edesign.aux_info, edesign.qubit_labels)
 
     @classmethod
     def from_dataframe(cls, df, qubit_labels=None):
@@ -1760,7 +1757,7 @@ class FreeformDesign(ExperimentDesign):
         mapped_qubit_labels = self._mapped_qubit_labels(mapper)
         return FreeformDesign(mapped_circuits, mapped_qubit_labels)
     
-     def write(self, dirname=None, parent=None):
+    def write(self, dirname=None, parent=None):
         """
         Write this experiment design to a directory.
 
@@ -1782,8 +1779,10 @@ class FreeformDesign(ExperimentDesign):
         None
         """
         # Convert circuits to string for then-jsonable serialization
-        self.aux_info = {str(k):v for k,v in self.aux_info.items()}
+        aux_info = self.aux_info
+        self.aux_info = {repr(k)[8:-1]: v for k,v in self.aux_info.items()}
         super().write(dirname, parent)
+        self.aux_info = aux_info
 
 
 class ProtocolData(_TreeNode, _MongoSerializable):

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,13 @@ extras = {
         'flake8'
     ],
     'interpygate': ['csaps'],
+    'serialization': ['bson'],
     'testing': [
         'pytest',
         'pytest-xdist',
         'pytest-cov',
         'nbval',
+        'bson',
         'csaps',
         'cvxopt<=1.3.0.1',
         'cvxpy',


### PR DESCRIPTION
This PR makes several quality-of-life improvements for `IBMQExperiment` and `FreeformDesign` serialization, including checkpointing for IBMQ experiments mentioned in #327.

`IBMQExperiment` updates:
1. The `IBMQExperiment` class is changed from a dict to a full class that inherits from `TreeNode`, making it commensurate with serialization of objects such as `ExperimentDesign` and `ProtocolData`.
2. With a more granular serialization strategy, it is now possible to checkpoint `IBMQExperiment` objects. If a `dirname` is provided to `transpile()`, `submit()`, or `retrieve_results`, the on-disk `ibmqexperiment` will be updated when possible.
3. If `bson` is installed, we can use the `json_util` hook to handle objects such as `datetime.datetime` which are present in `submit_time_calibration_data` and `batch_results` from the IBMQ server. Depending on the availability of `bson`, we can serialize to all text/json files, but fall back to pickle still.

`FreeformDesign` updates:
1. The `aux_info` member of `FreeformDesign` is written as JSON instead of pickle. To do this, first we cast the Circuit keys as strings and then write the now-JSONable dictionary to file. We convert back to Circuits on deserialization.
2. More controversially, I skip serializing `all_circuits_needing_data` for `FreeformDesign`. This field should match the keys of `aux_info`, and with the size of these designs, it saves quite a lot of space to not double save them (almost 1 GB for some of my SVB use cases!).

I've done my best to make it backwards-compatible; for example, we can still load old pickle-style `IBMQExperiment` directories into the new object. However, the `IBMQExperiment` workflow has to change a little to enable checkpointing - a minor pain point that I hope is well worth it for most users.