### PR TITLE
Bugfix Cirq Datasets and LGST Bug

### DIFF
--- a/pygsti/algorithms/core.py
+++ b/pygsti/algorithms/core.py
@@ -247,7 +247,10 @@ def run_lgst(dataset, prep_fiducials, effect_fiducials, target_model, op_labels=
                     circuit = rhostr
                 dsRow_fractions = dataset[circuit].fractions
                 # outcome labels should just be effect labels (no instruments!)
-                EVec[0, i] = dsRow_fractions[(effectLabel,)]
+                # when using a sparse data set format it might not be the case
+                # that all effect labels are present (only ones with non-zero counts are)
+                # so return 0 for the fraction in that case.
+                EVec[0, i] = dsRow_fractions.get((effectLabel,), 0)
             EVec_p = _np.dot(_np.dot(EVec, Vd), Pj)  # truncate Evec => Evec', shape (1,trunc)
             povm_effects.append((effectLabel, _np.transpose(EVec_p)))
         lgstModel.povms[povmLabel] = _povm.UnconstrainedPOVM(povm_effects, evotype='default')
@@ -262,7 +265,10 @@ def run_lgst(dataset, prep_fiducials, effect_fiducials, target_model, op_labels=
                 # try without prepLabel since it will be the default
                 circuit = estr
             dsRow_fractions = dataset[circuit].fractions
-            rhoVec[eoff:eoff + povmLen, 0] = [dsRow_fractions[(ol,)] for ol in target_model.povms[povmLbl]]
+            # when using a sparse data set format it might not be the case
+            # that all effect labels are present (only ones with non-zero counts are)
+            # so return 0 for the fraction in that case.
+            rhoVec[eoff:eoff + povmLen, 0] = [dsRow_fractions.get((ol,),0) for ol in target_model.povms[povmLbl]]
             eoff += povmLen
         rhoVec_p = _np.dot(Pjt, _np.dot(Ud, rhoVec))  # truncate rhoVec => rhoVec', shape (trunc, 1)
         rhoVec_p = _np.dot(invABMat_p, rhoVec_p)

--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -1603,7 +1603,7 @@ class DataSet(_MongoSerializable):
         self._add_raw_arrays(circuit, outcome_index_array, time_array, count_array,
                              overwriteExisting, record_zero_counts, aux)
 
-    def add_cirq_trial_result(self, circuit, trial_result, key):
+    def add_cirq_trial_result(self, circuit, trial_result, key, convert_int_to_binary = True, num_qubits = None):
         """
         Add a single circuit's counts --- stored in a Cirq TrialResult --- to this DataSet
 
@@ -1619,6 +1619,16 @@ class DataSet(_MongoSerializable):
         key : str
             The string key of the measurement. Set by cirq.measure.
 
+        convert_int_to_binary : bool, optional (defaut True)
+            By default the keys in the cirq Results object are the integers representing
+            the bitstrings of the measurements on a set of qubits, in big-endian convention.
+            If True this uses the cirq function `cirq.big_endian_int_to_bits` to convert back
+            to a binary string before adding the counts as a entry into the pygsti dataset.
+
+        num_qubits : int, optional (default None)
+            Number of qubits used in the conversion from integers to binary when convert_int_to_binary
+            is True. If None, then the number of line_labels on the input circuit is used.
+
         Returns
         -------
         None
@@ -1631,8 +1641,17 @@ class DataSet(_MongoSerializable):
 
         # TrialResult.histogram returns a collections.Counter object, which is a subclass of dict.
         histogram_counter = trial_result.histogram(key=key)
+
+        if num_qubits is None:
+            num_qubits = len(circuit.line_labels)
+
         # The keys in histogram_counter are integers, but pyGSTi likes dictionary keys to be strings.
-        count_dict = {str(key): value for key, value in histogram_counter.items()}
+        count_dict = {}
+        for key, value in histogram_counter.items():
+            if convert_int_to_binary:
+                count_dict[_np.binary_repr(key, width= num_qubits)] = value
+            else:
+                count_dict[str(key)] = value
         self.add_count_dict(circuit, count_dict)
 
     def add_raw_series_data(self, circuit, outcome_label_list, time_stamp_list,


### PR DESCRIPTION
This PR covers two bugfixes. The first is in the method for adding cirq trials to pygsti datasets which did not behave as expected for 2+ qubits. The default behavior of the histogram method of the cirq `Result` object, which is used for gathering aggregated counts for each measurement results is to index these results using integers corresponding to the binary string for an outcome. In pygsti we more commonly use the binary strings themselves as the key. To address this we have added new options to `add_cirq_trial_result` which controls conversion back to a bit string before adding it to the count dictionary.

The second bugfix was to the LGST routine in order to patch in support for datasets with sparse formats wherein we only include outcomes with non-zero counts in the count dict for a circuit. Previously the implementation assumed that the data set was in a dense format with zero entries listed.