### PR TITLE
GitHub runner updates

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # to fetch all branches and *tags* (needed to get version number correctly)
   
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.10'
@@ -39,7 +39,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: ./.github/ci-scripts/before_install.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -49,11 +49,11 @@ jobs:
     #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')   # doesn't work -- try using tags: above
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # to fetch all branches and *tags* (needed to get version number correctly)
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.10'
@@ -61,7 +61,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -73,7 +73,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: [3.8, 3.9, '3.10', '3.11']
         
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up installation environment (Ubuntu or Windows)
       if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
@@ -35,11 +35,11 @@ jobs:
       run: |
         ./.github/ci-scripts/before_install_macos.sh
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('**/*requirements.txt') }}

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -21,17 +21,17 @@ jobs:
     strategy:
       fail-fast: false # Finish all tests even if one fails
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9, '3.10', '3.11']
         
     steps:
     - uses: actions/checkout@v2
     - name: Set up installation environment (Ubuntu or Windows)
-      if: ${{matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-2019'}}
+      if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
         ./.github/ci-scripts/before_install.sh
     - name: Set up installation environment (MacOS)
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: |
         ./.github/ci-scripts/before_install_macos.sh
     - name: Set up Python ${{ matrix.python-version }}
@@ -51,17 +51,17 @@ jobs:
         python -m pip install -e .[testing]
         python setup.py build_ext --inplace
     - name: Run test_packages Ubuntu
-      if: ${{matrix.os == 'ubuntu-20.04'}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
         python -m pytest -v -n auto --dist loadscope --ignore=test/test_packages/mpi --ignore=test/test_packages/notebooks test/test_packages
     - name: Run test_packages Windows
-      if: ${{matrix.os == 'windows-2019'}}
+      if: ${{matrix.os == 'windows-latest'}}
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
         python -m pytest -v -n auto --dist loadscope --ignore=test/test_packages/mpi --ignore=test/test_packages/notebooks test/test_packages
     - name: Run test_packages MacOS
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'macos-latest'}}
 
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"

--- a/.github/workflows/main-mac.yml
+++ b/.github/workflows/main-mac.yml
@@ -19,17 +19,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11]
+        os: [macos-latest]
         python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up installation environment (Ubuntu or Windows)
-      if: ${{matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-2019'}}
-      run: |
-        ./.github/ci-scripts/before_install.sh
     - name: Set up installation environment (MacOS)
-      if: ${{matrix.os == 'macos-11'}}
       run: |
         ./.github/ci-scripts/before_install_macos.sh
     - name: Set up Python ${{ matrix.python-version }}
@@ -50,24 +45,13 @@ jobs:
         python setup.py build_ext --inplace
         # python -m pip freeze  # this isn't relevant anymore since pip install builds a wheel separately
     - name: Lint with flake8
-      if: ${{matrix.os != 'windows-2019'}}
       run: |
         # Critical errors, exit on failure
         flake8 . --count --show-source --statistics --config=.flake8-critical
         # Standard PEP8, allowed to fail since exit-zero treats all errors as warnings
         flake8 . --exit-zero --statistics
-    - name: Run unit tests ubuntu
-      if: ${{matrix.os == 'ubuntu-20.04'}}
-      run: |
-       python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
-       python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
-    - name: Run unit tests windows  
-      if: ${{matrix.os == 'windows-2019'}}
-      run: |
-       python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
-       python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
     - name: Run unit tests MacOS  
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit

--- a/.github/workflows/main-mac.yml
+++ b/.github/workflows/main-mac.yml
@@ -23,16 +23,16 @@ jobs:
         python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up installation environment (MacOS)
       run: |
         ./.github/ci-scripts/before_install_macos.sh
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('**/*requirements.txt') }}

--- a/.github/workflows/main-mac.yml
+++ b/.github/workflows/main-mac.yml
@@ -1,13 +1,12 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build and run tests (no MacOS, all Python versions)
+name: Build and run tests (MacOS only, all Python versions)
 
 on:
   push:
-    branches: [ "develop", "master" ]
-  pull_request:
-    branches: [ "**:**" ]
+    # Mac runners are expensive and oversubscribed. Only run on beta and master
+    branches: [ "beta", "master" ]
   # Allow running manually from Actions tab
   workflow_dispatch:
 
@@ -20,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [macos-11]
         python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
@@ -72,27 +71,7 @@ jobs:
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
-    
-  
-  push: # Push to stable "beta" branch on successful build
 
-    runs-on: ubuntu-20.04
-
-    # Only run on "develop" branch if tests pass
-    needs: build
-    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.PYGSTI_TOKEN }}
-    - name: Merge changes to beta branch
-      run: |
-        git config --global user.name 'PyGSTi'
-        git config --global user.email 'pygsti@noreply.github.com'
-        git checkout beta
-        git merge --ff-only ${GITHUB_SHA} && git push origin beta
 
 
 

--- a/.github/workflows/main-minimal.yml
+++ b/.github/workflows/main-minimal.yml
@@ -23,19 +23,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.8,'3.11']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up installation environment (Ubuntu or Windows)
-      if: ${{matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-2019'}}
+      if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
         ./.github/ci-scripts/before_install.sh
-    - name: Set up installation environment (MacOS)
-      if: ${{matrix.os == 'macos-11'}}
-      run: |
-        ./.github/ci-scripts/before_install_macos.sh
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -54,24 +50,19 @@ jobs:
         python setup.py build_ext --inplace
         # python -m pip freeze  # this isn't relevant anymore since pip install builds a wheel separately
     - name: Lint with flake8
-      if: ${{matrix.os != 'windows-2019'}}
+      if: ${{matrix.os != 'windows-latest'}}
       run: |
         # Critical errors, exit on failure
         flake8 . --count --show-source --statistics --config=.flake8-critical
         # Standard PEP8, allowed to fail since exit-zero treats all errors as warnings
         flake8 . --exit-zero --statistics
     - name: Run unit tests ubuntu
-      if: ${{matrix.os == 'ubuntu-20.04'}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
     - name: Run unit tests windows  
-      if: ${{matrix.os == 'windows-2019'}}
-      run: |
-       python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
-       python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
-    - name: Run unit tests MacOS  
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'windows-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
@@ -79,7 +70,7 @@ jobs:
   
   push: # Push to stable "beta" branch on successful build
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Only run on "develop" branch if tests pass
     needs: build

--- a/.github/workflows/main-minimal.yml
+++ b/.github/workflows/main-minimal.yml
@@ -27,17 +27,17 @@ jobs:
         python-version: [3.8,'3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up installation environment (Ubuntu or Windows)
       if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
         ./.github/ci-scripts/before_install.sh
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('**/*requirements.txt') }}
@@ -66,27 +66,7 @@ jobs:
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
-    
-  
-  push: # Push to stable "beta" branch on successful build
 
-    runs-on: ubuntu-latest
-
-    # Only run on "develop" branch if tests pass
-    needs: build
-    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.PYGSTI_TOKEN }}
-    - name: Merge changes to beta branch
-      run: |
-        git config --global user.name 'PyGSTi'
-        git config --global user.email 'pygsti@noreply.github.com'
-        git checkout beta
-        git merge --ff-only ${GITHUB_SHA} && git push origin beta
 
 
 

--- a/.github/workflows/main-minimal.yml
+++ b/.github/workflows/main-minimal.yml
@@ -1,11 +1,14 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build and run tests (no MacOS, all Python versions)
+name: Build and run tests (no MacOS, low/high Python versions only)
 
 on:
   push:
-    branches: [ "develop", "master" ]
+    # Intended to be fast checks on non-main branches
+    branches-ignore: [ "beta", "develop", "master" ]
+  # Hacky way to only run pull requests from forked repositories (assumes : is not used in branch names unless forked)
+  # https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
   pull_request:
     branches: [ "**:**" ]
   # Allow running manually from Actions tab
@@ -21,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8,'3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,19 +20,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up installation environment (Ubuntu or Windows)
-      if: ${{matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-2019'}}
+      if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
         ./.github/ci-scripts/before_install.sh
-    - name: Set up installation environment (MacOS)
-      if: ${{matrix.os == 'macos-11'}}
-      run: |
-        ./.github/ci-scripts/before_install_macos.sh
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -51,24 +47,19 @@ jobs:
         python setup.py build_ext --inplace
         # python -m pip freeze  # this isn't relevant anymore since pip install builds a wheel separately
     - name: Lint with flake8
-      if: ${{matrix.os != 'windows-2019'}}
+      if: ${{matrix.os != 'windows-latest'}}
       run: |
         # Critical errors, exit on failure
         flake8 . --count --show-source --statistics --config=.flake8-critical
         # Standard PEP8, allowed to fail since exit-zero treats all errors as warnings
         flake8 . --exit-zero --statistics
     - name: Run unit tests ubuntu
-      if: ${{matrix.os == 'ubuntu-20.04'}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
     - name: Run unit tests windows  
-      if: ${{matrix.os == 'windows-2019'}}
-      run: |
-       python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
-       python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
-    - name: Run unit tests MacOS  
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'windows-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --dist loadscope --cov=pygsti test/unit
@@ -76,7 +67,7 @@ jobs:
   
   push: # Push to stable "beta" branch on successful build
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Only run on "develop" branch if tests pass
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build and run tests (no MacOS, all Python versions)
+name: Build and run tests
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,17 @@ jobs:
         python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up installation environment (Ubuntu or Windows)
       if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
         ./.github/ci-scripts/before_install.sh
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('**/*requirements.txt') }}
@@ -74,7 +74,7 @@ jobs:
     if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.PYGSTI_TOKEN }}

--- a/.github/workflows/manualdeploy.yml
+++ b/.github/workflows/manualdeploy.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # to fetch all branches and *tags* (needed to get version number correctly)
   
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.10'
@@ -32,7 +32,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: ./.github/ci-scripts/before_install.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -41,11 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # to fetch all branches and *tags* (needed to get version number correctly)
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.10'
@@ -53,7 +53,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -61,7 +61,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       fail-fast: false # Finish all tests even if one fails
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9, '3.10', '3.11']
         
     steps:
     - uses: actions/checkout@v2
     - name: Set up installation environment (Ubuntu or Windows)
-      if: ${{matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-2019'}}
+      if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
         ./.github/ci-scripts/before_install.sh
         #download chp source code
@@ -33,7 +33,7 @@ jobs:
         #compile chp
         gcc -o ./jupyter_notebooks/Tutorials/algorithms/advanced/chp ./jupyter_notebooks/Tutorials/algorithms/advanced/chp.c 
     - name: Set up installation environment (MacOS)
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: |
         ./.github/ci-scripts/before_install_macos.sh
         #download chp source code
@@ -57,17 +57,17 @@ jobs:
         python -m pip install -e .[testing]
         python setup.py build_ext --inplace
     - name: Run notebook regression ubuntu
-      if: ${{matrix.os == 'ubuntu-20.04'}}
+      if: ${{matrix.os == 'ubuntu-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --nbval-lax --dist loadscope --nbval-current-env jupyter_notebooks
     - name: Run notebook regression windows 
-      if: ${{matrix.os == 'windows-2019'}}
+      if: ${{matrix.os == 'windows-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --nbval-lax --dist loadscope --nbval-current-env jupyter_notebooks
     - name: Run notebook regression MacOS  
-      if: ${{matrix.os == 'macos-11'}}
+      if: ${{matrix.os == 'macos-latest'}}
       run: |
        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
        python -m pytest -n auto --nbval-lax --dist loadscope --nbval-current-env jupyter_notebooks

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: [3.8, 3.9, '3.10', '3.11']
         
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up installation environment (Ubuntu or Windows)
       if: ${{matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'}}
       run: |
@@ -41,11 +41,11 @@ jobs:
         #compile chp source code
         gcc -o ./jupyter_notebooks/Tutorials/algorithms/advanced/chp ./jupyter_notebooks/Tutorials/algorithms/advanced/chp.c 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('**/*requirements.txt') }}

--- a/.github/workflows/testdeploy.yml
+++ b/.github/workflows/testdeploy.yml
@@ -19,11 +19,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # to fetch all branches and *tags* (needed to get version number correctly)
   
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.10'
@@ -41,7 +41,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: ./.github/ci-scripts/before_install.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -49,11 +49,11 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # to fetch all branches and *tags* (needed to get version number correctly)
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.10'
@@ -61,7 +61,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -73,7 +73,7 @@ jobs:
     # alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
This includes several quality-of-life and deprecation runner updates and addresses #387.

- MacOS runners are oversubscribed and 10x more expensive, and rarely break due to OS specific issues not caught by Linux tests. Therefore, MacOS tests are now only run on `beta` and `master`.
- Bugfix/feature branches now only test the lowest and highest supported Python versions - this should be sufficient to flag any deprecation or missing language feature problems and cuts down the runtime on these branches by 2x. (Combined with no MacOS tests, this takes the number of runners needed from 12 to 4).
- The runner versions were updated to `-latest`, bumping our testing environment to Ubuntu 22.04 from 20.04, Windows 2022 from 2019, and MacOS 12 from 11, and will now track updated environments.
- The GitHub-provided actions were updated from `v2` to `v4` (or `v3` in the case of `cache`) for node16 updates, which should remove the node12 deprecation warning we've been getting.

As an example, this cuts the current runtime from nearly 2 hours (with the MacOS oversubscription problem) to 13 minutes on this feature branch.