### PR TITLE
Cast gates to dense matrices in `optools`

### DIFF
--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -514,6 +514,10 @@ def average_gate_fidelity(a, b, mx_basis='pp', is_tp=None, is_unitary=None):
     AGI : float
         The AGI of a to b.
     """
+    # Cast to dense to ensure we can extract the shape.
+    with _contextlib.suppress(AttributeError):
+        a = a.to_dense()
+
     d = int(round(_np.sqrt(a.shape[0])))
     PF = entanglement_fidelity(a, b, mx_basis, is_tp, is_unitary)
     AGF = (d * PF + 1) / (1 + d)
@@ -720,6 +724,10 @@ def unitarity(a, mx_basis="gm"):
     -------
     float
     """
+    # Cast to dense to ensure we can extract the shape.
+    with _contextlib.suppress(AttributeError):
+        a = a.to_dense()
+        
     d = int(round(_np.sqrt(a.shape[0])))
     basisMxs = _bt.basis_matrices(mx_basis, a.shape[0])
 

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -20,6 +20,7 @@ import scipy.sparse as _sps
 import scipy.sparse.linalg as _spsl
 import functools as _functools
 
+from pygsti.modelmembers.operations.linearop import LinearOperator as _LinearOperator
 from pygsti.tools import basistools as _bt
 from pygsti.tools import jamiolkowski as _jam
 from pygsti.tools import lindbladtools as _lt
@@ -435,9 +436,9 @@ def entanglement_fidelity(a, b, mx_basis='pp', is_tp=None, is_unitary=None):
     """
     # Attempt to cast to dense array. If this is already an array, the AttributeError
     # will be suppressed.
-    with _contextlib.suppress(AttributeError):
+    if isinstance(a, _LinearOperator):
         a = a.to_dense()
-    with _contextlib.suppress(AttributeError):
+    if isinstance(b, _LinearOperator):
         b = b.to_dense()
 
     d2 = a.shape[0]
@@ -515,7 +516,7 @@ def average_gate_fidelity(a, b, mx_basis='pp', is_tp=None, is_unitary=None):
         The AGI of a to b.
     """
     # Cast to dense to ensure we can extract the shape.
-    with _contextlib.suppress(AttributeError):
+    if isinstance(a, _LinearOperator):
         a = a.to_dense()
 
     d = int(round(_np.sqrt(a.shape[0])))
@@ -725,7 +726,7 @@ def unitarity(a, mx_basis="gm"):
     float
     """
     # Cast to dense to ensure we can extract the shape.
-    with _contextlib.suppress(AttributeError):
+    if isinstance(a, _LinearOperator):
         a = a.to_dense()
         
     d = int(round(_np.sqrt(a.shape[0])))

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -11,7 +11,6 @@ Utility functions operating on operation matrices
 #***************************************************************************************************
 
 import collections as _collections
-import contextlib as _contextlib
 import warnings as _warnings
 
 import numpy as _np

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -11,6 +11,7 @@ Utility functions operating on operation matrices
 #***************************************************************************************************
 
 import collections as _collections
+import contextlib as _contextlib
 import warnings as _warnings
 
 import numpy as _np
@@ -402,11 +403,13 @@ def entanglement_fidelity(a, b, mx_basis='pp', is_tp=None, is_unitary=None):
         
     Parameters
     ----------
-    a : numpy array
-        First matrix.
+    a : array or gate
+        The gate to compute the entanglement fidelity to b of. E.g., an 
+        imperfect implementation of b.
 
-    b : numpy array
-        Second matrix.
+    b : array or gate
+        The gate to compute the entanglement fidelity to a of. E.g., the 
+        target gate corresponding to a.
 
     mx_basis : {'std', 'gm', 'pp', 'qt'} or Basis object
         The basis of the matrices.  Allowed values are Matrix-unit (std),
@@ -430,6 +433,13 @@ def entanglement_fidelity(a, b, mx_basis='pp', is_tp=None, is_unitary=None):
     -------
     float
     """
+    # Attempt to cast to dense array. If this is already an array, the AttributeError
+    # will be suppressed.
+    with _contextlib.suppress(AttributeError):
+        a = a.to_dense()
+    with _contextlib.suppress(AttributeError):
+        b = b.to_dense()
+
     d2 = a.shape[0]
     
     #if the tp flag isn't set we'll calculate whether it is true here


### PR DESCRIPTION
### Description of changes

Minor change: in `optools.entanglement_fidelity`, accept both arrays and gates for the `a` and `b` arguments. The arguments are cast to (dense) arrays within the function scope.

Perform similar casting in other functions, that call `a.shape`. 

### Motivation

See also #406.

Since some update (cannot pinpoint which exactly), this casting was not done anymore, neither within `optools.entanglement_fidelity`, nor in any of the functions calling this one.

I've chosen to cast to dense array within `optools.entanglement_fidelity`, rather than before calling this function, for two reasons:

- It keeps the number of changes as small as possible;
- It provides a more consistent interface across `optools`. Other functions (such as `average_gate_fidelity`, which calls `entanglement_fidelity`) accept arrays or gates. Hence, I'm of the opinion that casting to array within `entanglement_fidelity` is the more consistent choice. Alternatively, casting can be done before calling it, but (IMO) it's more consistent to then also do that for the other metrics functions defined in `optools`. I'm okay with either way, but this seems the simpler and less backwards-breaking solution, but I'm happy to implemetn otherwise if required.
- It resolves an error in for example `average_gate_fidelity`, which states in the docstring that it accepts arrays or gates for `a` and `b`, but directly passes `a` and `b` to `entanglement_fidelity`, leading to an error.
- Prevents errors on calling `a.shape` on gates that do not have the `shape` attribute (such as `ComposedOp`s)