### PR TITLE
Check if outcome_labels is of type numbers.Integral instead of np.int64

### DIFF
--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -1031,7 +1031,7 @@ class DataSet(_MongoSerializable):
             self.olIndex = outcome_label_indices
             self.olIndex_max = max(self.olIndex.values()) if len(self.olIndex) > 0 else -1
         elif outcome_labels is not None:
-            if isinstance(outcome_labels, _np.int64):
+            if isinstance(outcome_labels, _numbers.Integral):
                 nqubits = outcome_labels
                 tup_outcomeLabels = [("".join(x),) for x in _itertools.product(*([('0', '1')] * nqubits))]
             else:


### PR DESCRIPTION
`pygsti.data.Dataset` constructor has the `outcome_labels` argument which may be a `list` or `int` according to the docstring. However, passing a Python `int` did not work as the `isinstance` check was using `np.int64`. This pull request generalises the check to also work with Python `int`s using the `numbers` standard library module.

```
>>> import numbers, numpy as np
>>> isinstance(1, np.int64)
False
>>> isinstance(1, int)
True
>>> isinstance(np.int64(1), int)
False
>>> isinstance(np.int64(1), numbers.Integral)
True
>>> isinstance(1, numbers.Integral)
True
```

... after writing this up I see that pull requests by authors outside of SNL cannot be merged. I'm more than happy for a maintainer to take this change and put it in under their name.