### PR TITLE
Implement CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,15 +14,15 @@ pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-maintaine
 pygsti/modelmembers/instruments/ @pcwysoc @sandialabs/pygsti-maintainers
 
 ## RB owners ##
-pygsti/algorithms/compilers.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/algorithms/mirroring.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/algorithms/randomcircuit.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/algorithms/rbfit.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/extras/rb.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers # Should this just be deprecated and removed?
-pygsti/protocols/rb.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/tools/rbtheory.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/tools/rbtools.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-pygsti/tools/symplectic.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/algorithms/compilers.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/algorithms/mirroring.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/algorithms/randomcircuit.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/algorithms/rbfit.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/extras/rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers # Should this just be deprecated and removed?
+pygsti/protocols/rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/tools/rbtheory.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/tools/rbtools.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/tools/symplectic.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
 
 ## Reporting owners ##
 # Specifically just for workspace plots/tables
@@ -35,8 +35,8 @@ pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-maintainers
 # we will also have specific tutorials be owned
 # by topics owners are responsible for above
 jupyter_notebooks/ @sandialabs/pygsti-maintainers
-jupyter_notebooks/**/*RB-*.ipynb @jordanh6 @tjproct @sandialabs/pygsti-maintainers
-jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+jupyter_notebooks/**/*RB-*.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
 jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-maintainers
 jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sandialabs/pygsti-maintainers
 jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,42 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
 ## Global owners (default to pyGSTi maintainers) ##
 # These will also be owners for everything below
 # so they can approve minor PRs without adding
 # undue burden on volunteer code owners
-*       @sserita @coreyostrove @rileyjmurray
+*       @pygsti-maintainers
 
-## Instruments/QILGST owners ##
-pygsti/modelmembers/instruments/ @pcwysoc @sserita @coreyostrove @rileyjmurray
+
+## Drift analysis ##
+pygsti/protocols/stability.py @tjproct @pygsti-maintainers
+pygsti/report/section/drift.py @tjproct @pygsti-maintainers
+pygsti/report/templates/drift_html_report/ @tjproct @pygsti-maintainers
+
+## Instruments owners ##
+pygsti/modelmembers/instruments/ @pcwysoc @pygsti-maintainers
+
+## RB owners ##
+pygsti/algorithms/compilers.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/algorithms/mirroring.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/algorithms/randomcircuit.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/algorithms/rbfit.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/extras/rb.py @jordanh6 @tjproct @pygsti-maintainers # Should this just be deprecated and removed?
+pygsti/protocols/rb.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/tools/rbtheory.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/tools/rbtools.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/tools/symplectic.py @jordanh6 @tjproct @pygsti-maintainers
 
 ## Reporting owners ##
 # Specifically just for workspace plots/tables
-pygsti/report/workspace*.py @pcwysoc @sserita @coreyostrove @rileyjmurray
+pygsti/report/workspace*.py @pcwysoc @pygsti-maintainers
+
+
 
 ## Tutorial owners ##
 # In addition to general tutorial owners,
 # we will also have specific tutorials be owned
-# by topics they own above
-jupyter_notebooks/ @sserita @coreyostrove @rileyjmurray
-jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sserita @coreyostrove @rileyjmurray
-jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sserita @coreyostrove @rileyjmurray
+# by topics owners are responsible for above
+jupyter_notebooks/ @pygsti-maintainers
+jupyter_notebooks/**/*RB-*.ipynb @jordanh6 @tjproct @pygsti-maintainers
+jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @jordanh6 @tjproct @pygsti-maintainers
+jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @pygsti-maintainers
+jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @pygsti-maintainers
+jupyter_notebooks/Tutorials/reporting/ @pcwysoc @pygsti-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,23 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-# Global owners
+## Global owners (default to pyGSTi maintainers) ##
+# These will also be owners for everything below
+# so they can approve minor PRs without adding
+# undue burden on volunteer code owners
 *       @sserita @coreyostrove @rileyjmurray
+
+## Instruments/QILGST owners ##
+pygsti/modelmembers/instruments/ @pcwysoc @sserita @coreyostrove @rileyjmurray
+
+## Reporting owners ##
+# Specifically just for workspace plots/tables
+pygsti/report/workspace*.py @pcwysoc @sserita @coreyostrove @rileyjmurray
+
+## Tutorial owners ##
+# In addition to general tutorial owners,
+# we will also have specific tutorials be owned
+# by topics they own above
+jupyter_notebooks/ @sserita @coreyostrove @rileyjmurray
+jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sserita @coreyostrove @rileyjmurray
+jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sserita @coreyostrove @rileyjmurray

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@ pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-gatekeepe
 
 ## Forward simulators ##
 pygsti/forwardsims @rileyjmurray @sandialabs/pygsti-gatekeepers
+pygsti/forwardsims/termforwardsim* @adhumu @sandialabs/pygsti-gatekeepers
 
 ## IBMQ interface ##
 pygsti/extras/devices @sandialabs/pygsti-ibmq @sandialabs/pygsti-gatekeepers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,31 +2,31 @@
 # These will also be owners for everything below
 # so they can approve minor PRs without adding
 # undue burden on volunteer code owners
-*       @sandialabs/pygsti-maintainers
+*       @sandialabs/pygsti-maintainers @sandialabs/pygsti-gatekeepers
 
 
 ## Drift analysis ##
-pygsti/protocols/stability.py @tjproct @sandialabs/pygsti-maintainers
-pygsti/report/section/drift.py @tjproct @sandialabs/pygsti-maintainers
-pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-maintainers
+pygsti/protocols/stability.py @tjproct @sandialabs/pygsti-gatekeepers
+pygsti/report/section/drift.py @tjproct @sandialabs/pygsti-gatekeepers
+pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-gatekeepers
 
 ## Instruments owners ##
-pygsti/modelmembers/instruments/ @pcwysoc @sandialabs/pygsti-maintainers
+pygsti/modelmembers/instruments/ @pcwysoc @sandialabs/pygsti-gatekeepers
 
 ## RB owners ##
-pygsti/algorithms/compilers.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/algorithms/mirroring.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/algorithms/randomcircuit.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/algorithms/rbfit.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/extras/rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers # Should this just be deprecated and removed?
-pygsti/protocols/rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/tools/rbtheory.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/tools/rbtools.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-pygsti/tools/symplectic.py @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
+pygsti/algorithms/compilers.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/algorithms/mirroring.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/algorithms/randomcircuit.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/algorithms/rbfit.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/extras/rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers # Should this just be deprecated and removed?
+pygsti/protocols/rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/tools/rbtheory.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/tools/rbtools.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+pygsti/tools/symplectic.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 
 ## Reporting owners ##
 # Specifically just for workspace plots/tables
-pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-maintainers
+pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-gatekeepers
 
 
 
@@ -34,9 +34,9 @@ pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-maintainers
 # In addition to general tutorial owners,
 # we will also have specific tutorials be owned
 # by topics owners are responsible for above
-jupyter_notebooks/ @sandialabs/pygsti-maintainers
-jupyter_notebooks/**/*RB-*.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-maintainers
-jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-maintainers
-jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sandialabs/pygsti-maintainers
-jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-maintainers
+jupyter_notebooks/ @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/**/*RB-*.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-gatekeepers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,15 +11,15 @@ pygsti/report/section/drift.py @tjproct @sandialabs/pygsti-gatekeepers
 pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-gatekeepers
 
 ## Model member owners ##
-pygsti/modelmembers/ @rjmurr @sandialabs/pygsti-gatekeepers
+pygsti/modelmembers/ @rileyjmurray @sandialabs/pygsti-gatekeepers
 pygsti/modelmembers/instruments/ @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
 
 ## Modelpack owners ##
 pygsti/modelpacks/ @kmrudin @sandialabs/pygsti-gatekeepers
 
 ## Optimizer owners ##
-pygsti/objectivefns @rjmurr @sandialabs/pygsti-gatekeepers
-pygsti/optimize @rjmurr @sandialabs/pygsti-gatekeepers
+pygsti/objectivefns @rileyjmurray @sandialabs/pygsti-gatekeepers
+pygsti/optimize @rileyjmurray @sandialabs/pygsti-gatekeepers
 
 ## RB owners ##
 pygsti/algorithms/compilers.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,31 +2,31 @@
 # These will also be owners for everything below
 # so they can approve minor PRs without adding
 # undue burden on volunteer code owners
-*       @pygsti-maintainers
+*       @sandialabs/pygsti-maintainers
 
 
 ## Drift analysis ##
-pygsti/protocols/stability.py @tjproct @pygsti-maintainers
-pygsti/report/section/drift.py @tjproct @pygsti-maintainers
-pygsti/report/templates/drift_html_report/ @tjproct @pygsti-maintainers
+pygsti/protocols/stability.py @tjproct @sandialabs/pygsti-maintainers
+pygsti/report/section/drift.py @tjproct @sandialabs/pygsti-maintainers
+pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-maintainers
 
 ## Instruments owners ##
-pygsti/modelmembers/instruments/ @pcwysoc @pygsti-maintainers
+pygsti/modelmembers/instruments/ @pcwysoc @sandialabs/pygsti-maintainers
 
 ## RB owners ##
-pygsti/algorithms/compilers.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/algorithms/mirroring.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/algorithms/randomcircuit.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/algorithms/rbfit.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/extras/rb.py @jordanh6 @tjproct @pygsti-maintainers # Should this just be deprecated and removed?
-pygsti/protocols/rb.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/tools/rbtheory.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/tools/rbtools.py @jordanh6 @tjproct @pygsti-maintainers
-pygsti/tools/symplectic.py @jordanh6 @tjproct @pygsti-maintainers
+pygsti/algorithms/compilers.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/algorithms/mirroring.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/algorithms/randomcircuit.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/algorithms/rbfit.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/extras/rb.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers # Should this just be deprecated and removed?
+pygsti/protocols/rb.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/tools/rbtheory.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/tools/rbtools.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+pygsti/tools/symplectic.py @jordanh6 @tjproct @sandialabs/pygsti-maintainers
 
 ## Reporting owners ##
 # Specifically just for workspace plots/tables
-pygsti/report/workspace*.py @pcwysoc @pygsti-maintainers
+pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-maintainers
 
 
 
@@ -34,9 +34,9 @@ pygsti/report/workspace*.py @pcwysoc @pygsti-maintainers
 # In addition to general tutorial owners,
 # we will also have specific tutorials be owned
 # by topics owners are responsible for above
-jupyter_notebooks/ @pygsti-maintainers
-jupyter_notebooks/**/*RB-*.ipynb @jordanh6 @tjproct @pygsti-maintainers
-jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @jordanh6 @tjproct @pygsti-maintainers
-jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @pygsti-maintainers
-jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @pygsti-maintainers
-jupyter_notebooks/Tutorials/reporting/ @pcwysoc @pygsti-maintainers
+jupyter_notebooks/ @sandialabs/pygsti-maintainers
+jupyter_notebooks/**/*RB-*.ipynb @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @jordanh6 @tjproct @sandialabs/pygsti-maintainers
+jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-maintainers
+jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sandialabs/pygsti-maintainers
+jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,17 @@ pygsti/protocols/stability.py @tjproct @sandialabs/pygsti-gatekeepers
 pygsti/report/section/drift.py @tjproct @sandialabs/pygsti-gatekeepers
 pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-gatekeepers
 
-## Model member owners ##
+## Forward simulators ##
+pygsti/forwardsims @rileyjmurray @sandialabs/pygsti-gatekeepers
+
+## IBMQ interface ##
+pygsti/extras/devices @sandialabs/pygsti-ibmq @sandialabs/pygsti-gatekeepers
+pygsti/extras/ibmq @sandialabs/pygsti-ibmq @sandialabs/pygsti-gatekeepers
+
+## Interpygate ##
+pygsti/extras/interpygate/ @kevincyoung @sandialabs/pygsti-gatekeepers
+
+## Modelmembers ##
 pygsti/modelmembers/ @rileyjmurray @sandialabs/pygsti-gatekeepers
 pygsti/modelmembers/instruments/ @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
 
@@ -49,11 +59,34 @@ pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-gatekeepers
 # by topics owners are responsible for above
 jupyter_notebooks/ @sandialabs/pygsti-tutorials @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/**/*RB-*.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Examples/1QGST-InterpolatedOps.ipynb @kevincyoung @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/algorithms/RobustPhaseEstimation.ipynb @kmrudin @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/objects/advanced/IBMQExperiment.ipynb @sandialabs/pygsti-ibmq @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/objects/advanced/InterpolatedOperators.ipynb @kevincyoung @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/objects/advanced/ModelPacks.ipynb @kmrudin @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-gatekeepers
 
 ## Test owners ##
-# TODO: But code owners should probably also be responsible for their tests too
+test/ @rileyjmurray @sandialabs/pygsti-gatekeepers
+test/test_packages/extras/test_drift.py @tjproct @sandialabs/pygsti-gatekeepers
+test/test_packages/extras/test_interpygate.py @kevincyoung @sandialabs/pygsti-gatekeepers
+test/test_packages/extras/test_rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+test/test_packages/extras/test_rpe.py @kmrudin @sandialabs/pygsti-gatekeepers
+test/test_packages/extras/test_rpeobjects.py @kmrudin @sandialabs/pygsti-gatekeepers
+test/test_packages/objects/test_instruments.py @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
+test/test_packages/report/ @pcwysoc @sandialabs/pygsti-gatekeepers
+test/test_packages/reportb/ @pcwysoc @sandialabs/pygsti-gatekeepers
+test/unit/algorithms/test_randomcircuit.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+test/unit/extras/interpygate @kevincyoung @sandialabs/pygsti-gatekeepers
+test/unit/extras/rb/ @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+test/unit/extras/rpe/ @kmrudin @sandialabs/pygsti-gatekeepers
+test/unit/modelpacks/ @kmrudin @sandialabs/pygsti-gatekeepers
+test/unit/objects/test_instrument.py @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
+test/unit/protocols/test_rb.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+test/unit/report/ @pcwysoc @sandialabs/pygsti-gatekeepers
+test/unit/tools/test_symplectic.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,7 +52,7 @@ jupyter_notebooks/**/*RB-*.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gateke
 jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/algorithms/RobustPhaseEstimation.ipynb @kmrudin @sandialabs/pygsti-gatekeepers
-jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pygsti-mcm @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-gatekeepers
 
 ## Test owners ##

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,16 @@ pygsti/protocols/stability.py @tjproct @sandialabs/pygsti-gatekeepers
 pygsti/report/section/drift.py @tjproct @sandialabs/pygsti-gatekeepers
 pygsti/report/templates/drift_html_report/ @tjproct @sandialabs/pygsti-gatekeepers
 
-## Instruments owners ##
-pygsti/modelmembers/instruments/ @pcwysoc @sandialabs/pygsti-gatekeepers
+## Model member owners ##
+pygsti/modelmembers/ @rjmurr @sandialabs/pygsti-gatekeepers
+pygsti/modelmembers/instruments/ @sandialabs/pygsti-mcm @sandialabs/pygsti-gatekeepers
+
+## Modelpack owners ##
+pygsti/modelpacks/ @kmrudin @sandialabs/pygsti-gatekeepers
+
+## Optimizer owners ##
+pygsti/objectivefns @rjmurr @sandialabs/pygsti-gatekeepers
+pygsti/optimize @rjmurr @sandialabs/pygsti-gatekeepers
 
 ## RB owners ##
 pygsti/algorithms/compilers.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
@@ -24,6 +32,11 @@ pygsti/tools/rbtheory.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 pygsti/tools/rbtools.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 pygsti/tools/symplectic.py @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 
+## RPE owners ##
+pygsti/extras/rpe @kmrudin @sandialabs/pygsti-gatekeepers
+pygsti/models/rpemodel.py @kmrudin @sandialabs/pygsti-gatekeepers
+pygsti/protocols/rpe.py @kmrudin @sandialabs/pygsti-gatekeepers
+
 ## Reporting owners ##
 # Specifically just for workspace plots/tables
 pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-gatekeepers
@@ -34,9 +47,13 @@ pygsti/report/workspace*.py @pcwysoc @sandialabs/pygsti-gatekeepers
 # In addition to general tutorial owners,
 # we will also have specific tutorials be owned
 # by topics owners are responsible for above
-jupyter_notebooks/ @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/ @sandialabs/pygsti-tutorials @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/**/*RB-*.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
-jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/algorithms/DriftCharacterization.ipynb @tjproct @sandialabs/pygsti-gatekeepers
-jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pcwysoc @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/algorithms/MirrorCircuitBenchmarks.ipynb @sandialabs/pygsti-rb @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/algorithms/RobustPhaseEstimation.ipynb @kmrudin @sandialabs/pygsti-gatekeepers
+jupyter_notebooks/Tutorials/objects/advanced/Instruments.ipynb @pygsti-mcm @sandialabs/pygsti-gatekeepers
 jupyter_notebooks/Tutorials/reporting/ @pcwysoc @sandialabs/pygsti-gatekeepers
+
+## Test owners ##
+# TODO: But code owners should probably also be responsible for their tests too


### PR DESCRIPTION
Implement a CODEOWNERS file for pyGSTi to modernize our PR pipeline.

This branch/PR will stay open as we get volunteers in. Edit: We now have all the volunteers and subteams set up.