### PR TITLE
Bugfix 0.9.12.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ jupyter_notebooks/Tutorials/tutorial_files/modeltest_report
 jupyter_notebooks/Tutorials/tutorial_files/gettingStartedReport
 jupyter_notebooks/Examples/example_files/*.pkl
 jupyter_notebooks/Examples/example_files/*.json
+jupyter_notebooks/Examples/example_files/leakage_*
 jupyter_notebooks/Tutorials/tutorial_files/exampleReport
 jupyter_notebooks/Tutorials/tutorial_files/exampleStdReport
 jupyter_notebooks/Tutorials/tutorial_files/exampleMultiEstimateReport

--- a/jupyter_notebooks/Examples/Leakage.ipynb
+++ b/jupyter_notebooks/Examples/Leakage.ipynb
@@ -15,7 +15,9 @@
    "outputs": [],
    "source": [
     "import pygsti\n",
-    "import pygsti.modelpacks.legacy.std1Q_XYI as std1Q\n",
+    "import pygsti.modelpacks.smq1Q_XYI as smq1Q\n",
+    "from pygsti.baseobjs import Label\n",
+    "from pygsti.circuits import Circuit\n",
     "import numpy as np\n",
     "import scipy.linalg as sla\n",
     "#import pickle"
@@ -49,8 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mdl_2level_ideal = std1Q.target_model()\n",
-    "mdl_2level_ideal.sim = \"matrix\" # so we can create reports later on"
+    "mdl_2level_ideal = smq1Q.target_model(qubit_labels=[\"Qubit\"])"
    ]
   },
   {
@@ -67,17 +68,16 @@
     "                [0,1,0],\n",
     "                [0,0,1]], complex)\n",
     "\n",
-    "sslbls = pygsti.baseobjs.ExplicitStateSpace(['Qubit+Leakage'],[3])\n",
-    "mdl_3level_ideal = pygsti.models.ExplicitOpModel(sslbls, 'gm')\n",
+    "sslbls = pygsti.baseobjs.ExplicitStateSpace(['Qubit_leakage'],[3])\n",
+    "mdl_3level_ideal = pygsti.models.ExplicitOpModel(sslbls, 'gm', simulator='matrix')\n",
     "mdl_3level_ideal['rho0'] = pygsti.tools.stdmx_to_gmvec(rho0)\n",
     "mdl_3level_ideal['Mdefault'] = pygsti.modelmembers.povms.TPPOVM([('0',pygsti.tools.stdmx_to_gmvec(E0)),\n",
     "                                                                 ('1',pygsti.tools.stdmx_to_gmvec(E1))],\n",
     "                                                                evotype='default')\n",
     "\n",
-    "mdl_3level_ideal['Gi'] = unitary_to_gmgate( to_3level_unitary(Us['Gi']))\n",
-    "mdl_3level_ideal['Gx'] = unitary_to_gmgate( to_3level_unitary(Us['Gxpi2']))\n",
-    "mdl_3level_ideal['Gy'] = unitary_to_gmgate( to_3level_unitary(Us['Gypi2']))\n",
-    "mdl_3level_ideal.sim = \"matrix\" # so we can create reports later on"
+    "mdl_3level_ideal[tuple()] = unitary_to_gmgate( to_3level_unitary(Us['Gi']))\n",
+    "mdl_3level_ideal['Gxpi2', 'Qubit_leakage'] = unitary_to_gmgate( to_3level_unitary(Us['Gxpi2']))\n",
+    "mdl_3level_ideal['Gypi2', 'Qubit_leakage'] = unitary_to_gmgate( to_3level_unitary(Us['Gypi2']))"
    ]
   },
   {
@@ -95,15 +95,15 @@
     "\n",
     "#Guess of a model w/just unitary leakage\n",
     "mdl_3level_guess = mdl_3level_ideal.copy()\n",
-    "mdl_3level_guess['Gi'] = np.dot(leakageOp, mdl_3level_guess['Gi'])\n",
-    "#mdl_3level_guess['Gx'] = np.dot(leakageOp, mdl_3level_guess['Gx'])\n",
-    "#mdl_3level_guess['Gy'] = np.dot(leakageOp, mdl_3level_guess['Gy'])\n",
+    "mdl_3level_guess[tuple()] = np.dot(leakageOp, mdl_3level_guess[tuple()])\n",
+    "#mdl_3level_guess['Gxpi2', 'Qubit_leakage'] = np.dot(leakageOp, mdl_3level_guess['Gxpi2', 'Qubit_leakage'])\n",
+    "#mdl_3level_guess['Gypi2', 'Qubit_leakage'] = np.dot(leakageOp, mdl_3level_guess['Gypi2', 'Qubit_leakage'])\n",
     "\n",
     "#Actual model used for data generation (some depolarization too)\n",
     "mdl_3level_noisy = mdl_3level_ideal.depolarize(op_noise=0.005, spam_noise=0.01)\n",
-    "mdl_3level_noisy['Gi'] = np.dot(leakageOp, mdl_3level_noisy['Gi'])\n",
-    "#mdl_3level_noisy['Gx'] = np.dot(leakageOp, mdl_3level_noisy['Gx'])\n",
-    "#mdl_3level_noisy['Gy'] = np.dot(leakageOp, mdl_3level_noisy['Gy'])"
+    "mdl_3level_noisy[tuple()] = np.dot(leakageOp, mdl_3level_noisy[tuple()])\n",
+    "#mdl_3level_noisy['Gxpi2', 'Qubit_leakage'] = np.dot(leakageOp, mdl_3level_noisy['Gxpi2', 'Qubit_leakage'])\n",
+    "#mdl_3level_noisy['Gypi2', 'Qubit_leakage'] = np.dot(leakageOp, mdl_3level_noisy['Gypi2', 'Qubit_leakage'])"
    ]
   },
   {
@@ -126,7 +126,7 @@
     "\n",
     "if find_fiducials:\n",
     "    prepfids, measfids = pygsti.algorithms.find_fiducials(\n",
-    "        mdl_3level_guess, omit_identity=False, max_fid_length=4, verbosity=4)\n",
+    "        mdl_3level_guess, omit_identity=False, candidate_fid_counts={4: \"all upto\"}, verbosity=4)\n",
     "    pygsti.io.write_circuit_list(\"example_files/leakage_prepfids.txt\", prepfids)\n",
     "    pygsti.io.write_circuit_list(\"example_files/leakage_measfids.txt\", measfids)"
    ]
@@ -140,11 +140,8 @@
     "# If files missing, run previous cell at least once with find_fiducials = True\n",
     "prepfids = pygsti.io.read_circuit_list(\"example_files/leakage_prepfids.txt\")\n",
     "measfids = pygsti.io.read_circuit_list(\"example_files/leakage_measfids.txt\")\n",
-    "# HACK: Fix broken force empty labels\n",
-    "prepfids[-1] = pygsti.circuits.Circuit([])\n",
-    "measfids[-1] = pygsti.circuits.Circuit([])\n",
-    "germs = std1Q.germs\n",
-    "maxLengths = [1,]\n",
+    "germs = smq1Q.germs(qubit_labels=[\"Qubit_leakage\"])\n",
+    "maxLengths = [1,2]\n",
     "expList = pygsti.circuits.create_lsgst_circuits(mdl_3level_noisy, prepfids, measfids, germs, maxLengths)\n",
     "ds = pygsti.data.simulate_data(mdl_3level_noisy, expList, 1000, 'binomial', seed=1234)"
    ]
@@ -155,8 +152,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_2level = pygsti.run_stdpractice_gst(ds, mdl_2level_ideal, prepfids, measfids,\n",
-    "                                           germs, maxLengths, modes=\"CPTPLND\", verbosity=3)"
+    "\n",
+    "# We have found out prep fids, meas fids, and germs, as well as simulated noisy data, for the 3 level model\n",
+    "# If we want to run GST on another model, we need to get versions of the circuits will the correct state space labels\n",
+    "\n",
+    "def map_2level_sslbls(circuit):\n",
+    "    sslbl_map = {'Qubit_leakage': 'Qubit'}\n",
+    "    return circuit.map_state_space_labels(sslbl_map)\n",
+    "\n",
+    "prepfids_2level = [map_2level_sslbls(c) for c in prepfids]\n",
+    "measfids_2level = [map_2level_sslbls(c) for c in measfids]\n",
+    "germs_2level = [map_2level_sslbls(c) for c in germs]\n",
+    "ds_2level = ds.process_circuits(map_2level_sslbls)\n",
+    "\n",
+    "results_2level = pygsti.run_stdpractice_gst(ds_2level, mdl_2level_ideal, prepfids_2level, measfids_2level,\n",
+    "                                           germs_2level, maxLengths, modes=\"CPTPLND\", verbosity=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pygsti.report.construct_standard_report(results_2level, \"2-level Leakage Example Report\").write_html('example_files/leakage_report_2level')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open the report [here](example_files/leakage_report_2level/main.html)"
    ]
   },
   {
@@ -168,7 +194,7 @@
    "outputs": [],
    "source": [
     "results_3level = pygsti.run_stdpractice_gst(ds, mdl_3level_ideal, prepfids, measfids,\n",
-    "                                           germs, maxLengths, modes=[\"CPTP\",\"True\"],\n",
+    "                                           germs, maxLengths, modes=[\"CPTPLND\",\"True\"],\n",
     "                                           models_to_test={'True': mdl_3level_noisy}, \n",
     "                                           verbosity=4, advanced_options={'all': {'tolerance': 1e-2}})"
    ]
@@ -179,10 +205,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pygsti.report.construct_standard_report(\n",
-    "    {'two-level': results_2level, 'three-level': results_3level},\n",
-    "    \"Leakage Example Report\"\n",
-    ").write_html('example_files/leakage_report')"
+    "pygsti.report.construct_standard_report(results_3level, \"3-level Leakage Example Report\").write_html('example_files/leakage_report')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Open the report [here](example_files/leakage_report/main.html)"
    ]
   },
   {
@@ -254,17 +284,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pygsti.report.construct_standard_report(\n",
-    "    {'two-level': results_2level, 'three-level': results_3level_leakage_basis},\n",
-    "    \"Leakage Example Report\"\n",
-    ").write_html('example_files/leakage_report')"
+    "pygsti.report.construct_standard_report(results_3level_leakage_basis, \"3-level with Basis Change Leakage Example Report\"\n",
+    "                                        ).write_html('example_files/leakage_report_basis')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open the report [here](example_files/leakage_report/main.html)"
+    "Open the report [here](example_files/leakage_report_basis/main.html)"
    ]
   },
   {
@@ -288,15 +316,15 @@
     "E1 = np.concatenate( (mdl_2level_ideal.povms['Mdefault']['1'].to_dense(),[eps]), axis=0)\n",
     "\n",
     "\n",
-    "statespace = pygsti.baseobjs.ExplicitStateSpace([('Qubit',),('Leakage',)],[(2,),(1,)])\n",
-    "mdl_2plus1_ideal = pygsti.models.ExplicitOpModel(statespace, 'gm')\n",
+    "statespace = pygsti.baseobjs.ExplicitStateSpace([('Qubit',),('Leakage',)], [(2,), (1,)])\n",
+    "mdl_2plus1_ideal = pygsti.models.ExplicitOpModel(statespace, 'gm', simulator='matrix')\n",
     "mdl_2plus1_ideal['rho0'] = rho0\n",
     "mdl_2plus1_ideal['Mdefault'] = pygsti.modelmembers.povms.UnconstrainedPOVM([('0',E0),('1',E1)],\n",
     "                                                                           evotype='default', state_space=statespace)\n",
     "\n",
-    "mdl_2plus1_ideal['Gi'] = to_2plus1_superop(mdl_2level_ideal['Gi'])\n",
-    "mdl_2plus1_ideal['Gx'] = to_2plus1_superop(mdl_2level_ideal['Gx'])\n",
-    "mdl_2plus1_ideal['Gy'] = to_2plus1_superop(mdl_2level_ideal['Gy'])"
+    "mdl_2plus1_ideal[tuple()] = to_2plus1_superop(mdl_2level_ideal[tuple()])\n",
+    "mdl_2plus1_ideal['Gxpi2'] = to_2plus1_superop(mdl_2level_ideal['Gxpi2', 'Qubit'])\n",
+    "mdl_2plus1_ideal['Gypi2'] = to_2plus1_superop(mdl_2level_ideal['Gypi2', 'Qubit'])"
    ]
   },
   {
@@ -305,12 +333,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mdl_2plus1_ideal.sim = \"matrix\" # so we can construct report below\n",
-    "results_2plus1 = pygsti.run_long_sequence_gst(ds, mdl_2plus1_ideal, prepfids, measfids,\n",
-    "                                             germs, maxLengths, verbosity=2,\n",
+    "# We have found out prep fids, meas fids, and germs, as well as simulated noisy data, for the 3 level model\n",
+    "# If we want to run GST on another model, we need to get versions of the circuits will the correct state space labels\n",
+    "\n",
+    "# We do this in a slightly different/awkward way here for this case since our state space labels are not a single entry\n",
+    "# This would not be necessary if we were rebuilding the circuits/dataset from scratch, only hacky since we are reusing the 3-level information\n",
+    "def map_2plus1_circuit_linelabels(circuit):\n",
+    "    return Circuit([Label(l.name) if l.name != \"COMPOUND\" else tuple() for l in circuit.layertup],\n",
+    "                   ['Qubit', 'Leakage'], None, not circuit._static)\n",
+    "\n",
+    "prepfids_2plus1 = [map_2plus1_circuit_linelabels(c) for c in prepfids]\n",
+    "measfids_2plus1 = [map_2plus1_circuit_linelabels(c) for c in measfids]\n",
+    "germs_2plus1 = [map_2plus1_circuit_linelabels(c) for c in germs]\n",
+    "ds_2plus1 = ds.process_circuits(map_2plus1_circuit_linelabels)\n",
+    "\n",
+    "results_2plus1 = pygsti.run_long_sequence_gst(ds_2plus1, mdl_2plus1_ideal, prepfids_2plus1, measfids_2plus1,\n",
+    "                                             germs_2plus1, maxLengths, verbosity=2,\n",
     "                                             advanced_options={\"starting_point\": \"target\",\n",
     "                                                               \"tolerance\": 1e-8,  # (lowering tolerance from 1e-6 gave a better fit)\n",
     "                                                               \"estimate_label\": \"kite\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdl_2plus1_ideal._default_primitive_povm_layer_lbl()"
    ]
   },
   {
@@ -324,11 +374,8 @@
    "outputs": [],
    "source": [
     "# TODO: This is currently broken\n",
-    "pygsti.report.construct_standard_report(\n",
-    "    {'two-level': results_2level, 'three-level': results_3level_leakage_basis,\n",
-    "     'two+one level': results_2plus1},\n",
-    "    \"Leakage Example Report\"\n",
-    ").write_html('example_files/leakage_report', autosize='none')"
+    "pygsti.report.construct_standard_report(results_2plus1,\"2+1 Leakage Example Report\"\n",
+    ").write_html('example_files/leakage_report_2plus1', autosize='none')"
    ]
   },
   {
@@ -341,9 +388,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "leakage_models",
+   "display_name": "pygsti",
    "language": "python",
-   "name": "leakage_models"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -355,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/jupyter_notebooks/Examples/Leakage.ipynb
+++ b/jupyter_notebooks/Examples/Leakage.ipynb
@@ -141,7 +141,7 @@
     "prepfids = pygsti.io.read_circuit_list(\"example_files/leakage_prepfids.txt\")\n",
     "measfids = pygsti.io.read_circuit_list(\"example_files/leakage_measfids.txt\")\n",
     "germs = smq1Q.germs(qubit_labels=[\"Qubit_leakage\"])\n",
-    "maxLengths = [1,2]\n",
+    "maxLengths = [1,]\n",
     "expList = pygsti.circuits.create_lsgst_circuits(mdl_3level_noisy, prepfids, measfids, germs, maxLengths)\n",
     "ds = pygsti.data.simulate_data(mdl_3level_noisy, expList, 1000, 'binomial', seed=1234)"
    ]

--- a/jupyter_notebooks/Examples/Leakage.ipynb
+++ b/jupyter_notebooks/Examples/Leakage.ipynb
@@ -340,7 +340,7 @@
     "# This would not be necessary if we were rebuilding the circuits/dataset from scratch, only hacky since we are reusing the 3-level information\n",
     "def map_2plus1_circuit_linelabels(circuit):\n",
     "    return Circuit([Label(l.name) if l.name != \"COMPOUND\" else tuple() for l in circuit.layertup],\n",
-    "                   ['Qubit', 'Leakage'], None, not circuit._static)\n",
+    "                   \"*\", None, not circuit._static)\n",
     "\n",
     "prepfids_2plus1 = [map_2plus1_circuit_linelabels(c) for c in prepfids]\n",
     "measfids_2plus1 = [map_2plus1_circuit_linelabels(c) for c in measfids]\n",
@@ -352,15 +352,6 @@
     "                                             advanced_options={\"starting_point\": \"target\",\n",
     "                                                               \"tolerance\": 1e-8,  # (lowering tolerance from 1e-6 gave a better fit)\n",
     "                                                               \"estimate_label\": \"kite\"})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mdl_2plus1_ideal._default_primitive_povm_layer_lbl()"
    ]
   },
   {

--- a/jupyter_notebooks/Tutorials/algorithms/GST-Protocols.ipynb
+++ b/jupyter_notebooks/Tutorials/algorithms/GST-Protocols.ipynb
@@ -142,6 +142,95 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Wildcard parameters\n",
+    "\n",
+    "TODO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proto = pygsti.protocols.GateSetTomography(\n",
+    "    target_model_TP, name=\"GSTwithPerGateWildcard\",\n",
+    "    badfit_options={'actions': ['wildcard']}\n",
+    "    )\n",
+    "\n",
+    "# Artifically unset threshold so that wildcard runs. YOU WOULD NOT DO THIS IN PRODUCTION RUNS\n",
+    "proto.badfit_options.threshold = None\n",
+    "\n",
+    "results_pergate_wildcard = proto.run(data, disable_checkpointing=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The wildcard can be retrieved by looking at unmodeled_error in the estimates\n",
+    "results_pergate_wildcard.estimates['GSTwithPerGateWildcard'].parameters['unmodeled_error']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another common form of wildcard is to have one parameter for SPAM and one for all the other gates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "op_label_dict = {k:0 for k in target_model_TP.operations} # Assign all gates to value 0\n",
+    "op_label_dict['SPAM'] = 1 # Assign SPAM to value 1\n",
+    "\n",
+    "proto = pygsti.protocols.GateSetTomography(\n",
+    "    target_model_TP, name=\"GSTwithPerGateWildcard\",\n",
+    "    badfit_options={'actions': ['wildcard'], 'wildcard_primitive_op_labels': op_label_dict}\n",
+    "    )\n",
+    "\n",
+    "# Artifically unset threshold so that wildcard runs. YOU WOULD NOT DO THIS IN PRODUCTION RUNS\n",
+    "proto.badfit_options.threshold = None\n",
+    "\n",
+    "results_globalgate_wildcard = proto.run(data, disable_checkpointing=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unfortunately both of these wildcard strategies have the same problem. They are not unique, i.e. it is possible to \"slosh\" wildcard strength from one parameter to another to get another valid wildcard solution. This makes it difficult to make any quantitative statements about relative wildcard strengths.\n",
+    "\n",
+    "In order to avoid this, we have also introduced a 1D wildcard solution. This takes some reference weighting for the model operations and scales a single wildcard parameter ($\\alpha$) up until the model fits the data. Since there is only one parameter, this does not have any of the ambiguity of the above wildcard strategies. Currently, the reference weighting used is the diamond distance from the noisy model to the target model, with the intuition that \"noisier\" operations are more likely to contribute to model violation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proto = pygsti.protocols.GateSetTomography(\n",
+    "    target_model_TP, name=\"GSTwithPerGateWildcard\",\n",
+    "    badfit_options={'actions': ['wildcard1d'], 'wildcard1d_reference': 'diamond distance'}\n",
+    "    )\n",
+    "\n",
+    "# Artifically unset threshold so that wildcard runs. YOU WOULD NOT DO THIS IN PRODUCTION RUNS\n",
+    "proto.badfit_options.threshold = None\n",
+    "\n",
+    "results_1d_wildcard = proto.run(data, disable_checkpointing=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### running GST using a custom set of circuits\n",
     "So far we've giving the `GateSetTomography.run` method an \"standard\" experiment design containing circuits chosen to amplify all of a standard TP (or CPTP) model's parameters (see the `StandardGSTExpermentDesign` used in the [DataSet tutorial](../objects/DataSet.ipynb)).  A `GateSetTomography` protocol can be run on more general experiment designs, namely those that specify the circuits to use as either a list of lists of `Circuit` objects or a list of or single `CircuitStructure` object(s).  A `CircuitStructure` is preferable as it allows the structured plotting of the sequences in report figures.  In this example, we'll just generate a standard set of circuit structures, but with some of the sequences randomly dropped (see the [tutorial on GST circuit reduction](advanced/GST-FiducialPairReduction.ipynb)."
    ]
@@ -487,9 +576,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gst_checkpointing",
+   "display_name": "pygsti",
    "language": "python",
-   "name": "gst_checkpointing"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -501,7 +590,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/jupyter_notebooks/Tutorials/reporting/ProceduralErrorBars.ipynb
+++ b/jupyter_notebooks/Tutorials/reporting/ProceduralErrorBars.ipynb
@@ -1,0 +1,174 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Procedural Error Bars\n",
+    "\n",
+    "One other way we can use the `pygsti.report.reportables` module described in the [ModelAnalysisMetrics tutorial](ModelAnalysisMetrics.ipynb) is to procedurally generate error bars for any quantity you want.\n",
+    "\n",
+    "First, let's simulate a noisy GST experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pygsti\n",
+    "from pygsti.modelpacks import smq1Q_XY\n",
+    "from pygsti.report import reportables as rptbl, modelfunction as modelfn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_model = smq1Q_XY.target_model()\n",
+    "\n",
+    "L=128\n",
+    "edesign = smq1Q_XY.create_gst_experiment_design(L)\n",
+    "\n",
+    "noisy_model = target_model.randomize_with_unitary(.1)\n",
+    "noisy_model = noisy_model.depolarize(.05)\n",
+    "\n",
+    "N=64\n",
+    "dataset = pygsti.data.simulate_data(noisy_model,edesign,N)\n",
+    "\n",
+    "\n",
+    "gst_proto = pygsti.protocols.StandardGST(modes=['full TP','CPTPLND','Target'],verbosity=2)\n",
+    "data = pygsti.protocols.ProtocolData(edesign,dataset)\n",
+    "results = gst_proto.run(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's compute error bars on the CPTP estimate, and then get a 95% confidence interval \"view\" from the `ConfidenceRegionFactory`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crfact = results.estimates['CPTPLND'].add_confidence_region_factory('stdgaugeopt', 'final')\n",
+    "crfact.compute_hessian(comm=None, mem_limit=3.0*(1024.0)**3) #optionally use multiple processors & set memlimit\n",
+    "crfact.project_hessian('intrinsic error')\n",
+    "\n",
+    "crf_view = results.estimates['CPTPLND'].confidence_region_factories['stdgaugeopt','final'].view(95)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can construct `pygsti.report.ModelFunction` objects that take a function which computes some observable from a model and the extracted view from above to compute error bars on that quantity of interest.\n",
+    "\n",
+    "One common thing to check is error bars on the process matrices. The `ModelFunction` in this case only needs to return the operation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_model = results.estimates['CPTPLND'].models['stdgaugeopt'].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_op(model, lbl):\n",
+    "    return model[lbl]\n",
+    "get_op_modelfn = modelfn.modelfn_factory(get_op)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rptbl.evaluate(get_op_modelfn(final_model, (\"Gxpi2\", 0)), crf_view)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rptbl.evaluate(get_op_modelfn(final_model, (\"Gypi2\", 0)), crf_view)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But we can also create model functions that perform more complicated actions, such as computing other reportables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that when creating ModelFunctions in this way, the model where you want the quantity evaluated must be the first argument\n",
+    "def ddist(model, ideal_model, lbl, basis):\n",
+    "    return rptbl.half_diamond_norm(model[lbl], ideal_model[lbl], basis)\n",
+    "ddist_modelfn = modelfn.modelfn_factory(ddist)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rptbl.evaluate(ddist_modelfn(final_model, target_model, (\"Gxpi2\", 0), 'pp'), crf_view)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rptbl.evaluate(ddist_modelfn(final_model, target_model, (\"Gypi2\", 0), 'pp'), crf_view)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pygsti",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pygsti/algorithms/fiducialselection.py
+++ b/pygsti/algorithms/fiducialselection.py
@@ -2013,7 +2013,23 @@ def create_candidate_fiducial_list(target_model, omit_identity= True, ops_to_omi
         else:
             availableFidList.extend(_circuits.list_random_circuits_onelen(
                 fidOps, fidLength, count, seed=candidate_seed))
-    return availableFidList
+
+    #force the line labels on each circuit to match the state space labels for the target model.
+    #this is suboptimal for many-qubit models, so will probably want to revisit this. #TODO
+    finalFidList = []
+    for ckt in availableFidList:
+        if ckt._static:
+            new_ckt = ckt.copy(editable=True)
+            new_ckt.line_labels = target_model.state_space.state_space_labels
+            new_ckt.done_editing()
+            
+            finalFidList.append(new_ckt)
+        else:
+            ckt.line_labels = target_model.state_space.state_space_labels
+
+            finalFidList.append(ckt)
+        
+    return finalFidList
     
     
     

--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -1622,8 +1622,8 @@ class DataSet(_MongoSerializable):
         convert_int_to_binary : bool, optional (defaut True)
             By default the keys in the cirq Results object are the integers representing
             the bitstrings of the measurements on a set of qubits, in big-endian convention.
-            If True this uses the cirq function `cirq.big_endian_int_to_bits` to convert back
-            to a binary string before adding the counts as a entry into the pygsti dataset.
+            If True this converts back to a binary string before adding the counts as a 
+            entry into the pygsti dataset.
 
         num_qubits : int, optional (default None)
             Number of qubits used in the conversion from integers to binary when convert_int_to_binary

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -595,7 +595,7 @@ class GSTBadFitOptions(_NicelySerializable):
         Actions to take when a GST fit is unsatisfactory. Allowed actions include:
         
         * 'wildcard': Find an admissable wildcard model.
-        * 'ddist_wildcard': Fits a single parameter wildcard model in which
+        * 'wildcard1d': Fits a single parameter wildcard model in which
           the amount of wildcard error added to an operation is proportional
           to the diamond distance between that operation and the target.
         * 'robust': scale data according out "robust statistics v1" algorithm,

--- a/pygsti/report/templates/offline/pygsti_dashboard.css
+++ b/pygsti/report/templates/offline/pygsti_dashboard.css
@@ -598,6 +598,12 @@ div.sidenav div.linkgroup a.active {
     display: block !important;
 }
 
+.defaultcaptiondetail {
+    display: none;
+    font-weight: normal;
+}
+
+
 #status {
     color: #777;
     background:#ccc;

--- a/pygsti/report/templates/offline/pygsti_dashboard.js
+++ b/pygsti/report/templates/offline/pygsti_dashboard.js
@@ -158,10 +158,22 @@ $(document).ready(function() {
     // Render KaTeX
     render_katex('body');
 
+    // Iterate through all figure captions and add a default caption detail
+    const figcaptions = document.getElementsByTagName("figcaption")
+    for (const figcap of figcaptions) {
+        const defaultcaption = document.createElement('span')
+        defaultcaption.className = 'defaultcaptiondetail'
+        defaultcaption.innerHTML = '(Click to expand details)'
+        defaultcaption.classList.toggle("showcaption")
+        figcap.appendChild(defaultcaption)
+    }
+
     // Enable figure caption toggling
     $('figcaption').on('click', function() {
         // captiondetails should be divs, not spans
         $(this).children('.captiondetail').toggleClass('showcaption')
+        // Also turn off default caption
+        $(this).children('.defaultcaptiondetail').toggleClass('showcaption')
     });
 });
 

--- a/pygsti/report/workspaceplots.py
+++ b/pygsti/report/workspaceplots.py
@@ -1894,6 +1894,58 @@ class ColorBoxPlot(WorkspacePlot):
             #TODO: propagate mdc_store down into compute_sub_mxs?
             if (submatrices is not None) and ptyp in submatrices:
                 subMxs = submatrices[ptyp]  # "custom" type -- all mxs precomputed by user
+
+                #some of the branches below rely on circuit_struct being defined, which is previously
+                #wasn't when hitting this condition on the if statement, so add those definitions here.
+                #also need to built the addl_hover_info as well, based on circuit_struct.
+                if isinstance(circuits, _PlaquetteGridCircuitStructure):
+                    circuit_struct = circuits
+
+                    addl_hover_info = _collections.OrderedDict()
+                    for lbl, (addl_mx_fn, addl_extra_arg) in addl_hover_info_fns.items():
+                        if (submatrices is not None) and lbl in submatrices:
+                            addl_subMxs = submatrices[lbl]  # ever useful?
+                        else:
+                            addl_subMxs = self._ccompute(_ph._compute_sub_mxs, circuit_struct, model,
+                                                        addl_mx_fn, dataset, addl_extra_arg)
+                        addl_hover_info[lbl] = addl_subMxs
+
+                elif isinstance(circuits, _CircuitList):
+                    circuit_struct = [circuits]
+
+                    addl_hover_info = _collections.OrderedDict()
+                    for lbl, (addl_mx_fn, addl_extra_arg) in addl_hover_info_fns.items():
+                        if (submatrices is not None) and lbl in submatrices:
+                            addl_subMxs = submatrices[lbl]  # ever useful?
+                        else:
+                            addl_subMxs = self._ccompute(_ph._compute_sub_mxs_circuit_list, circuit_struct, model,
+                                                        addl_mx_fn, dataset, addl_extra_arg)
+                        addl_hover_info[lbl] = addl_subMxs
+
+                elif isinstance(circuits, list) and all([isinstance(el, _CircuitList) for el in circuits]):
+                    circuit_struct = circuits
+
+                    addl_hover_info = _collections.OrderedDict()
+                    for lbl, (addl_mx_fn, addl_extra_arg) in addl_hover_info_fns.items():
+                        if (submatrices is not None) and lbl in submatrices:
+                            addl_subMxs = submatrices[lbl]  # ever useful?
+                        else:
+                            addl_subMxs = self._ccompute(_ph._compute_sub_mxs_circuit_list, circuit_struct, model,
+                                                        addl_mx_fn, dataset, addl_extra_arg)
+                        addl_hover_info[lbl] = addl_subMxs
+
+                #Otherwise fall-back to the old casting behavior and proceed
+                else:
+                    circuit_struct = _PlaquetteGridCircuitStructure.cast(circuits)
+                    addl_hover_info = _collections.OrderedDict()
+                    for lbl, (addl_mx_fn, addl_extra_arg) in addl_hover_info_fns.items():
+                        if (submatrices is not None) and lbl in submatrices:
+                            addl_subMxs = submatrices[lbl]  # ever useful?
+                        else:
+                            addl_subMxs = self._ccompute(_ph._compute_sub_mxs, circuit_struct, model,
+                                                        addl_mx_fn, dataset, addl_extra_arg)
+                        addl_hover_info[lbl] = addl_subMxs
+                
             elif isinstance(circuits, _PlaquetteGridCircuitStructure):
                 circuit_struct= circuits
                 subMxs = self._ccompute(_ph._compute_sub_mxs, circuit_struct, model, mx_fn, dataset, extra_arg)


### PR DESCRIPTION
This PR contains three minor bugfixes slated for 0.9.12.2:

1. Tutorial updates for #317 
2. A revamp of the leakage example notebook following broken tests from PR #418
3. Additional labels to indicate report figure/table titles can be clicked for #416 

The leakage notebook may not be in a completely finished state. These updates are more or less making it so that circuit line labels are explicit, but it's a little awkward/still not working completely, especially for the kite structure example at the bottom. Suggestion now are welcome, or we can just slate it reworking later.