### PR TITLE
Bugfix for fiducial circuit line labels

### DIFF
--- a/pygsti/algorithms/fiducialselection.py
+++ b/pygsti/algorithms/fiducialselection.py
@@ -2013,6 +2013,12 @@ def create_candidate_fiducial_list(target_model, omit_identity= True, ops_to_omi
         else:
             availableFidList.extend(_circuits.list_random_circuits_onelen(
                 fidOps, fidLength, count, seed=candidate_seed))
+
+    #force the line labels on each circuit to match the state space labels for the target model.
+    #this is suboptimal for many-qubit models, so will probably want to revisit this. #TODO
+    for ckt in availableFidList:
+        ckt.line_labels = target_model.state_space.state_space_labels
+        
     return availableFidList
     
     


### PR DESCRIPTION
This is a quick bugfix for issue #396. The fix here is to simply force each of the line labels for candidate fiducial circuits to match the state space labels of the input target model. This is a suboptimal fix looking forward to many-qubit systems (as I mentioned in a comment on #396), but we don't presently have the infrastructure needed for doing this a better way and this fix should be fine for 99% of use cases with ExplicitOpModels in the few-qubit setting. 

