### PR TITLE
Update/New Cirq Parsing Capabilities

### DIFF
--- a/jupyter_notebooks/Examples/CirqIntegration.ipynb
+++ b/jupyter_notebooks/Examples/CirqIntegration.ipynb
@@ -398,7 +398,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "2. By default cirq included idle gates explicitly on all qubits in a layer without a specified operation applied. In pygsti we typically treat these as implied, and so the default behavior is to strip these extra idles. This can be turned off by setting `implied_idles` to `True`."
+    "2. By default cirq included idle gates explicitly on all qubits in a layer without a specified operation applied. In pygsti we typically treat these as implied, and so the default behavior is to strip these extra idles. This can be turned off by setting `remove_implied_idles` to `False`."
    ]
   },
   {
@@ -407,7 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "converted_cirq_circuit_implied_idles = Circuit.from_cirq(cirq_circuit_example, implied_idles=True)\n",
+    "converted_cirq_circuit_implied_idles = Circuit.from_cirq(cirq_circuit_example, remove_implied_idles=True)\n",
     "print(converted_cirq_circuit_implied_idles)"
    ]
   },
@@ -415,7 +415,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3. If desired, a layers consisting entirely of idle gates can be converted to the default pyGSTi global idle convention or Label(()), or to a user specified replacement."
+    "3. Layers consisting entirely of idle gates are by default converted to the default pyGSTi global idle convention or Label(()), or to a user specified replacement. This is controlled by the `global_idle_replacement_label` kwarg. The default value is the string 'auto', which will utilize the aforementioned default convention. Users can instead pass in either a string, which is converted to a corresponding Label object, or a circuit Label object directly. Finally, by passing in `None` the global idle replacement is not performed, and the full verbatim translation of that cirq layer is produced."
    ]
   },
   {
@@ -424,7 +424,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "converted_cirq_circuit_global_idle = Circuit.from_cirq(cirq_circuit_example, global_idle=True)\n",
+    "#auto is the default value, explicitly including here for comparison to alternative options.\n",
+    "converted_cirq_circuit_global_idle = Circuit.from_cirq(cirq_circuit_example, global_idle_replacement_label='auto')\n",
     "print(converted_cirq_circuit_global_idle)"
    ]
   },
@@ -434,7 +435,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "converted_cirq_circuit_global_idle_1 = Circuit.from_cirq(cirq_circuit_example, global_idle='Gbanana')\n",
+    "converted_cirq_circuit_global_idle_1 = Circuit.from_cirq(cirq_circuit_example, global_idle_replacement_label='Gbanana')\n",
     "print(converted_cirq_circuit_global_idle_1)"
    ]
   },
@@ -445,8 +446,18 @@
    "outputs": [],
    "source": [
     "from pygsti.baseobjs import Label\n",
-    "converted_cirq_circuit_global_idle_2 = Circuit.from_cirq(cirq_circuit_example, global_idle=Label('Gbanana', ('Q0_0','Q0_1')))\n",
+    "converted_cirq_circuit_global_idle_2 = Circuit.from_cirq(cirq_circuit_example, global_idle_replacement_label=Label('Gbanana', ('Q0_0','Q0_1')))\n",
     "print(converted_cirq_circuit_global_idle_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted_cirq_circuit_global_idle_3 = Circuit.from_cirq(cirq_circuit_example, global_idle_replacement_label= None)\n",
+    "print(converted_cirq_circuit_global_idle_3)"
    ]
   },
   {

--- a/jupyter_notebooks/Examples/CirqIntegration.ipynb
+++ b/jupyter_notebooks/Examples/CirqIntegration.ipynb
@@ -18,12 +18,13 @@
     "\n",
     "1. Sets up pyGSTi.\n",
     "2. Shows how pyGSTi circuits can be converted to Cirq circuits.\n",
-    "3. Shows how the Cirq circuits can be run and the results loaded back into pyGSTi for analysis."
+    "3. Shows how Cirq circuits can be converted into pyGSTi circuits.\n",
+    "4. Shows how the Cirq circuits can be run and the results loaded back into pyGSTi for analysis."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -34,6 +35,7 @@
     "import cirq\n",
     "import pygsti\n",
     "from pygsti.modelpacks import smq1Q_XYI\n",
+    "from pygsti.circuits import Circuit\n",
     "import numpy as np\n",
     "import tqdm"
    ]
@@ -55,12 +57,12 @@
     "id": "cWpHwZVtvejH"
    },
    "source": [
-    "### Make target gate set $\\{\\sqrt{X},\\sqrt{Y},I\\}$"
+    "### Make target gate set $\\{R_{X}(\\pi/2), R_{Y}(\\pi/2),I\\}$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -104,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -117,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -127,22 +129,14 @@
     "id": "SuvgxDpKwCul",
     "outputId": "6654eeeb-3870-4b61-af43-0c66cb09169e"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(max_lengths)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -155,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -165,18 +159,7 @@
     "id": "9vD8DXOPwHSV",
     "outputId": "06e10aec-f7ab-4b7b-d0c6-242ce225d5a2"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1624"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(pygsti_circuits)"
    ]
@@ -204,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,23 +211,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pyGSTi:\n",
-      "Qubit 0 ---|Gxpi2|-|Gxpi2|-| |-| |-|Gxpi2|---\n",
-      "\n",
-      "Cirq:\n",
-      "(8, 3): ───X^0.5───X^0.5───────────X^0.5───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pygsti_circuit = pygsti_circuits[111]\n",
     "print('pyGSTi:')\n",
@@ -262,21 +233,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pyGSTi:\n",
-      "Qubit 0 ---|Gypi2|-|Gypi2|-|Gypi2|-|Gypi2|-|Gxpi2|-|Gxpi2|-|Gxpi2|---\n",
-      "\n",
-      "Cirq:\n",
-      "(8, 3): ───Y^0.5───Y^0.5───Y^0.5───Y^0.5───X^0.5───X^0.5───X^0.5───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pygsti_circuit = pygsti_circuits[90]\n",
     "print('pyGSTi:')\n",
@@ -294,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,21 +262,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pyGSTi:\n",
-      "Qubit 0 ---|Gxpi2|-|Gxpi2|-| |-| |-|Gxpi2|---\n",
-      "\n",
-      "Cirq:\n",
-      "(8, 3): ───X^0.5───X^0.5───WaitGate(100 ns)───WaitGate(100 ns)───X^0.5───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pygsti_circuit = pygsti_circuits[111]\n",
     "print('pyGSTi:')\n",
@@ -328,21 +275,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "pyGSTi:\n",
-      "Qubit 0 ---|Gypi2|-|Gypi2|-|Gypi2|-|Gypi2|-|Gxpi2|-|Gxpi2|-|Gxpi2|---\n",
-      "\n",
-      "Cirq:\n",
-      "(8, 3): ───Y^0.5───Y^0.5───Y^0.5───Y^0.5───X^0.5───X^0.5───X^0.5───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pygsti_circuit = pygsti_circuits[90]\n",
     "print('pyGSTi:')\n",
@@ -367,33 +302,177 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1624/1624 [00:08<00:00, 189.73it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cirq_circuits = [c.convert_to_cirq(qubit_label_dict, wait_duration) for c in tqdm.tqdm(pygsti_circuits)]"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
-    "Note that we're missing the measurments, the idle operations don't have a time associated with them, and the first circuit is empty (it's should just be an idle). Otherwise, the results look good, and those things should be easy to fix."
+    "cirq_circuits"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Run the circuits"
+    "Note that we're missing the measurments and the first circuit is empty (it's should just be an idle). Otherwise, the results look good, and those things should be easy to fix."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Convert Cirq circuits to pyGSTi circuits\n",
+    "We also have support for converting a cirq circuit to a pyGSTi circuit, which is demonstrated below.\n",
+    "Begin by constructing a cirq circuit directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#create to cirq qubit objects\n",
+    "qubit_00 = cirq.GridQubit(0,0)\n",
+    "qubit_01 = cirq.GridQubit(0,1)\n",
+    "#define a series of Moment objects, which fill the same role as circuit layers in pyGSTi.\n",
+    "moment1 = cirq.Moment([cirq.XPowGate(exponent=.5).on(qubit_00), cirq.I(qubit_01)])\n",
+    "moment2 = cirq.Moment([cirq.I(qubit_00), cirq.I(qubit_01)])\n",
+    "#This weird looking gate is the so-called N gate.\n",
+    "moment3 = cirq.Moment([cirq.PhasedXZGate(axis_phase_exponent=0.14758361765043326, \n",
+    "                                         x_exponent=0.4195693767448338, \n",
+    "                                         z_exponent=-0.2951672353008665).on(qubit_00),\n",
+    "                    cirq.I(qubit_01)])\n",
+    "moment4 = cirq.Moment([cirq.H(qubit_00), (cirq.T**-1).on(qubit_01)])\n",
+    "moment5 = cirq.Moment([cirq.CNOT.on(qubit_00, qubit_01)])\n",
+    "cirq_circuit_example = cirq.Circuit([moment1, moment2, moment3, moment4, moment5])\n",
+    "print(cirq_circuit_example)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To convert this into a pyGSTi circuit we can use the `from_cirq` class method of the Circuit class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted_cirq_circuit_default = Circuit.from_cirq(cirq_circuit_example)\n",
+    "print(converted_cirq_circuit_default)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Above you can see the result of converting the circuit using the default conversion settings. The classmethod has multiple options for customizing the returned pyGSTi circuit.\n",
+    "1. By default the method constructs a mapping between cirq qubit objects and pygsti qubit labels based on the type of cirq qubit provided. E.g. a GridQubit gets mapped to `Q{row}_{col}` where row and col are the corresponding attribute values for the GridQubit. Something similar is done for NamedQubit and LineQubit objects. This can be overridden by passing in a dictionary for the `qubit_conversion` kwarg."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted_cirq_circuit_custom_qubit_map = Circuit.from_cirq(cirq_circuit_example, qubit_conversion={qubit_00: 'Qalice', qubit_01: 'Qbob'})\n",
+    "print(converted_cirq_circuit_custom_qubit_map)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2. By default cirq included idle gates explicitly on all qubits in a layer without a specified operation applied. In pygsti we typically treat these as implied, and so the default behavior is to strip these extra idles. This can be turned off by setting `implied_idles` to `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted_cirq_circuit_implied_idles = Circuit.from_cirq(cirq_circuit_example, implied_idles=True)\n",
+    "print(converted_cirq_circuit_implied_idles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3. If desired, a layers consisting entirely of idle gates can be converted to the default pyGSTi global idle convention or Label(()), or to a user specified replacement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted_cirq_circuit_global_idle = Circuit.from_cirq(cirq_circuit_example, global_idle=True)\n",
+    "print(converted_cirq_circuit_global_idle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "converted_cirq_circuit_global_idle_1 = Circuit.from_cirq(cirq_circuit_example, global_idle='Gbanana')\n",
+    "print(converted_cirq_circuit_global_idle_1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pygsti.baseobjs import Label\n",
+    "converted_cirq_circuit_global_idle_2 = Circuit.from_cirq(cirq_circuit_example, global_idle=Label('Gbanana', ('Q0_0','Q0_1')))\n",
+    "print(converted_cirq_circuit_global_idle_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "4. There is built-in support for converting _most_ Cirq gates into their corresponding built-in pyGSTi gate names (see `cirq_gatenames_standard_conversions` in `pygsti.tools.internalgates` for more on this). There is also a fallback behavior where if not found in the default map, the converter will search among the built-in gate unitaries for one that matches (up to a global phase). If this doesn't work for a particular gate of user interest, of you simply want to override the default mapping as needed, this can be done by passing in a custom dictionary for the `cirq_gate_conversion` kwarg."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_gate_map = pygsti.tools.internalgates.cirq_gatenames_standard_conversions()\n",
+    "custom_gate_map[cirq.H] = 'Gdefinitelynoth'\n",
+    "converted_cirq_circuit_custom_gate_map = Circuit.from_cirq(cirq_circuit_example, cirq_gate_conversion=custom_gate_map)\n",
+    "print(converted_cirq_circuit_custom_gate_map)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Run the circuits"
    ]
   },
   {
@@ -405,7 +484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,17 +501,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1624/1624 [00:39<00:00, 41.60it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "simulator = cirq.Simulator()\n",
     "results = [simulator.run(circuit, repetitions=1000) for circuit in tqdm.tqdm(cirq_circuits)]"
@@ -447,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,18 +536,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- Circuit Creation ---\n",
-      "-- Std Practice:  [##################################################] 100.0%  (Target) --\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "gst_results = pygsti.run_stdpractice_gst(dataset, target_model, preps, effects, germs, max_lengths, modes=[\"full TP\",\"Target\"], verbosity=1)"
    ]
@@ -490,18 +552,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2DeltaLogL(estimate, data):  1102.0101377779301\n",
-      "2DeltaLogL(ideal, data):  1118.865389448009\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mdl_estimate = gst_results.estimates['full TP'].models['stdgaugeopt']\n",
     "print(\"2DeltaLogL(estimate, data): \", pygsti.tools.two_delta_logl(mdl_estimate, dataset))\n",
@@ -523,9 +576,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "api_updates",
    "language": "python",
-   "name": "python3"
+   "name": "api_updates"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -3769,7 +3769,8 @@ class Circuit(object):
         return cirq.Circuit(moments)
     
     @classmethod
-    def from_cirq(cls, circuit, qubit_conversion=None, cirq_gate_conversion= None,implied_idles = False, global_idle = False):
+    def from_cirq(cls, circuit, qubit_conversion=None, cirq_gate_conversion= None,
+                  remove_implied_idles = True, global_idle_replacement_label = 'auto'):
         """
         Converts and instantiates a pyGSTi Circuit object from a Cirq Circuit object.
 
@@ -3788,16 +3789,18 @@ class Circuit(object):
             and values given by pygsti gate names which overrides the built-in
             conversion dictionary used by default.
 
-        implied_idles : bool, optional (default False)
+        remove_implied_idles : bool, optional (default False)
             A flag indicating whether to explicitly include
             implied idles as part of a circuit layer containing
             other explicitly specified gates.
 
-        global_idle : bool or string or Label, optional (default False)
-            A flag/specified for the handling of global idle layers.
-            If True, then the behavior is to replace global idle layers with
+        global_idle_replacement_label : string or Label or None, optional (default 'auto')
+            An option specified for the handling of global idle layers.
+            If None, no replacement of global idle layers is performed and a verbatim
+            conversion from the cirq layer is performed.
+            If the string 'auto', then the behavior is to replace global idle layers with
             the gate label Label(()), which is the special syntax for the global
-            idle layer, stylized typically as '[]'. If a string replace with a 
+            idle layer, stylized typically as '[]'. If another string then replace with a 
             gate label with the specified name acting on all of the qubits
             appearing in the cirq circuit. If a Label object, use this directly,
             this does not check for compatibility so it is up to the user to ensure
@@ -3875,16 +3878,17 @@ class Circuit(object):
                     assert name is not None, 'Could not find a matching standard gate name for conversion.'
                 sslbls = tuple(qubit_conversion[qubit] for qubit in op.qubits)
                 #global idle handling:
-                if name == 'Gi' and global_idle:
+                if name == 'Gi' and global_idle_replacement_label:
                     #set a flag indicating that we've seen a global idle to use later.
                     seen_global_idle = True
-                    if isinstance(global_idle, str):
-                        circuit_layers.append(_Label(global_idle, tuple(sorted([qubit_conversion[qubit] for qubit in all_cirq_qubits]))))
-                    elif isinstance(global_idle, _Label):
-                        circuit_layers.append(global_idle)
-                    #otherwise append the default.
-                    else:
-                        circuit_layers.append(_Label(()))
+                    if isinstance(global_idle_replacement_label, str):
+                        if global_idle_replacement_label == 'auto':
+                            #append the default.
+                            circuit_layers.append(_Label(()))
+                        else:
+                            circuit_layers.append(_Label(global_idle_replacement_label, tuple(sorted([qubit_conversion[qubit] for qubit in all_cirq_qubits]))))
+                    elif isinstance(global_idle_replacement_label, _Label):
+                        circuit_layers.append(global_idle_replacement_label)   
                 else:
                     circuit_layers.append(_Label(name, state_space_labels = sslbls))
 
@@ -3908,22 +3912,23 @@ class Circuit(object):
                 layer_label_elem_names = [elem.name for elem in layer_label_elems]
                 all_idles = all([name == 'Gi' for name in layer_label_elem_names])
                 
-                if global_idle and all_idles:
+                if global_idle_replacement_label and all_idles:
                     #set a flag indicating that we've seen a global idle to use later.
                     seen_global_idle = True
                     #if global idle is a string, replace this layer with the user specified one:
-                    if isinstance(global_idle, str):
-                        circuit_layers.append(_Label(global_idle, tuple(sorted([qubit_conversion[qubit] for qubit in all_cirq_qubits]))))
-                    elif isinstance(global_idle, _Label):
-                        circuit_layers.append(global_idle)
-                    #otherwise append the default.
-                    else:
-                        circuit_layers.append(_Label(()))
+                    if isinstance(global_idle_replacement_label, str):
+                        if global_idle_replacement_label == 'auto':
+                            #append the default.
+                            circuit_layers.append(_Label(()))
+                        else:
+                            circuit_layers.append(_Label(global_idle_replacement_label, tuple(sorted([qubit_conversion[qubit] for qubit in all_cirq_qubits]))))
+                    elif isinstance(global_idle_replacement_label, _Label):
+                        circuit_layers.append(global_idle_replacement_label)
                 #check whether any of the elements are implied idles, and if so use flag
                 #to determine whether to include them. We have already checked if this layer
                 #is a global idle, so if not then we only need to check if any of the layer
                 #elements are implied idles.
-                elif not implied_idles and 'Gi' in layer_label_elem_names and not all_idles:
+                elif remove_implied_idles and 'Gi' in layer_label_elem_names and not all_idles:
                     stripped_layer_label_elems = [elem for elem in layer_label_elems 
                                                   if not elem.name == 'Gi']
                     #if this is length one then add this to the circuit as a bare label, otherwise

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -3789,10 +3789,11 @@ class Circuit(object):
             and values given by pygsti gate names which overrides the built-in
             conversion dictionary used by default.
 
-        remove_implied_idles : bool, optional (default False)
-            A flag indicating whether to explicitly include
-            implied idles as part of a circuit layer containing
-            other explicitly specified gates.
+        remove_implied_idles : bool, optional (default True)
+            A flag indicating whether to remove explicit idles
+            that are part of a circuit layer containing
+            other explicitly specified gates
+            (i.e., whether to abide by the normal pyGSTi implicit idle convention).
 
         global_idle_replacement_label : string or Label or None, optional (default 'auto')
             An option specified for the handling of global idle layers.

--- a/pygsti/modelpacks/smq1Q_ZN.py
+++ b/pygsti/modelpacks/smq1Q_ZN.py
@@ -1,7 +1,9 @@
 """
 A standard multi-qubit gate set module.
 
-Variables for working with the a model containing Idle, Z(pi/2) and rot(X=pi/2, Y=sqrt(3)/2) gates.
+Variables for working with the a model containing Idle, Z(pi/2) and N gate, where the N gate is a
+pi/2 rotation about the (np.sqrt(3)/2, 0, -1/2) axis of the Bloch sphere.
+gates.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).

--- a/pygsti/modelpacks/smq2Q_XXYYII.py
+++ b/pygsti/modelpacks/smq2Q_XXYYII.py
@@ -2,7 +2,8 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CPHASE.
+I*I, I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, X(pi/2)*X(pi/2),
+Y(pi/2)*Y(pi/2), X(pi/2)*Y(pi/2), and Y(pi/2)*X(pi/2) gates.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).

--- a/pygsti/modelpacks/smq2Q_XYXX.py
+++ b/pygsti/modelpacks/smq2Q_XYXX.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CNOT.
+I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and XX gates
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).

--- a/pygsti/modelpacks/smq2Q_XYZZ.py
+++ b/pygsti/modelpacks/smq2Q_XYZZ.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CNOT.
+I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and ZZ gates.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).

--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -16,6 +16,7 @@ import scipy.linalg as _spl
 from pygsti.tools import optools as _ot
 from pygsti.tools import symplectic as _symp
 from pygsti.baseobjs.unitarygatefunction import UnitaryGateFunction as _UnitaryGateFunction
+from pygsti import sigmax, sigmay, sigmaz, sigmaxz
 
 
 class Gzr(_UnitaryGateFunction):
@@ -192,14 +193,18 @@ def standard_gatename_unitaries():
       * 'Gxmpi2','Gympi2','Gzmpi2' : 1Q -pi/2 rotations around X, Y and Z.
       * 'Gh' : Hadamard.
       * 'Gp', 'Gpdag' : phase and inverse phase (an alternative notation/name for Gzpi and Gzmpi2).
-      * 'Gci' where `i = 0, 1, ..., 23` : the 24 1-qubit Cliffor gates (all the gates above are included as one of these).
-      * 'Gcphase','Gcnot','Gswap' : standard 2Q gates.
-
+      * 'Gci' where `i = 0, 1, ..., 23` : the 24 1-qubit Clifford gates (all the gates above are included as one of these).
+      * 'Gcphase','Gcnot','Gswap', 'Giswap' : standard 2Q gates.
+      * 'Gsqrtiswap' : square-root of ISWAP gate, used in some superconducting qubit platforms.
+      * 'Gxx', 'Gzz' : MS-style parity gates
+      * 'Gcres', 'Gecres' : Cross-resonance and echoed cross-resonance gates. Native gate operations common on transmon systems (including IBM).
+      
     * Non-Clifford gates:
 
       * 'Gt', 'Gtdag' : the T and inverse T gates (T is a Z rotation by pi/4).
       * 'Gzr' : a parameterized gate that is a Z rotation by an angle, where when the angle = pi then it equals Z.
-
+      * 'Gn' : N gate, pi/2 rotation about the (np.sqrt(3)/2, 0, -1/2) axis of the Bloch sphere, native gate in some spin qubit systems.
+      
     Mostly, pyGSTi does not assume that a gate with one of these names is indeed
     the unitary specified here. Instead, these names are intended as short-hand
     for defining ProcessorSpecs and n-qubit models. Moreover, when these names
@@ -211,10 +216,6 @@ def standard_gatename_unitaries():
     dict of numpy.ndarray objects.
     """
     std_unitaries = {}
-
-    sigmax = _np.array([[0, 1], [1, 0]])
-    sigmay = _np.array([[0, -1.0j], [1.0j, 0]])
-    sigmaz = _np.array([[1, 0], [0, -1]])
 
     def u_op(exp):
         return _np.array(_spl.expm(-1j * exp / 2), complex)
@@ -233,6 +234,11 @@ def standard_gatename_unitaries():
     std_unitaries['Gympi2'] = u_op(-1 * _np.pi / 2 * sigmay)
     std_unitaries['Gzmpi2'] = u_op(-1 * _np.pi / 2 * sigmaz)
 
+    std_unitaries['Gxpi4'] = u_op(_np.pi / 4 * sigmax)
+    std_unitaries['Gypi4'] = u_op(_np.pi / 4 * sigmay)
+    std_unitaries['Gzpi4'] = u_op(_np.pi / 4 * sigmaz)
+    
+
     H = (1 / _np.sqrt(2)) * _np.array([[1., 1.], [1., -1.]], complex)
     P = _np.array([[1., 0.], [0., 1j]], complex)
     Pdag = _np.array([[1., 0.], [0., -1j]], complex)
@@ -245,6 +251,11 @@ def standard_gatename_unitaries():
     #std_unitaries['Ghph'] = _np.dot(H,_np.dot(P,H))
     std_unitaries['Gt'] = _np.array([[1., 0.], [0., _np.exp(1j * _np.pi / 4)]], complex)
     std_unitaries['Gtdag'] = _np.array([[1., 0.], [0., _np.exp(-1j * _np.pi / 4)]], complex)
+    
+    #N gate, pi/2 rotation about the (np.sqrt(3)/2, 0, -1/2) axis of the Bloch sphere
+    #native gate in some spin qubit systems.
+    std_unitaries['Gn'] = _spl.expm(-1j*(_np.pi/4)*((_np.sqrt(3)/2)*sigmax - (.5)*sigmaz))
+
     # The 1-qubit Clifford group. The labelling is the same as in the the 1-qubit Clifford group generated
     # in pygsti.extras.rb.group, and also in the internal standard unitary (but with 'Gci' -> 'Ci')
     std_unitaries['Gc0'] = _np.array([[1, 0], [0, 1]], complex)  # This is Gi
@@ -273,6 +284,7 @@ def standard_gatename_unitaries():
     std_unitaries['Gc21'] = _np.array([[1, -1], [1, 1]], complex) / _np.sqrt(2)  # This is Gypi2 (up to phase)
     std_unitaries['Gc22'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [-0.5 + 0.5j, -0.5 - 0.5j]], complex)
     std_unitaries['Gc23'] = _np.array([[1, 0], [0, -1j]], complex)  # This is Gzmpi2 / Gpdag (up to phase)
+    
     # Two-qubit gates
     std_unitaries['Gcphase'] = _np.array([[1., 0., 0., 0.], [0., 1., 0., 0.], [
                                          0., 0., 1., 0.], [0., 0., 0., -1.]], complex)
@@ -284,6 +296,17 @@ def standard_gatename_unitaries():
                                       [0, -1j, 1, 0], [-1j, 0, 0, 1]], complex) / _np.sqrt(2)
     std_unitaries['Gswap'] = _np.array([[1., 0., 0., 0.], [0., 0., 1., 0.],
                                         [0., 1., 0., 0.], [0., 0., 0., 1.]], complex)
+
+    std_unitaries['Giswap'] = _np.array([[1., 0., 0., 0.], [0., 0., 1j, 0.],
+                                        [0., 1j, 0., 0.], [0., 0., 0., 1.]], complex)
+    
+    std_unitaries['Gsqrtiswap'] = _np.array([[1., 0., 0., 0.], [0., 1/_np.sqrt(2), 1j/_np.sqrt(2), 0.],
+                                        [0., 1j/_np.sqrt(2), 1/_np.sqrt(2), 0.], [0., 0., 0., 1.]], complex)
+    
+    #cross-resonance gate (exp(-1j*pi/4 sigmaxz))
+    std_unitaries['Gcres'] = _spl.expm(-1j*_np.pi/4*sigmaxz)
+    std_unitaries['Gecres'] = _np.array([[0, 1, 0., 1j], [1., 0, -1j, 0.],
+                                        [0., 1j, 0, 1], [-1j, 0., 1, 0]], complex)/_np.sqrt(2)
 
     std_unitaries['Gzr'] = Gzr()
     std_unitaries['Gczr'] = Gczr()
@@ -347,7 +370,10 @@ def standard_gatenames_cirq_conversions():
         raise ImportError("Cirq is required for this operation, and it does not appear to be installed.")
 
     std_gatenames_to_cirq = {}
-    std_gatenames_to_cirq['Gi'] = None
+
+    #single-qubit gates
+
+    std_gatenames_to_cirq['Gi'] = cirq.I
     std_gatenames_to_cirq['Gxpi2'] = cirq.XPowGate(exponent=1 / 2)
     std_gatenames_to_cirq['Gxmpi2'] = cirq.XPowGate(exponent=-1 / 2)
     std_gatenames_to_cirq['Gxpi'] = cirq.X
@@ -362,9 +388,51 @@ def standard_gatenames_cirq_conversions():
     std_gatenames_to_cirq['Gh'] = cirq.H
     std_gatenames_to_cirq['Gt'] = cirq.T
     std_gatenames_to_cirq['Gtdag'] = cirq.T**-1
+    std_gatenames_to_cirq['Gn'] = cirq.PhasedXZGate(axis_phase_exponent=0.147584, x_exponent=0.419569, z_exponent=-0.295167)
+
+    #two-qubit gates
+
     std_gatenames_to_cirq['Gcphase'] = cirq.CZ
     std_gatenames_to_cirq['Gcnot'] = cirq.CNOT
     std_gatenames_to_cirq['Gswap'] = cirq.SWAP
+    std_gatenames_to_cirq['Gzz'] = cirq.ZZPowGate(exponent=.5, global_shift=-.5)
+    std_gatenames_to_cirq['Gxx'] = cirq.XXPowGate(exponent=.5, global_shift=-.5)
+    std_gatenames_to_cirq['Giswap'] = cirq.ISWAP
+    std_gatenames_to_cirq['Gsqrtiswap'] = cirq.SQRT_ISWAP
+    #I don't presently see a one-to-one conversion for cross-resonance
+
+    #single-qubit clifford group
+
+    std_gatenames_to_cirq['Gc0'] = cirq.I # This is Gi
+    std_gatenames_to_cirq['Gc1'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=0.5, z_exponent=0.5)
+    std_gatenames_to_cirq['Gc2'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=-0.5)
+    std_gatenames_to_cirq['Gc3'] = cirq.X # This is pauli X
+    std_gatenames_to_cirq['Gc4'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=-0.5, z_exponent=0.5)
+    std_gatenames_to_cirq['Gc5'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=0.5)
+    std_gatenames_to_cirq['Gc6'] = cirq.Y # This is pauli Y
+    std_gatenames_to_cirq['Gc7'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=0.5, z_exponent=-0.5)
+    std_gatenames_to_cirq['Gc8'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=0.5, z_exponent=-0.5)
+    std_gatenames_to_cirq['Gc9'] = cirq.Z # This is pauli Z
+    std_gatenames_to_cirq['Gc10'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=-0.5, z_exponent=-0.5)
+    std_gatenames_to_cirq['Gc11'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=0.5, z_exponent=0.5)
+    std_gatenames_to_cirq['Gc12'] = cirq.H # This is Gh
+    std_gatenames_to_cirq['Gc13'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=-0.5, z_exponent=0.0) # This is Gxmpi2 (up to phase)
+    std_gatenames_to_cirq['Gc14'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=0.0, z_exponent=0.5) # THis is Gzpi2 / Gp (up to phase)
+    std_gatenames_to_cirq['Gc15'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=0.0)# This is Gympi2 (up to phase)
+    std_gatenames_to_cirq['Gc16'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=0.5, z_exponent=0.0)# This is Gxpi2 (up to phase)
+    std_gatenames_to_cirq['Gc17'] = cirq.PhasedXZGate(axis_phase_exponent=0.25, x_exponent=1.0, z_exponent=0.0)# This is Gypi2 (up to phase)
+    std_gatenames_to_cirq['Gc18'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=0.5, z_exponent=1.0)
+    std_gatenames_to_cirq['Gc19'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=-0.5, z_exponent=1.0)
+    std_gatenames_to_cirq['Gc20'] = cirq.PhasedXZGate(axis_phase_exponent=-0.25, x_exponent=1.0, z_exponent=0.0)
+    std_gatenames_to_cirq['Gc21'] = cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=0.5, z_exponent=0.0) # This is Gypi2 (up to phase)
+    std_gatenames_to_cirq['Gc22'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=0.5, z_exponent=1.0)
+    std_gatenames_to_cirq['Gc23'] = cirq.PhasedXZGate(axis_phase_exponent=0.0, x_exponent=0.0, z_exponent=-0.5) # This is Gzmpi2 / Gpdag (up to phase)
+
+    #legacy aliasing:
+    std_gatenames_to_cirq['Gx'] = std_gatenames_to_cirq['Gxpi2']
+    std_gatenames_to_cirq['Gy'] = std_gatenames_to_cirq['Gypi2']
+    std_gatenames_to_cirq['Gz'] = std_gatenames_to_cirq['Gzpi2']    
+
 
     return std_gatenames_to_cirq
 

--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -460,6 +460,9 @@ def cirq_gatenames_standard_conversions():
     cirq_to_standard_mapping[cirq.X] = 'Gxpi'
     cirq_to_standard_mapping[cirq.Y] = 'Gypi'
     cirq_to_standard_mapping[cirq.Z] = 'Gzpi'
+    cirq_to_standard_mapping[cirq.XPowGate(exponent=1 / 2)] = 'Gxpi2'
+    cirq_to_standard_mapping[cirq.YPowGate(exponent=1 / 2)] = 'Gypi2'
+    cirq_to_standard_mapping[cirq.ZPowGate(exponent=1 / 2)] = 'Gzpi2'
     cirq_to_standard_mapping[cirq.H] = 'Gh'
 
     return cirq_to_standard_mapping

--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -16,7 +16,7 @@ import scipy.linalg as _spl
 from pygsti.tools import optools as _ot
 from pygsti.tools import symplectic as _symp
 from pygsti.baseobjs.unitarygatefunction import UnitaryGateFunction as _UnitaryGateFunction
-from pygsti import sigmax, sigmay, sigmaz, sigmaxz
+from pygsti.tools.gatetools import sigmax, sigmay, sigmaz, sigmaxz
 
 
 class Gzr(_UnitaryGateFunction):
@@ -357,12 +357,11 @@ def standard_gatenames_cirq_conversions():
 
     Currently there are some standard gate names with no conversion to cirq.
 
-    TODO: add Clifford gates with
-    https://cirq.readthedocs.io/en/latest/generated/cirq.SingleQubitCliffordGate.html
-
     Returns
     -------
-    dict mapping strings to string
+    std_gatenames_to_cirq
+        dict mapping strings corresponding to standard built-in pyGSTi names to
+        corresponding cirq operation objects. 
     """
     try:
         import cirq
@@ -388,7 +387,9 @@ def standard_gatenames_cirq_conversions():
     std_gatenames_to_cirq['Gh'] = cirq.H
     std_gatenames_to_cirq['Gt'] = cirq.T
     std_gatenames_to_cirq['Gtdag'] = cirq.T**-1
-    std_gatenames_to_cirq['Gn'] = cirq.PhasedXZGate(axis_phase_exponent=0.147584, x_exponent=0.419569, z_exponent=-0.295167)
+    std_gatenames_to_cirq['Gn'] = cirq.PhasedXZGate(axis_phase_exponent=0.14758361765043326, 
+                                                    x_exponent=0.4195693767448338, 
+                                                    z_exponent=-0.2951672353008665)
 
     #two-qubit gates
 
@@ -435,6 +436,33 @@ def standard_gatenames_cirq_conversions():
 
 
     return std_gatenames_to_cirq
+
+def cirq_gatenames_standard_conversions():
+    
+    """
+    A dictionary converting cirq gates to built-in pyGSTi names for these gates.
+    Does not currently support conversion of all cirq gate types.
+    """
+
+    try:
+        import cirq
+    except ImportError:
+        raise ImportError("Cirq is required for this operation, and it does not appear to be installed.")
+
+
+    #reverse the mapping in standard_gatenames_cirq_conversions
+    cirq_to_standard_mapping = {value: key for key,value in standard_gatenames_cirq_conversions().items()}
+
+    #A direct reversing doesn't quite do what we want since the originally mapping was not
+    #one-to-one (some pyGSTi gate names refer to the same cirq Circuit, primarily because of the cliffords). 
+    #Manually add back in some preference on the non-one-to-one gates.
+    cirq_to_standard_mapping[cirq.I] = 'Gi'
+    cirq_to_standard_mapping[cirq.X] = 'Gxpi'
+    cirq_to_standard_mapping[cirq.Y] = 'Gypi'
+    cirq_to_standard_mapping[cirq.Z] = 'Gzpi'
+    cirq_to_standard_mapping[cirq.H] = 'Gh'
+
+    return cirq_to_standard_mapping
 
 
 def standard_gatenames_quil_conversions():

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -557,10 +557,45 @@ MEASURE 2 ro[2]
         converted_pygsti_circuit = circuit.Circuit.from_cirq(cirq_circuit, 
                                                              qubit_conversion= {qubit_00: 0, qubit_01: 1})
         
-        ckt = circuit.Circuit([Label('Gxpi2',0), Label(()), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
+        ckt = circuit.Circuit([Label('Gxpi2',0), Label([Label('Gi',0), Label('Gi',1)]), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
                                Label('Gcnot', (0,1))], line_labels=(0,1))
         
         self.assertEqual(ckt, converted_pygsti_circuit)
+
+        #test without stipping implied idles:
+        converted_pygsti_circuit_implied_idles = circuit.Circuit.from_cirq(cirq_circuit, 
+                                                             qubit_conversion= {qubit_00: 0, qubit_01: 1},
+                                                             implied_idles= True)
+
+        ckt_implied_idles = circuit.Circuit([Label([Label('Gxpi2',0), Label('Gi',1)]), 
+                                             Label([Label('Gi',0), Label('Gi',1)]), 
+                                             Label([Label('Gn',0), Label('Gi',1)]), 
+                                             Label([Label('Gh',0), Label('Gtdag',1)]), 
+                                             Label('Gcnot', (0,1))], line_labels=(0,1))
+        
+        self.assertEqual(ckt_implied_idles, converted_pygsti_circuit_implied_idles)
+
+        #test w/replacement of global idle
+        ckt_global_idle = circuit.Circuit([Label('Gxpi2',0), Label(()), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
+                               Label('Gcnot', (0,1))], line_labels=(0,1))
+        ckt_global_idle_custom = circuit.Circuit([Label('Gxpi2',0), Label('Gbanana', (0,1)), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
+                               Label('Gcnot', (0,1))], line_labels=(0,1))
+        
+        converted_pygsti_circuit_global_idle = circuit.Circuit.from_cirq(cirq_circuit, 
+                                                             qubit_conversion= {qubit_00: 0, qubit_01: 1},
+                                                             global_idle=True)
+        
+        converted_pygsti_circuit_global_idle_custom = circuit.Circuit.from_cirq(cirq_circuit, 
+                                                             qubit_conversion= {qubit_00: 0, qubit_01: 1},
+                                                             global_idle='Gbanana')
+        
+        converted_pygsti_circuit_global_idle_custom_1 = circuit.Circuit.from_cirq(cirq_circuit, 
+                                                             qubit_conversion= {qubit_00: 0, qubit_01: 1},
+                                                             global_idle=Label('Gbanana', (0,1)))
+        
+        self.assertEqual(ckt_global_idle, converted_pygsti_circuit_global_idle)
+        self.assertEqual(ckt_global_idle_custom, converted_pygsti_circuit_global_idle_custom)
+        self.assertEqual(ckt_global_idle_custom, converted_pygsti_circuit_global_idle_custom_1)
 
     def test_done_editing(self):
         self.c.done_editing()

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -557,18 +557,18 @@ MEASURE 2 ro[2]
         converted_pygsti_circuit = circuit.Circuit.from_cirq(cirq_circuit, 
                                                              qubit_conversion= {qubit_00: 0, qubit_01: 1})
         
-        ckt = circuit.Circuit([Label('Gxpi2',0), Label([Label('Gi',0), Label('Gi',1)]), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
+        ckt = circuit.Circuit([Label('Gxpi2',0), Label(()), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
                                Label('Gcnot', (0,1))], line_labels=(0,1))
         
         self.assertEqual(ckt, converted_pygsti_circuit)
 
-        #test without stipping implied idles:
+        #test without stripping implied idles:
         converted_pygsti_circuit_implied_idles = circuit.Circuit.from_cirq(cirq_circuit, 
                                                              qubit_conversion= {qubit_00: 0, qubit_01: 1},
-                                                             implied_idles= True)
+                                                             remove_implied_idles= False)
 
         ckt_implied_idles = circuit.Circuit([Label([Label('Gxpi2',0), Label('Gi',1)]), 
-                                             Label([Label('Gi',0), Label('Gi',1)]), 
+                                             Label(()), 
                                              Label([Label('Gn',0), Label('Gi',1)]), 
                                              Label([Label('Gh',0), Label('Gtdag',1)]), 
                                              Label('Gcnot', (0,1))], line_labels=(0,1))
@@ -581,22 +581,31 @@ MEASURE 2 ro[2]
         ckt_global_idle_custom = circuit.Circuit([Label('Gxpi2',0), Label('Gbanana', (0,1)), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
                                Label('Gcnot', (0,1))], line_labels=(0,1))
         
+        ckt_global_idle_none = circuit.Circuit([Label('Gxpi2',0), Label([Label('Gi',0), Label('Gi',1)]), Label('Gn',0), Label([Label('Gh',0), Label('Gtdag',1)]), 
+                               Label('Gcnot', (0,1))], line_labels=(0,1))
+        
         converted_pygsti_circuit_global_idle = circuit.Circuit.from_cirq(cirq_circuit, 
                                                              qubit_conversion= {qubit_00: 0, qubit_01: 1},
-                                                             global_idle=True)
+                                                             global_idle_replacement_label='auto')
         
         converted_pygsti_circuit_global_idle_custom = circuit.Circuit.from_cirq(cirq_circuit, 
                                                              qubit_conversion= {qubit_00: 0, qubit_01: 1},
-                                                             global_idle='Gbanana')
+                                                             global_idle_replacement_label='Gbanana')
         
         converted_pygsti_circuit_global_idle_custom_1 = circuit.Circuit.from_cirq(cirq_circuit, 
                                                              qubit_conversion= {qubit_00: 0, qubit_01: 1},
-                                                             global_idle=Label('Gbanana', (0,1)))
+                                                             global_idle_replacement_label=Label('Gbanana', (0,1)))
         
+        converted_pygsti_circuit_global_idle_none = circuit.Circuit.from_cirq(cirq_circuit, 
+                                                             qubit_conversion= {qubit_00: 0, qubit_01: 1},
+                                                             global_idle_replacement_label=None)
+        
+
         self.assertEqual(ckt_global_idle, converted_pygsti_circuit_global_idle)
         self.assertEqual(ckt_global_idle_custom, converted_pygsti_circuit_global_idle_custom)
         self.assertEqual(ckt_global_idle_custom, converted_pygsti_circuit_global_idle_custom_1)
-
+        self.assertEqual(ckt_global_idle_none, converted_pygsti_circuit_global_idle_none)
+        
     def test_done_editing(self):
         self.c.done_editing()
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
This PR updates the existing parser for conversion of pyGSTi Circuit objects to Cirq Circuit objects. Also introduced is a new parser for converting from Cirq Circuits objects into pyGSTi Circuit objects. A few other minor changes include:

1. Updates to pyGSTi's built-in gate definitions to include the following: 

- 'Giswap' and 'Gsqrtiswap' (2-qubit gates commonly used on superconducting platforms)
- 'Gcres' and 'Gecres' (2-qubit cross-resonance and echoed cross-resonance gates, respectively, native on many platforms including IBM's)
-  'Gn' (one-qubit N gate, a pi/2 rotation about the (np.sqrt(3)/2, 0, -1/2) axis of the Bloch sphere, commonly used native gate in some silicon qubit platforms, the N referred to in the smq1Q_ZN modelpack), 
- 'Gxpi4', 'Gypi4', 'Gzpi4' (pi/4 rotations above the various Bloch sphere axes, Gxpi4 appeared in one of the modelpacks, and I figured it best to add the Y and Z counterparts at the same time).

2. Updated the function `unitary_to_standard_gatename` in `tools.internalgates` to allow the option for checking for equivalence of unitaries to a built-in gate up to an overall global phase.

3. New unit tests (including one for qasm conversion, which was previously not unit tested) and updates to the cirq integration demo notebook to include the new functionality. 

Note: I branched this off of #403, which is why there is so much testing update stuff in the commit log (once that gets merged in it should go away from this PR), stuff relevant to this update begins 3/13/24 w/ 185a59ad759bbb2d7a494e7f48f8ab36773aaa52.