### PR TITLE
Fixes bug where depolarizing noise strength differs with parameterization

### DIFF
--- a/pygsti/models/modelnoise.py
+++ b/pygsti/models/modelnoise.py
@@ -799,7 +799,7 @@ class DepolarizationNoise(OpNoise):
 
         # LindbladErrorgen with "depol" or "diagonal" param
         basis_size = state_space.dim  # e.g. 4 for a single qubit
-        basis = _BuiltinBasis('pp', basis_size)
+        basis = _BuiltinBasis('PP', basis_size)
         rate_per_pauli = self.depolarization_rate / (basis_size - 1)
         errdict = {('S', bl): rate_per_pauli for bl in basis.labels[1:]}
         return _op.LindbladErrorgen.from_elementary_errorgens(
@@ -896,7 +896,7 @@ class StochasticNoise(OpNoise):
             raise ValueError("Stochastic noise parameterization must be one of %s" % str(allowed_values))
 
         basis_size = state_space.dim  # e.g. 4 for a single qubit
-        basis = _BuiltinBasis('pp', basis_size)
+        basis = _BuiltinBasis('PP', basis_size)
         errdict = {('S', bl): rate for bl, rate in zip(basis.labels[1:], sto_rates)}
         return _op.LindbladErrorgen.from_elementary_errorgens(
             errdict, "S", basis, mx_basis='pp',

--- a/test/unit/objects/test_modelnoise.py
+++ b/test/unit/objects/test_modelnoise.py
@@ -1,0 +1,30 @@
+from pygsti.processors import QubitProcessorSpec
+from pygsti.models import create_crosstalk_free_model
+from pygsti.circuits import Circuit
+from pygsti.modelmembers.operations.opfactory import ComposedOpFactory
+from pygsti.modelmembers.operations.depolarizeop import DepolarizeOp
+
+from ..util import BaseCase
+
+
+class ModelNoiseTester(BaseCase):
+    def test_linblad_agrees_with_depol(self):
+        pspec = QubitProcessorSpec(1, ["Gi"], geometry="line")
+
+        mdl1 = create_crosstalk_free_model(
+            pspec,
+            depolarization_parameterization="lindblad",
+            depolarization_strengths={'Gi': 0.02}
+        )
+
+        mdl2 = create_crosstalk_free_model(
+            pspec,
+            depolarization_parameterization="depolarize",
+            depolarization_strengths={'Gi': 0.02}
+        )
+
+        c = Circuit("Gi:0@(0)")
+        p1 = mdl1.probabilities(c)
+        p2 = mdl2.probabilities(c)
+        self.assertAlmostEqual(p1['0'], p2['0'], places=3)
+        self.assertAlmostEqual(p1['1'], p2['1'], places=3)


### PR DESCRIPTION
Depolarizing noise constructed with `depolarization_parameterization="lindblad"` doesn't match the same constructio when `depolarization_parameterization="depolarize"`, as demonstrated by the below code.  This is due to the use of the normalized Pauli basis (`"pp"`) where we should be using the un-normalized basis (`"PP"`).  This PR fixes this issue and adds a unit test.

To see the bug, run this (printed output should be the same but is not):
```
import pygsti
from pygsti.modelmembers.operations.opfactory import ComposedOpFactory
from pygsti.modelmembers.operations.depolarizeop import DepolarizeOp

pspec = pygsti.processors.QubitProcessorSpec(1, ["Gi"], geometry="line")

mdl1 = pygsti.models.create_crosstalk_free_model(
        pspec,
        depolarization_parameterization="lindblad",
        depolarization_strengths={'Gi': 0.02}
)

mdl2 = pygsti.models.create_crosstalk_free_model(
        pspec,
        depolarization_parameterization="depolarize",
        depolarization_strengths={'Gi': 0.02}
)

c = pygsti.circuits.Circuit("Gi:0@(0)")

print(dict(mdl1.probabilities(c)))
print(dict(mdl2.probabilities(c)))
```