### PR TITLE
Replace deprecated numpy.product, numpy.NaN and others

### DIFF
--- a/pygsti/baseobjs/opcalc/fastopcalc.pyx
+++ b/pygsti/baseobjs/opcalc/fastopcalc.pyx
@@ -69,7 +69,7 @@ def bulk_eval_compact_polynomials_real(np.ndarray[np.int64_t, ndim=1, mode="c"] 
                                  np.ndarray[double, ndim=1, mode="c"] ctape,
                                  np.ndarray[double, ndim=1, mode="c"] paramvec,
                                  dest_shape):
-    cdef INT dest_size = np.product(dest_shape)
+    cdef INT dest_size = np.prod(dest_shape)
     cdef np.ndarray[np.float64_t, ndim=1, mode="c"] res = np.empty(dest_size, np.float64)
 
     cdef INT c = 0
@@ -108,7 +108,7 @@ def bulk_eval_compact_polynomials_complex(np.ndarray[np.int64_t, ndim=1, mode="c
                                     np.ndarray[double, ndim=1, mode="c"] paramvec,
                                     dest_shape):
     cdef INT k
-    cdef INT dest_size = 1  # np.product(dest_shape) #SLOW!
+    cdef INT dest_size = 1  # np.prod(dest_shape) #SLOW!
     for k in range(len(dest_shape)):
         dest_size *= dest_shape[k]
     cdef np.ndarray[np.complex128_t, ndim=1, mode="c"] res = np.empty(dest_size, np.complex128)

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -75,7 +75,7 @@ def _np_to_quil_def_str(name, input_array):
 def _num_to_rqc_str(num):
     """Convert float to string to be included in RQC quil DEFGATE block
     (as written by _np_to_quil_def_str)."""
-    num = _np.complex_(_np.real_if_close(num))
+    num = _np.complex128(_np.real_if_close(num))
     if _np.imag(num) == 0:
         output = str(_np.real(num))
         return output

--- a/pygsti/data/datacomparator.py
+++ b/pygsti/data/datacomparator.py
@@ -75,11 +75,11 @@ def _loglikelihood_ratio(n_list_list):
         The log-likehood ratio for this model comparison.
     """
     nListC = _np.sum(n_list_list, axis=0)
-    pListC = nListC / _np.float_(_np.sum(nListC))
+    pListC = nListC / _np.float64(_np.sum(nListC))
     lC = _loglikelihood(pListC, nListC)
     li_list = []
     for nList in n_list_list:
-        pList = _np.array(nList) / _np.float_(_np.sum(nList))
+        pList = _np.array(nList) / _np.float64(_np.sum(nList))
         li_list.append(_loglikelihood(pList, nList))
     lS = _np.sum(li_list)
     return -2 * (lC - lS)

--- a/pygsti/evotypes/densitymx/effectreps.pyx
+++ b/pygsti/evotypes/densitymx/effectreps.pyx
@@ -108,7 +108,7 @@ cdef class EffectRepTensorProduct(EffectRep):
         cdef _np.ndarray[_np.int64_t, ndim=1, mode='c'] factor_dims = \
             _np.ascontiguousarray(_np.array([fct.state_space.dim for fct in povm_factors], _np.int64))
 
-        cdef INT dim = _np.product(factor_dims)
+        cdef INT dim = _np.prod(factor_dims)
         cdef INT nfactors = len(povm_factors)
         self.povm_factors = povm_factors
         self.effect_labels = effect_labels

--- a/pygsti/evotypes/densitymx/opreps.pyx
+++ b/pygsti/evotypes/densitymx/opreps.pyx
@@ -540,7 +540,7 @@ def _compute_embedding_quantities_cachekey(state_space, target_labels, embedded_
     # final map just acts as identity w.r.t.
     labelIndices = [tensorProdBlkLabels.index(label) for label in target_labels]
     cdef _np.ndarray[_np.int64_t, ndim=1, mode='c'] action_inds = _np.array(labelIndices, _np.int64)
-    assert(_np.product([num_basis_els[i] for i in action_inds]) == embedded_rep_dim), \
+    assert(_np.prod([num_basis_els[i] for i in action_inds]) == embedded_rep_dim), \
         "Embedded operation has dimension (%d) inconsistent with the given target labels (%s)" % (
             embedded_rep_dim, str(target_labels))
 
@@ -550,7 +550,7 @@ def _compute_embedding_quantities_cachekey(state_space, target_labels, embedded_
     cdef INT ncomponents_in_active_block = len(state_space.tensor_product_block_labels(active_block_index))
     cdef INT embedded_dim = embedded_rep_dim
     cdef _np.ndarray[_np.int64_t, ndim=1, mode='c'] blocksizes = \
-        _np.array([_np.product(state_space.tensor_product_block_dimensions(k))
+        _np.array([_np.prod(state_space.tensor_product_block_dimensions(k))
                    for k in range(nblocks)], _np.int64)
     cdef INT i, j
 

--- a/pygsti/evotypes/densitymx/statereps.pyx
+++ b/pygsti/evotypes/densitymx/statereps.pyx
@@ -163,7 +163,7 @@ cdef class StateRepTensorProduct(StateRep):
 
     def __cinit__(self, factor_state_reps, state_space):
         self.factor_reps = factor_state_reps
-        dim = _np.product([fct.dim for fct in self.factor_reps])
+        dim = _np.prod([fct.dim for fct in self.factor_reps])
         self._cinit_base(_np.zeros(dim, 'd'), state_space)
         self.reps_have_changed()
 

--- a/pygsti/evotypes/stabilizer/statereps.pyx
+++ b/pygsti/evotypes/stabilizer/statereps.pyx
@@ -129,7 +129,7 @@ cdef class StateRepTensorProduct(StateRep):
     def __cinit__(self, factor_state_reps, state_space):
         self.factor_reps = factor_state_reps
         n = sum([sf.nqubits for sf in self.factor_reps])  # total number of qubits
-        np = int(_np.product([len(sf.pvectors) for sf in self.factor_reps]))
+        np = int(_np.prod([len(sf.pvectors) for sf in self.factor_reps]))
         self._cinit_base(_np.zeros((2 * n, 2 * n), _np.int64),
                          _np.zeros((np, 2 * n), _np.int64),
                          _np.ones(np, complex),

--- a/pygsti/evotypes/statevec/effectreps.pyx
+++ b/pygsti/evotypes/statevec/effectreps.pyx
@@ -111,7 +111,7 @@ cdef class EffectRepTensorProduct(EffectRep):
         cdef _np.ndarray[_np.int64_t, ndim=1, mode='c'] factor_dims = \
             _np.ascontiguousarray(_np.array([fct.state_space.udim for fct in povm_factors], _np.int64))
 
-        cdef INT dim = _np.product(factor_dims)
+        cdef INT dim = _np.prod(factor_dims)
         cdef INT nfactors = len(self.povm_factors)
         self.povm_factors = povm_factors
         self.effect_labels = effect_labels

--- a/pygsti/evotypes/statevec/opreps.pyx
+++ b/pygsti/evotypes/statevec/opreps.pyx
@@ -246,7 +246,7 @@ cdef class OpRepEmbedded(OpRep):
         # final map just acts as identity w.r.t.
         labelIndices = [tensorProdBlkLabels.index(label) for label in target_labels]
         cdef _np.ndarray[_np.int64_t, ndim=1, mode='c'] action_inds = _np.array(labelIndices, _np.int64)
-        assert(_np.product([num_basis_els[i] for i in action_inds]) == embedded_rep.dim), \
+        assert(_np.prod([num_basis_els[i] for i in action_inds]) == embedded_rep.dim), \
             "Embedded operation has dimension (%d) inconsistent with the given target labels (%s)" % (
                 embedded_rep.dim, str(target_labels))
 
@@ -256,7 +256,7 @@ cdef class OpRepEmbedded(OpRep):
         cdef INT ncomponents_in_active_block = len(state_space.tensor_product_block_labels(active_block_index))
         cdef INT embedded_dim = embedded_rep.dim
         cdef _np.ndarray[_np.int64_t, ndim=1, mode='c'] blocksizes = \
-            _np.array([_np.product(state_space.tensor_product_block_udimensions(k))
+            _np.array([_np.prod(state_space.tensor_product_block_udimensions(k))
                        for k in range(nblocks)], _np.int64)
         cdef INT i, j
 

--- a/pygsti/evotypes/statevec/statereps.pyx
+++ b/pygsti/evotypes/statevec/statereps.pyx
@@ -150,7 +150,7 @@ cdef class StateRepTensorProduct(StateRep):
 
     def __init__(self, factor_state_reps, state_space):
         self.factor_reps = factor_state_reps
-        dim = _np.product([fct.dim for fct in self.factor_reps])
+        dim = _np.prod([fct.dim for fct in self.factor_reps])
         self._cinit_base(_np.zeros(dim, complex), state_space, None)  # TODO: compute a tensorprod basis?
         self.reps_have_changed()
 

--- a/pygsti/protocols/vbdataframe.py
+++ b/pygsti/protocols/vbdataframe.py
@@ -19,7 +19,7 @@ def _calculate_summary_statistic(x, statistic, lower_cutoff=None):
     Utility function that returns statistic(x), or the maximum
     of statistic(x) and lower_cutoff if lower_cutoff is not None.
     """
-    if len(x) == 0 or _np.all(_np.isnan(x)): return _np.NaN
+    if len(x) == 0 or _np.all(_np.isnan(x)): return _np.nan
     if statistic == 'mean': func = _np.nanmean
     elif statistic == 'max' or statistic == 'monotonic_max': func = _np.nanmax
     elif statistic == 'min' or statistic == 'monotonic_min': func = _np.nanmin

--- a/pygsti/report/fogidiagram.py
+++ b/pygsti/report/fogidiagram.py
@@ -1038,7 +1038,7 @@ class FOGIMultiscaleGridDiagram(FOGIDiagram):
         for i in range(nOps):
             for j in range(i, nOps):
                 total_items[i, j] = sum([len(by_qty_items[qty][i, j]) for qty in all_qtys])
-                if total_items[i, j] == 0: totals[i, j] = _np.NaN
+                if total_items[i, j] == 0: totals[i, j] = _np.nan
 
         box_size_mode = "condensed"  # or "inflated"
         if detail_level == 2:

--- a/pygsti/tools/fastcalc.pyx
+++ b/pygsti/tools/fastcalc.pyx
@@ -50,7 +50,7 @@ def embedded_fast_acton_sparse(embedded_gate_acton_fn,
     cdef np.ndarray[double, ndim=1, mode="c"] slc1 = np.empty(nActionIndices, dtype='d')
     cdef np.ndarray[double, ndim=1, mode="c"] slc2 = np.empty(nActionIndices, dtype='d')
 
-    # nActionIndices = np.product(numBasisEls_action)
+    # nActionIndices = np.prod(numBasisEls_action)
     #for i in range(nAction):
     #    nActionIndices *= numBasisEls_action[i]
 
@@ -274,7 +274,7 @@ def embedded_fast_acton_sparse_complex(embedded_gate_acton_fn,
     cdef np.ndarray[np.complex128_t, ndim=1, mode="c"] slc1 = np.empty(nActionIndices, dtype=np.complex128)
     cdef np.ndarray[np.complex128_t, ndim=1, mode="c"] slc2 = np.empty(nActionIndices, dtype=np.complex128)
 
-    # nActionIndices = np.product(numBasisEls_action)
+    # nActionIndices = np.prod(numBasisEls_action)
     #for i in range(nAction):
     #    nActionIndices *= numBasisEls_action[i]
 

--- a/pygsti/tools/matrixmod2.py
+++ b/pygsti/tools/matrixmod2.py
@@ -468,7 +468,7 @@ def fix_top(a):
     found_B = False
     for ind in range(t):
         aa, P = permute_top(a, ind)
-        B = _np.round_(aa[1:, 1:])
+        B = _np.round(aa[1:, 1:])
 
         if det_mod2(B) == 0:
             continue


### PR DESCRIPTION
Numpy 2.0 is about to be released and several deprecated attributes will be removed. In this PR we replace them with the preferred alternatives.

Also see: https://github.com/numpy/numpy/issues/24300, https://numpy.org/devdocs/numpy_2_0_migration_guide.html