### PR TITLE
Bugfixes and efficiency improvements for basis conversion, inner products, and computing Frobenius distance

### DIFF
--- a/pygsti/algorithms/contract.py
+++ b/pygsti/algorithms/contract.py
@@ -358,7 +358,7 @@ def _contract_to_valid_spam(model, verbosity=0):
 
     # ** assumption: only the first vector element of pauli vectors has nonzero trace
     dummyVec = _np.zeros((model.dim, 1), 'd'); dummyVec[0, 0] = 1.0
-    firstElTrace = _np.real(_tools.trace(_tools.ppvec_to_stdmx(dummyVec)))  # == sqrt(2)**nQubits
+    firstElTrace = _np.real(_np.trace(_tools.ppvec_to_stdmx(dummyVec)))  # == sqrt(2)**nQubits
     diff = 0
 
     # rhoVec must be positive semidefinite and trace = 1

--- a/pygsti/baseobjs/basis.py
+++ b/pygsti/baseobjs/basis.py
@@ -547,7 +547,7 @@ class Basis(_NicelySerializable):
         """
         if self.elndim == 2:
             for i, mx in enumerate(self.elements):
-                t = _np.linalg.norm(mx.ravel(), 2) # == sqrt(tr(mx mx))
+                t = _np.linalg.norm(mx) # == sqrt(tr(mx mx))
                 if not _np.isclose(t, 1.0): return False
             return True
         elif self.elndim == 1:

--- a/pygsti/baseobjs/basis.py
+++ b/pygsti/baseobjs/basis.py
@@ -547,8 +547,7 @@ class Basis(_NicelySerializable):
         """
         if self.elndim == 2:
             for i, mx in enumerate(self.elements):
-                t = _np.trace(_np.dot(mx, mx))
-                t = _np.real(t)
+                t = _np.linalg.norm(mx.ravel(), 2) # == sqrt(tr(mx mx))
                 if not _np.isclose(t, 1.0): return False
             return True
         elif self.elndim == 1:

--- a/pygsti/modelmembers/operations/__init__.py
+++ b/pygsti/modelmembers/operations/__init__.py
@@ -480,7 +480,7 @@ def optimize_operation(op_to_optimize, target_op):
 
     def _objective_func(param_vec):
         op_to_optimize.from_vector(param_vec)
-        return _np.linalg.norm((op_to_optimize.to_dense() - targetMatrix).ravel())
+        return _np.linalg.norm(op_to_optimize.to_dense() - targetMatrix)
 
     x0 = op_to_optimize.to_vector()
     minSol = _opt.minimize(_objective_func, x0, method='BFGS', maxiter=10000, maxfev=10000,

--- a/pygsti/modelmembers/operations/__init__.py
+++ b/pygsti/modelmembers/operations/__init__.py
@@ -475,18 +475,16 @@ def optimize_operation(op_to_optimize, target_op):
         return
 
     from pygsti import optimize as _opt
-    from pygsti.tools import matrixtools as _mt
     assert(target_op.dim == op_to_optimize.dim)  # operations must have the same overall dimension
     targetMatrix = target_op.to_dense() if isinstance(target_op, LinearOperator) else target_op
 
     def _objective_func(param_vec):
         op_to_optimize.from_vector(param_vec)
-        return _mt.frobeniusnorm(op_to_optimize.to_dense() - targetMatrix)
+        return _np.linalg.norm((op_to_optimize.to_dense() - targetMatrix).ravel())
 
     x0 = op_to_optimize.to_vector()
     minSol = _opt.minimize(_objective_func, x0, method='BFGS', maxiter=10000, maxfev=10000,
                            tol=1e-6, callback=None)
 
     op_to_optimize.from_vector(minSol.x)
-    #print("DEBUG: optimized operation to min frobenius distance %g" %
-    #      _mt.frobeniusnorm(op_to_optimize-targetMatrix))
+    return

--- a/pygsti/modelmembers/operations/fullcptpop.py
+++ b/pygsti/modelmembers/operations/fullcptpop.py
@@ -93,7 +93,7 @@ class FullCPTPOp(_KrausOperatorInterface, _LinearOperator):
             Lmx = _np.linalg.cholesky(choi_mx)
 
         #check TP condition: that diagonal els of Lmx squared add to 1.0
-        Lmx_norm = _np.linalg.norm(Lmx.ravel())  # = sqrt(tr(Lmx' Lmx))
+        Lmx_norm = _np.linalg.norm(Lmx)  # = sqrt(tr(Lmx' Lmx))
         assert(_np.isclose(Lmx_norm, 1.0)), "Cholesky decomp didn't preserve trace=1!"
 
         self.params = _np.empty(dim**2, 'd')

--- a/pygsti/modelmembers/operations/fullcptpop.py
+++ b/pygsti/modelmembers/operations/fullcptpop.py
@@ -93,7 +93,7 @@ class FullCPTPOp(_KrausOperatorInterface, _LinearOperator):
             Lmx = _np.linalg.cholesky(choi_mx)
 
         #check TP condition: that diagonal els of Lmx squared add to 1.0
-        Lmx_norm = _np.trace(_np.dot(Lmx.T.conjugate(), Lmx))  # sum of magnitude^2 of all els
+        Lmx_norm = _np.linalg.norm(Lmx.ravel())  # = sqrt(tr(Lmx' Lmx))
         assert(_np.isclose(Lmx_norm, 1.0)), "Cholesky decomp didn't preserve trace=1!"
 
         self.params = _np.empty(dim**2, 'd')

--- a/pygsti/modelmembers/states/__init__.py
+++ b/pygsti/modelmembers/states/__init__.py
@@ -426,17 +426,16 @@ def optimize_state(vec_to_optimize, target_vec):
         return
 
     from pygsti import optimize as _opt
-    from pygsti.tools import matrixtools as _mt
     assert(target_vec.dim == vec_to_optimize.dim)  # vectors must have the same overall dimension
     targetVector = target_vec.to_dense() if isinstance(target_vec, State) else target_vec
 
     def _objective_func(param_vec):
         vec_to_optimize.from_vector(param_vec)
-        return _mt.frobeniusnorm(vec_to_optimize.to_dense() - targetVector)
+        return _np.linalg.norm((vec_to_optimize.to_dense() - targetVector).ravel())
 
     x0 = vec_to_optimize.to_vector()
     minSol = _opt.minimize(_objective_func, x0, method='BFGS', maxiter=10000, maxfev=10000,
                            tol=1e-6, callback=None)
 
     vec_to_optimize.from_vector(minSol.x)
-    #print("DEBUG: optimized vector to min frobenius distance %g" % _mt.frobeniusnorm(vec_to_optimize-targetVector))
+    return

--- a/pygsti/modelmembers/states/__init__.py
+++ b/pygsti/modelmembers/states/__init__.py
@@ -431,7 +431,7 @@ def optimize_state(vec_to_optimize, target_vec):
 
     def _objective_func(param_vec):
         vec_to_optimize.from_vector(param_vec)
-        return _np.linalg.norm((vec_to_optimize.to_dense() - targetVector).ravel())
+        return _np.linalg.norm(vec_to_optimize.to_dense() - targetVector)
 
     x0 = vec_to_optimize.to_vector()
     minSol = _opt.minimize(_objective_func, x0, method='BFGS', maxiter=10000, maxfev=10000,

--- a/pygsti/modelmembers/states/cptpstate.py
+++ b/pygsti/modelmembers/states/cptpstate.py
@@ -150,7 +150,7 @@ class CPTPState(_DenseState):
             Lmx = _np.linalg.cholesky(density_mx)
 
         #check TP condition: that diagonal els of Lmx squared add to 1.0
-        Lmx_norm = _np.trace(_np.dot(Lmx.T.conjugate(), Lmx))  # sum of magnitude^2 of all els
+        Lmx_norm = _np.linalg.norm(Lmx.ravel())  # = sqrt(tr(Lmx' Lmx))
         assert(_np.isclose(Lmx_norm, 1.0)), \
             "Cholesky decomp didn't preserve trace=1!"
 
@@ -180,7 +180,7 @@ class CPTPState(_DenseState):
             for j in range(i):
                 self.Lmx[i, j] = (self.params[i * dmDim + j] + 1j * self.params[j * dmDim + i]) / paramNorm
 
-        Lmx_norm = _np.trace(_np.dot(self.Lmx.T.conjugate(), self.Lmx))  # sum of magnitude^2 of all els
+        Lmx_norm = _np.linalg.norm(self.Lmx.ravel())  # = sqrt(tr(Lmx' Lmx))
         assert(_np.isclose(Lmx_norm, 1.0)), "Violated trace=1 condition!"
 
         #The (complex, Hermitian) density matrix is build by
@@ -192,7 +192,7 @@ class CPTPState(_DenseState):
         # write density matrix in given basis: = sum_i alpha_i B_i
         # ASSUME that basis is orthogonal, i.e. Tr(Bi^dag*Bj) = delta_ij
         basis_mxs = _np.rollaxis(self.basis_mxs, 2)  # shape (dmDim, dmDim, len(vec))
-        vec = _np.array([_np.trace(_np.dot(M.T.conjugate(), density_mx)) for M in basis_mxs])
+        vec = _np.array([_np.vdot(M, density_mx) for M in basis_mxs])
 
         #for now, assume Liouville vector should always be real (TODO: add 'real' flag later?)
         assert(_np.linalg.norm(_np.imag(vec)) < IMAG_TOL)

--- a/pygsti/modelmembers/states/cptpstate.py
+++ b/pygsti/modelmembers/states/cptpstate.py
@@ -150,7 +150,7 @@ class CPTPState(_DenseState):
             Lmx = _np.linalg.cholesky(density_mx)
 
         #check TP condition: that diagonal els of Lmx squared add to 1.0
-        Lmx_norm = _np.linalg.norm(Lmx.ravel())  # = sqrt(tr(Lmx' Lmx))
+        Lmx_norm = _np.linalg.norm(Lmx)  # = sqrt(tr(Lmx' Lmx))
         assert(_np.isclose(Lmx_norm, 1.0)), \
             "Cholesky decomp didn't preserve trace=1!"
 
@@ -180,7 +180,7 @@ class CPTPState(_DenseState):
             for j in range(i):
                 self.Lmx[i, j] = (self.params[i * dmDim + j] + 1j * self.params[j * dmDim + i]) / paramNorm
 
-        Lmx_norm = _np.linalg.norm(self.Lmx.ravel())  # = sqrt(tr(Lmx' Lmx))
+        Lmx_norm = _np.linalg.norm(self.Lmx)  # = sqrt(tr(Lmx' Lmx))
         assert(_np.isclose(Lmx_norm, 1.0)), "Violated trace=1 condition!"
 
         #The (complex, Hermitian) density matrix is build by

--- a/pygsti/report/reportables.py
+++ b/pygsti/report/reportables.py
@@ -538,10 +538,6 @@ if _CVXPY_AVAILABLE:
                 nearby_model.sim.product(self.circuit), mxBasis)
             JBstd = self.d * _tools.fast_jamiolkowski_iso_std(self.B, mxBasis)
             J = JBstd - JAstd
-            # Old code. Keep for now, to make it easier to see correctness of new code.
-            #   Jt = J.T
-            #   val = 0.5 * _np.trace(_np.dot(Jt.real, self.W.real) + _np.dot(Jt.imag, self.W.imag))
-            # New code.
             val = 0.5 * (_np.vdot(J.real, self.W.real) + _np.vdot(J.imag, self.W.imag))
             return val
 
@@ -1248,10 +1244,6 @@ if _CVXPY_AVAILABLE:
             JAstd = self.d * _tools.fast_jamiolkowski_iso_std(A, mxBasis)
             JBstd = self.d * _tools.fast_jamiolkowski_iso_std(self.B, mxBasis)
             J = JBstd - JAstd
-            # Old code. Keep for now, to make it easier to see correctness of new code.
-            #   Jt = J.T
-            #   val = 0.5 * _np.trace(_np.dot(Jt.real, self.W.real) + _np.dot(Jt.imag, self.W.imag))
-            # New code.
             val = 0.5 * (_np.vdot(J.real, self.W.real) + _np.vdot(J.imag, self.W.imag))
             return val
 
@@ -2031,20 +2023,7 @@ def robust_log_gti_and_projections(model_a, model_b, synthetic_idle_circuits):
                 noise = first_order_noise(opstr, errOnGate, gl)
                 jac[:, i * nSuperOps + k] = [_np.vdot(errOut.flatten(), noise.flatten()) for errOut in error_superops]
 
-                # DEBUG CHECK  # keep old code for now, to show correctness of new code.
-                #
-                # ------------------------------ original code ----------------------------
-                # check = [_np.trace(_np.dot(
-                #     _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis).conj().T,
-                #     _tools.jamiolkowski_iso(noise,  mxBasis, mxBasis))) * 4  # for 1-qubit...
-                #     for errOut in error_superops]
-                # --------------------------- more readable code --------------------------
-                # check = []
-                # for errOut in error_superops:
-                #     arg1 = _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis).conj().T
-                #     arg2 = _tools.jamiolkowski_iso(noise,  mxBasis, mxBasis)
-                #     check.append(_np.trace(_np.dot(arg1, arg2)) * 4)
-                # ---------------------------- efficient code -----------------------------
+                # DEBUG CHECK
                 check = []
                 for errOut in error_superops:
                     arg1 = _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis)

--- a/pygsti/report/reportables.py
+++ b/pygsti/report/reportables.py
@@ -537,8 +537,13 @@ if _CVXPY_AVAILABLE:
             JAstd = self.d * _tools.fast_jamiolkowski_iso_std(
                 nearby_model.sim.product(self.circuit), mxBasis)
             JBstd = self.d * _tools.fast_jamiolkowski_iso_std(self.B, mxBasis)
-            Jt = (JBstd - JAstd).T
-            return 0.5 * _np.trace(_np.dot(Jt.real, self.W.real) + _np.dot(Jt.imag, self.W.imag))
+            J = JBstd - JAstd
+            # Old code. Keep for now, to make it easier to see correctness of new code.
+            #   Jt = J.T
+            #   val = 0.5 * _np.trace(_np.dot(Jt.real, self.W.real) + _np.dot(Jt.imag, self.W.imag))
+            # New code.
+            val = 0.5 * (_np.vdot(J.real, self.W.real) + _np.vdot(J.imag, self.W.imag))
+            return val
 
     #def circuit_half_diamond_norm(model_a, model_b, circuit):
     #    A = model_a.sim.product(circuit) # "gate"
@@ -1238,12 +1243,17 @@ if _CVXPY_AVAILABLE:
             -------
             float
             """
-            gl = self.oplabel; mxBasis = nearby_model.basis
-            JAstd = self.d * _tools.fast_jamiolkowski_iso_std(
-                nearby_model.operations[gl].to_dense(on_space='HilbertSchmidt'), mxBasis)
+            mxBasis = nearby_model.basis
+            A = nearby_model.operations[self.oplabel].to_dense(on_space='HilbertSchmidt')
+            JAstd = self.d * _tools.fast_jamiolkowski_iso_std(A, mxBasis)
             JBstd = self.d * _tools.fast_jamiolkowski_iso_std(self.B, mxBasis)
-            Jt = (JBstd - JAstd).T
-            return 0.5 * _np.trace(_np.dot(Jt.real, self.W.real) + _np.dot(Jt.imag, self.W.imag))
+            J = JBstd - JAstd
+            # Old code. Keep for now, to make it easier to see correctness of new code.
+            #   Jt = J.T
+            #   val = 0.5 * _np.trace(_np.dot(Jt.real, self.W.real) + _np.dot(Jt.imag, self.W.imag))
+            # New code.
+            val = 0.5 * (_np.vdot(J.real, self.W.real) + _np.vdot(J.imag, self.W.imag))
+            return val
 
     def half_diamond_norm(a, b, mx_basis):
         """
@@ -2021,11 +2031,26 @@ def robust_log_gti_and_projections(model_a, model_b, synthetic_idle_circuits):
                 noise = first_order_noise(opstr, errOnGate, gl)
                 jac[:, i * nSuperOps + k] = [_np.vdot(errOut.flatten(), noise.flatten()) for errOut in error_superops]
 
-                #DEBUG CHECK
-                check = [_np.trace(_np.dot(
-                    _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis).conj().T,
-                    _tools.jamiolkowski_iso(noise, mxBasis, mxBasis))) * 4  # for 1-qubit...
-                    for errOut in error_superops]
+                # DEBUG CHECK  # keep old code for now, to show correctness of new code.
+                #
+                # ------------------------------ original code ----------------------------
+                # check = [_np.trace(_np.dot(
+                #     _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis).conj().T,
+                #     _tools.jamiolkowski_iso(noise,  mxBasis, mxBasis))) * 4  # for 1-qubit...
+                #     for errOut in error_superops]
+                # --------------------------- more readable code --------------------------
+                # check = []
+                # for errOut in error_superops:
+                #     arg1 = _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis).conj().T
+                #     arg2 = _tools.jamiolkowski_iso(noise,  mxBasis, mxBasis)
+                #     check.append(_np.trace(_np.dot(arg1, arg2)) * 4)
+                # ---------------------------- efficient code -----------------------------
+                check = []
+                for errOut in error_superops:
+                    arg1 = _tools.jamiolkowski_iso(errOut, mxBasis, mxBasis)
+                    arg2 = _tools.jamiolkowski_iso(noise,  mxBasis, mxBasis)
+                    check.append(_np.vdot(arg1, arg2) * 4)
+
                 assert(_np.allclose(jac[:, i * nSuperOps + k], check))
 
         assert(_np.linalg.norm(jac.imag) < 1e-6), "error generator jacobian should be real!"

--- a/pygsti/tools/basistools.py
+++ b/pygsti/tools/basistools.py
@@ -549,9 +549,9 @@ def stdmx_to_vec(m, basis):
     v = _np.empty((basis.size, 1))
     for i, mx in enumerate(basis.elements):
         if basis.real:
-            v[i, 0] = _np.real(_mt.trace(_np.dot(mx, m)))
+            v[i, 0] = _np.real(_np.vdot(mx, m))
         else:
-            v[i, 0] = _np.real_if_close(_mt.trace(_np.dot(mx, m)))
+            v[i, 0] = _np.real_if_close(_np.vdot(mx, m))
     return v
 
 

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -117,11 +117,6 @@ def jamiolkowski_iso(operation_mx, op_mx_basis='pp', choi_mx_basis='pp'):
     for i in range(M):
         for j in range(M):
             BiBj = _np.kron(BVec[i], _np.conjugate(BVec[j]))
-            # BiBj_dag = _np.transpose(_np.conjugate(BiBj))
-            # num = _np.trace(_np.dot(opMxInStdBasis, BiBj_dag))  # original code
-            #     = _np.trace(_np.dot(BiBj_dag, opMxInStdBasis))  # cycle the trace
-            #     = _np.vdot(BiBj, opMxInStdBasis)                # efficient version
-            # den = _np.trace(_np.dot(BiBj, BiBj_dag))
             num = _np.vdot(BiBj, opMxInStdBasis)
             den = _np.linalg.norm(BiBj) ** 2
             choiMx[i, j] = num / den 

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -117,9 +117,14 @@ def jamiolkowski_iso(operation_mx, op_mx_basis='pp', choi_mx_basis='pp'):
     for i in range(M):
         for j in range(M):
             BiBj = _np.kron(BVec[i], _np.conjugate(BVec[j]))
-            BiBj_dag = _np.transpose(_np.conjugate(BiBj))
-            choiMx[i, j] = _mt.trace(_np.dot(opMxInStdBasis, BiBj_dag)) \
-                / _mt.trace(_np.dot(BiBj, BiBj_dag))
+            # BiBj_dag = _np.transpose(_np.conjugate(BiBj))
+            # num = _np.trace(_np.dot(opMxInStdBasis, BiBj_dag))  # original code
+            #     = _np.trace(_np.dot(BiBj_dag, opMxInStdBasis))  # cycle the trace
+            #     = _np.vdot(BiBj, opMxInStdBasis)                # efficient version
+            # den = _np.trace(_np.dot(BiBj, BiBj_dag))
+            num = _np.vdot(BiBj, opMxInStdBasis)
+            den = _np.linalg.norm(BiBj.ravel()) ** 2
+            choiMx[i, j] = num / den 
 
     # This construction results in a Jmx with trace == dim(H) = sqrt(operation_mx.shape[0])
     #  (dimension of density matrix) but we'd like a Jmx with trace == 1, so normalize:

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -123,7 +123,7 @@ def jamiolkowski_iso(operation_mx, op_mx_basis='pp', choi_mx_basis='pp'):
             #     = _np.vdot(BiBj, opMxInStdBasis)                # efficient version
             # den = _np.trace(_np.dot(BiBj, BiBj_dag))
             num = _np.vdot(BiBj, opMxInStdBasis)
-            den = _np.linalg.norm(BiBj.ravel()) ** 2
+            den = _np.linalg.norm(BiBj) ** 2
             choiMx[i, j] = num / den 
 
     # This construction results in a Jmx with trace == dim(H) = sqrt(operation_mx.shape[0])

--- a/pygsti/tools/lindbladtools.py
+++ b/pygsti/tools/lindbladtools.py
@@ -13,7 +13,6 @@ Utility functions relevant to Lindblad forms and projections
 import numpy as _np
 import scipy.sparse as _sps
 
-from pygsti.tools import matrixtools as _mt
 from pygsti.tools.basistools import basis_matrices
 
 

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -31,37 +31,6 @@ except ImportError:
 EXPM_DEFAULT_TOL = 2**-53  # Scipy default
 
 
-def trace(m):  # memory leak in numpy causes repeated trace calls to eat up all memory --TODO: Cython this
-    """
-    The trace of a matrix, sum_i m[i,i].
-
-    A memory leak in some version of numpy can cause repeated calls to numpy's
-    trace function to eat up all available system memory, and this function
-    does not have this problem.
-
-    Parameters
-    ----------
-    m : numpy array
-        the matrix (any object that can be double-indexed)
-
-    Returns
-    -------
-    element type of m
-        The trace of m.
-    """
-    return sum([m[i, i] for i in range(m.shape[0])])
-#    with warnings.catch_warnings():
-#        warnings.filterwarnings('error')
-#        try:
-#            ret =
-#        except Warning:
-#            print "BAD trace from:\n"
-#            for i in range(M.shape[0]):
-#                print M[i,i]
-#            raise ValueError("STOP")
-#    return ret
-
-
 def is_hermitian(mx, tol=1e-9):
     """
     Test whether mx is a hermitian matrix.
@@ -125,47 +94,7 @@ def is_valid_density_mx(mx, tol=1e-9):
     bool
         True if mx is a valid density matrix, otherwise False.
     """
-    return is_hermitian(mx, tol) and is_pos_def(mx, tol) and abs(trace(mx) - 1.0) < tol
-
-
-def frobeniusnorm(ar):
-    """
-    Compute the frobenius norm of an array (or matrix),
-
-    sqrt( sum( each_element_of_a^2 ) )
-
-    Parameters
-    ----------
-    ar : numpy array
-        What to compute the frobenius norm of.  Note that ar can be any shape
-        or number of dimenions.
-
-    Returns
-    -------
-    float or complex
-        depending on the element type of ar.
-    """
-    return _np.sqrt(_np.sum(ar**2))
-
-
-def frobeniusnorm_squared(ar):
-    """
-    Compute the squared frobenius norm of an array (or matrix),
-
-    sum( each_element_of_a^2 ) )
-
-    Parameters
-    ----------
-    ar : numpy array
-        What to compute the squared frobenius norm of.  Note that ar can be any
-        shape or number of dimenions.
-
-    Returns
-    -------
-    float or complex
-        depending on the element type of ar.
-    """
-    return _np.sum(ar**2)
+    return is_hermitian(mx, tol) and is_pos_def(mx, tol) and abs(_np.trace(mx) - 1.0) < tol
 
 
 def nullspace(m, tol=1e-7):

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -43,19 +43,6 @@ def _flat_mut_blks(i, j, block_dims):
     return ret
 
 
-def _hack_sqrtm(a):
-    sqrt, _ = _spl.sqrtm(a, disp=False)  # Travis found this scipy function
-    # to be incorrect in certain cases (we need a workaround)
-    if _np.any(_np.isnan(sqrt)):  # this is sometimes a good fallback when sqrtm doesn't work.
-        ev, U = _np.linalg.eig(a)
-        sqrt = _np.dot(U, _np.dot(_np.diag(_np.sqrt(ev)), _np.linalg.inv(U)))
-    # Scipy 1.10 fix for PR 16294 (which doubles precision of complex to complex)
-    if _np.iscomplexobj(a):
-        sqrt = sqrt.astype(a.dtype, copy=False)
-
-    return sqrt
-
-
 def fidelity(a, b):
     """
     Returns the quantum state fidelity between density matrices.
@@ -81,32 +68,81 @@ def fidelity(a, b):
     float
         The resulting fidelity.
     """
-    evals, U = _np.linalg.eig(a)
-    if len([ev for ev in evals if abs(ev) > 1e-8]) == 1:
+    __SCALAR_TOL__ = _np.finfo(a.dtype).eps ** 0.75
+    # ^ use for checks that have no dimensional dependence; about 1e-12 for double precision.
+    __VECTOR_TOL__ = (a.shape[0] ** 0.5) * __SCALAR_TOL__
+    # ^ use for checks that do have dimensional dependence (will naturally increase for larger matrices)
+    hermiticity_error = _np.abs(a - a.T.conj())
+    if _np.any(hermiticity_error > __SCALAR_TOL__):
+        message = f"""
+            Input matrix 'a' is not Hermitian, up to tolerance {__SCALAR_TOL__}.
+            The absolute values of entries in (a - a^H) are \n{hermiticity_error}. 
+        """
+        raise ValueError(message)
+
+    def check_rank_one_density(mat):
+        # Check if mat = alpha * np.outer(v, v.conj()) for some unit vector v and scalar alpha > 0.
+        #     If this holds up to some numerical tolerance, then we return (alpha, v)
+        #     If (we believe) no such vector exists, then we return None.
+        # 
+        # This function runs on O(n^2) time, where mat is n-by-n.
+        #
+        _np.random.seed(0)
+        n = mat.shape[0]
+        test_vec = _np.random.randn(n)
+        if _np.iscomplexobj(mat):
+            test_vec = test_vec + 1j * _np.random.randn(n)
+        test_vec /= _np.linalg.norm(test_vec)
+        candidate_v = mat @ test_vec
+        candidate_v /= _np.linalg.norm(candidate_v)
+        alpha = _np.real(candidate_v.conj() @ mat @ candidate_v)
+        reconstruction = alpha * _np.outer(candidate_v, candidate_v.conj())
+        if _np.linalg.norm(mat - reconstruction) < __VECTOR_TOL__:
+            return alpha, candidate_v
+        else:
+            return None
+
+    alphavec = check_rank_one_density(a)
+    if alphavec is not None:
         # special case when a is rank 1, a = vec * vec^T and sqrt(a) = a
-        ivec = _np.argmax(evals)
-        vec = U[:, ivec:(ivec + 1)]
-        F = evals[ivec].real * _np.dot(_np.conjugate(_np.transpose(vec)), _np.dot(b, vec)).real  # vec^T * b * vec
-        return float(F[0, 0])
+        alpha, vec = alphavec
+        f = alpha * (vec.T.conj() @ b @ vec).real  # vec^T * b * vec
+        return f
 
-    evals, U = _np.linalg.eig(b)
-    if len([ev for ev in evals if abs(ev) > 1e-8]) == 1:
+    alphavec = check_rank_one_density(b)
+    if alphavec is not None:
         # special case when b is rank 1 (recally fidelity is sym in args)
-        ivec = _np.argmax(evals)
-        vec = U[:, ivec:(ivec + 1)]
-        F = evals[ivec].real * _np.dot(_np.conjugate(_np.transpose(vec)), _np.dot(a, vec)).real  # vec^T * a * vec
-        return float(F[0, 0])
+        alpha, vec = alphavec
+        f = alpha * (vec.T.conj() @ a @ vec).real  # vec^T * a * vec
+        return f
+    
+    # Neither a nor b are rank-1. We need to actually evaluate the matrix square root of
+    # one of them. We do this with an eigendecomposition, since this lets us check for 
+    # negative eigenvalues and raise a warning if needed.
 
-    #if _np.array_equal(a, b): return 1.0  # HACK - some cases when a and b are perfecty equal sqrtm(a) fails...
-    sqrtA = _hack_sqrtm(a)  # _spl.sqrtm(a)
-    # test the scipy sqrtm function - sometimes fails when rank defficient
-    #assert(_np.linalg.norm(_np.dot(sqrtA, sqrtA) - a) < 1e-8)
-    if _np.linalg.norm(_np.dot(sqrtA, sqrtA) - a) > 1e-8:
-        evals = _np.linalg.eigvals(a)
-        _warnings.warn(("sqrtm(a) failure when computing fidelity - beware result. "
-                        "Maybe due to rank defficiency - eigenvalues of a are: %s") % evals)
-    F = (_np.trace(_hack_sqrtm(_np.dot(sqrtA, _np.dot(b, sqrtA)))).real)**2  # Tr( sqrt{ sqrt(a) * b * sqrt(a) } )^2
-    return float(F)
+    def psd_square_root(mat):
+        evals, U = _np.linalg.eigh(mat)
+        if _np.min(evals) < -__SCALAR_TOL__:
+            message = f"""
+            Input matrix is not PSD up to tolerance {__SCALAR_TOL__}.
+            We'll project out the bad eigenspaces to only work with the PSD part.
+            """
+            _warnings.warn(message)
+        evals[evals < 0] = 0.0
+        tr = _np.sum(evals)
+        if abs(tr - 1) > __VECTOR_TOL__:
+            message = f"""
+            The PSD part of the input matrix is not trace-1 up to tolerance {__VECTOR_TOL__}.
+            Beware result!
+            """
+            _warnings.warn(message)
+        sqrt_mat = U @ (_np.sqrt(evals).reshape((-1, 1)) * U.T.conj())
+        return sqrt_mat
+    
+    sqrt_a = psd_square_root(a)
+    tr_arg = psd_square_root(sqrt_a @ b @ sqrt_a)
+    f = _mt.trace(tr_arg).real ** 2  # Tr( sqrt{ sqrt(a) * b * sqrt(a) } )^2
+    return f
 
 
 def frobeniusdist(a, b):

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -72,7 +72,7 @@ def fidelity(a, b):
     # ^ use for checks that have no dimensional dependence; about 1e-12 for double precision.
     __VECTOR_TOL__ = (a.shape[0] ** 0.5) * __SCALAR_TOL__
     # ^ use for checks that do have dimensional dependence (will naturally increase for larger matrices)
-    def assert_hermicity(mat):
+    def assert_hermitian(mat):
         hermiticity_error = _np.abs(mat - mat.T.conj())
         if _np.any(hermiticity_error > __SCALAR_TOL__):
             message = f"""
@@ -81,8 +81,8 @@ def fidelity(a, b):
             """
             raise ValueError(message)
     
-    assert_hermicity(a)
-    assert_hermicity(b)
+    assert_hermitian(a)
+    assert_hermitian(b)
 
     def check_rank_one_density(mat):
         # Check if mat = alpha * np.outer(v, v.conj()) for some unit vector v and scalar alpha > 0.

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -105,17 +105,15 @@ def fidelity(a, b):
         evals = _np.linalg.eigvals(a)
         _warnings.warn(("sqrtm(a) failure when computing fidelity - beware result. "
                         "Maybe due to rank defficiency - eigenvalues of a are: %s") % evals)
-    F = (_mt.trace(_hack_sqrtm(_np.dot(sqrtA, _np.dot(b, sqrtA)))).real)**2  # Tr( sqrt{ sqrt(a) * b * sqrt(a) } )^2
+    F = (_np.trace(_hack_sqrtm(_np.dot(sqrtA, _np.dot(b, sqrtA)))).real)**2  # Tr( sqrt{ sqrt(a) * b * sqrt(a) } )^2
     return float(F)
 
 
 def frobeniusdist(a, b):
     """
-    Returns the frobenius distance between gate or density matrices.
+    Returns the frobenius distance between arrays: ||a - b||_Fro.
 
-    This is given by :
-
-      `sqrt( sum( (a_ij-b_ij)^2 ) )`
+    This could be inlined, but we're keeping it for API consistency with other distance functions.
 
     Parameters
     ----------
@@ -130,16 +128,14 @@ def frobeniusdist(a, b):
     float
         The resulting frobenius distance.
     """
-    return _mt.frobeniusnorm(a - b)
+    return _np.linalg.norm((a - b).ravel())
 
 
 def frobeniusdist_squared(a, b):
     """
-    Returns the square of the frobenius distance between gate or density matrices.
+    Returns the square of the frobenius distance between arrays: (||a - b||_Fro)^2.
 
-    This is given by :
-
-      `sum( (A_ij-B_ij)^2 )`
+    This could be inlined, but we're keeping it for API consistency with other distance functions.
 
     Parameters
     ----------
@@ -154,7 +150,7 @@ def frobeniusdist_squared(a, b):
     float
         The resulting frobenius distance.
     """
-    return _mt.frobeniusnorm_squared(a - b)
+    return frobeniusdist(a, b)**2
 
 
 def residuals(a, b):
@@ -742,10 +738,7 @@ def unitarity(a, mx_basis="gm"):
         B = _bt.change_basis(a, mx_basis, "gm")  # everything should be able to be put in the "gm" basis
 
     unital = B[1:d**2, 1:d**2]
-    #old version
-    #u = _np.trace(_np.dot(_np.conj(_np.transpose(unital)), unital)) / (d**2 - 1)
-    #new version
-    u= _np.einsum('ij,ji->', unital.conjugate().T, unital ) / (d**2 - 1)
+    u = _np.linalg.norm(unital.ravel())**2 / (d**2 - 1)
     return u
 
 
@@ -778,7 +771,7 @@ def fidelity_upper_bound(operation_mx):
     # # gives same result:
     # closestUnitaryJmx = _np.dot(choi_evecs, _np.dot( _np.diag(new_evals), _np.linalg.inv(choi_evecs) ) )
     closestJmx = _np.kron(closestVec, _np.transpose(_np.conjugate(closestVec)))  # closest rank-1 Jmx
-    closestJmx /= _mt.trace(closestJmx)  # normalize so trace of Jmx == 1.0
+    closestJmx /= _np.trace(closestJmx)  # normalize so trace of Jmx == 1.0
 
     maxF = fidelity(choi, closestJmx)
 
@@ -791,7 +784,7 @@ def fidelity_upper_bound(operation_mx):
         #    print "DEBUG choi_evals = ",choi_evals, " iMax = ",iMax
         #    #print "DEBUG: J = \n", closestUnitaryJmx
         #    print "DEBUG: eigvals(J) = ", _np.linalg.eigvals(closestJmx)
-        #    print "DEBUG: trace(J) = ", _mt.trace(closestJmx)
+        #    print "DEBUG: trace(J) = ", _np.trace(closestJmx)
         #    print "DEBUG: maxF = %f,  maxF_direct = %f" % (maxF, maxF_direct)
         #    raise ValueError("ERROR: maxF - maxF_direct = %f" % (maxF -maxF_direct))
         assert(abs(maxF - maxF_direct) < 1e-6)

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -128,7 +128,7 @@ def frobeniusdist(a, b):
     float
         The resulting frobenius distance.
     """
-    return _np.linalg.norm((a - b).ravel())
+    return _np.linalg.norm(a - b)
 
 
 def frobeniusdist_squared(a, b):
@@ -738,7 +738,7 @@ def unitarity(a, mx_basis="gm"):
         B = _bt.change_basis(a, mx_basis, "gm")  # everything should be able to be put in the "gm" basis
 
     unital = B[1:d**2, 1:d**2]
-    u = _np.linalg.norm(unital.ravel())**2 / (d**2 - 1)
+    u = _np.linalg.norm(unital)**2 / (d**2 - 1)
     return u
 
 

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -145,7 +145,7 @@ def fidelity(a, b):
     
     sqrt_a = psd_square_root(a)
     tr_arg = psd_square_root(sqrt_a @ b @ sqrt_a)
-    f = _mt.trace(tr_arg).real ** 2  # Tr( sqrt{ sqrt(a) * b * sqrt(a) } )^2
+    f = _np.trace(tr_arg).real ** 2  # Tr( sqrt{ sqrt(a) * b * sqrt(a) } )^2
     return f
 
 

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -72,13 +72,17 @@ def fidelity(a, b):
     # ^ use for checks that have no dimensional dependence; about 1e-12 for double precision.
     __VECTOR_TOL__ = (a.shape[0] ** 0.5) * __SCALAR_TOL__
     # ^ use for checks that do have dimensional dependence (will naturally increase for larger matrices)
-    hermiticity_error = _np.abs(a - a.T.conj())
-    if _np.any(hermiticity_error > __SCALAR_TOL__):
-        message = f"""
-            Input matrix 'a' is not Hermitian, up to tolerance {__SCALAR_TOL__}.
-            The absolute values of entries in (a - a^H) are \n{hermiticity_error}. 
-        """
-        raise ValueError(message)
+    def assert_hermicity(mat):
+        hermiticity_error = _np.abs(mat - mat.T.conj())
+        if _np.any(hermiticity_error > __SCALAR_TOL__):
+            message = f"""
+                Input matrix 'mat' is not Hermitian, up to tolerance {__SCALAR_TOL__}.
+                The absolute values of entries in (mat - mat^H) are \n{hermiticity_error}. 
+            """
+            raise ValueError(message)
+    
+    assert_hermicity(a)
+    assert_hermicity(b)
 
     def check_rank_one_density(mat):
         # Check if mat = alpha * np.outer(v, v.conj()) for some unit vector v and scalar alpha > 0.

--- a/test/unit/tools/test_basisconstructors.py
+++ b/test/unit/tools/test_basisconstructors.py
@@ -40,8 +40,7 @@ class BasisConstructorsTester(BaseCase):
         gm_trMx = np.zeros((N, N), 'complex')
         for i in range(N):
             for j in range(N):
-                gm_trMx[i, j] = np.trace(np.dot(np.conjugate(np.transpose(mxs[i])), mxs[j]))
-                #Note: conjugate transpose not needed since mxs are Hermitian
+                gm_trMx[i, j] = np.vdot(mxs[i], mxs[j])
         self.assertArraysAlmostEqual(gm_trMx, np.identity(N, 'complex'))
 
         #Std Basis
@@ -52,7 +51,7 @@ class BasisConstructorsTester(BaseCase):
         std_trMx = np.zeros((N, N), 'complex')
         for i in range(N):
             for j in range(N):
-                std_trMx[i, j] = np.trace(np.dot(np.conjugate(np.transpose(mxs[i])), mxs[j]))
+                std_trMx[i, j] = np.vdot(mxs[i],mxs[j])
         self.assertArraysAlmostEqual(std_trMx, np.identity(N, 'complex'))
 
         #Pauli-product basis
@@ -71,8 +70,7 @@ class BasisConstructorsTester(BaseCase):
         pp_trMx = np.zeros((N, N), 'complex')
         for i in range(N):
             for j in range(N):
-                pp_trMx[i, j] = np.trace(np.dot(np.conjugate(np.transpose(mxs[i])), mxs[j]))
-                #Note: conjugate transpose not needed since mxs are Hermitian
+                pp_trMx[i, j] = np.vdot(mxs[i], mxs[j])
         self.assertArraysAlmostEqual(pp_trMx, np.identity(N, 'complex'))
 
     def test_basis_misc(self):

--- a/test/unit/tools/test_optools.py
+++ b/test/unit/tools/test_optools.py
@@ -108,14 +108,6 @@ class OpToolsTester(BaseCase):
         decomp = ot.decompose_gate_matrix(largeMx)  # can only handle 1Q mxs
         self.assertFalse(decomp['isValid'])
 
-    def test_hack_sqrt_m(self):
-        expected = np.array([
-            [ 0.55368857+0.46439416j,  0.80696073-0.21242648j],
-            [ 1.21044109-0.31863972j,  1.76412966+0.14575444j]
-        ])
-        sqrt = ot._hack_sqrtm(np.array([[1, 2], [3, 4]]))
-        self.assertArraysAlmostEqual(sqrt, expected)
-
     def test_unitary_to_process_mx(self):
         identity = np.identity(2)
         processMx = ot.unitary_to_std_process_mx(identity)
@@ -388,36 +380,35 @@ class GateOpsTester(BaseCase):
             [ 0.71538573+0.j,  0.2680266 +0.36300238j, 0.2680266 -0.36300238j,  0.28461427+0.j]])
 
     def test_jtrace_distance(self):
-        self.assertAlmostEqual(ot.jtracedist(self.A, self.A, mx_basis="std"), 0.0)
-        self.assertAlmostEqual(ot.jtracedist(self.A, self.B, mx_basis="std"), 0.26430148)  # OLD: 0.2601 ?
+        val = ot.jtracedist(self.A_TP, self.A_TP, mx_basis="pp")
+        self.assertAlmostEqual(val, 0.0)
+        val = ot.jtracedist(self.A_TP, self.B_unitary, mx_basis="pp")
+        self.assertGreaterEqual(val, 0.5)
 
     @needs_cvxpy
     def test_diamond_distance(self):
         if SKIP_DIAMONDIST_ON_WIN and sys.platform.startswith('win'): return
-        self.assertAlmostEqual(ot.diamonddist(self.A, self.A, mx_basis="std"), 0.0)
-        self.assertAlmostEqual(ot.diamonddist(self.A, self.B, mx_basis="std"), 0.614258836298)
+        val = ot.diamonddist(self.A_TP, self.A_TP, mx_basis="pp")
+        self.assertAlmostEqual(val, 0.0)
+        val = ot.diamonddist(self.A_TP, self.B_unitary, mx_basis="pp")
+        self.assertGreaterEqual(val, 0.7)
 
     def test_entanglement_fidelity(self):
-        fidelity = ot.entanglement_fidelity(self.A, self.B)
         fidelity_TP_unitary= ot.entanglement_fidelity(self.A_TP, self.B_unitary, is_tp=True, is_unitary=True)
         fidelity_TP_unitary_no_flag= ot.entanglement_fidelity(self.A_TP, self.B_unitary)
         fidelity_TP_unitary_jam= ot.entanglement_fidelity(self.A_TP, self.B_unitary, is_tp=False, is_unitary=False)
         fidelity_TP_unitary_std= ot.entanglement_fidelity(self.A_TP_std, self.B_unitary_std, mx_basis='std')
         
-        self.assertAlmostEqual(fidelity, 0.42686642003)
-        self.assertAlmostEqual(fidelity_TP_unitary, 0.4804724656092404)
-        self.assertAlmostEqual(fidelity_TP_unitary_no_flag, 0.4804724656092404)
-        self.assertAlmostEqual(fidelity_TP_unitary, fidelity_TP_unitary_jam)
-        self.assertAlmostEqual(fidelity_TP_unitary_std, 0.4804724656092404)
+        expect = 0.4804724656092404
+        self.assertAlmostEqual(fidelity_TP_unitary, expect)
+        self.assertAlmostEqual(fidelity_TP_unitary_no_flag, expect)
+        self.assertAlmostEqual(fidelity_TP_unitary_jam, expect)
+        self.assertAlmostEqual(fidelity_TP_unitary_std, expect)
 
     def test_fidelity_upper_bound(self):
-        upperBound = ot.fidelity_upper_bound(self.A)
-        expected = (
-            np.array([[ 0.25]]),
-            np.array([[  1.00000000e+00,  -8.27013523e-16,   8.57305616e-33, 1.95140273e-15],
-                      [ -8.27013523e-16,   1.00000000e+00,   6.28036983e-16, -8.74760501e-31],
-                      [  5.68444574e-33,  -6.28036983e-16,   1.00000000e+00, -2.84689309e-16],
-                      [  1.95140273e-15,  -9.27538795e-31,   2.84689309e-16, 1.00000000e+00]])
-        )
-        self.assertArraysAlmostEqual(upperBound[0], expected[0])
-        self.assertArraysAlmostEqual(upperBound[1], expected[1])
+        np.random.seed(0)
+        Q = np.linalg.qr(np.random.randn(4,4) + 1j*np.random.randn(4,4))[0]
+        Q[:, 0] = 0.0  # zero out the first column
+        bad_superoperator = ot.unitary_to_superop(Q)
+        upperBound, _ = ot.fidelity_upper_bound(bad_superoperator)
+        self.assertAlmostEqual(upperBound, 0.75)

--- a/test/unit/tools/test_optools.py
+++ b/test/unit/tools/test_optools.py
@@ -387,13 +387,6 @@ class GateOpsTester(BaseCase):
             [-0.35432747-0.27939404j, -0.02266757+0.71502652j, -0.27452307+0.07511567j,  0.35432747+0.27939404j],
             [ 0.71538573+0.j,  0.2680266 +0.36300238j, 0.2680266 -0.36300238j,  0.28461427+0.j]])
 
-    def test_frobenius_distance(self):
-        self.assertAlmostEqual(ot.frobeniusdist(self.A, self.A), 0.0)
-        self.assertAlmostEqual(ot.frobeniusdist(self.A, self.B), (0.430116263352+0j))
-
-        self.assertAlmostEqual(ot.frobeniusdist_squared(self.A, self.A), 0.0)
-        self.assertAlmostEqual(ot.frobeniusdist_squared(self.A, self.B), (0.185+0j))
-
     def test_jtrace_distance(self):
         self.assertAlmostEqual(ot.jtracedist(self.A, self.A, mx_basis="std"), 0.0)
         self.assertAlmostEqual(ot.jtracedist(self.A, self.B, mx_basis="std"), 0.26430148)  # OLD: 0.2601 ?
@@ -403,11 +396,6 @@ class GateOpsTester(BaseCase):
         if SKIP_DIAMONDIST_ON_WIN and sys.platform.startswith('win'): return
         self.assertAlmostEqual(ot.diamonddist(self.A, self.A, mx_basis="std"), 0.0)
         self.assertAlmostEqual(ot.diamonddist(self.A, self.B, mx_basis="std"), 0.614258836298)
-
-    def test_frobenius_norm_equiv(self):
-        from pygsti.tools import matrixtools as mt
-        self.assertAlmostEqual(ot.frobeniusdist(self.A, self.B), mt.frobeniusnorm(self.A - self.B))
-        self.assertAlmostEqual(ot.frobeniusdist(self.A, self.B), np.sqrt(mt.frobeniusnorm_squared(self.A - self.B)))
 
     def test_entanglement_fidelity(self):
         fidelity = ot.entanglement_fidelity(self.A, self.B)


### PR DESCRIPTION
Changes:
* Remove frobeniusnorm and frobeniusnorm_squared functions (which were only correct for real inputs). Inline equivalent numpy functions in the few places they were used.
* Replace the np.trace(np.dot(...)) pattern for computing the trace inner product with np.vdot(...). This resolves #430.
* Note that use of np.vdot has a secondary affect of conjugating the first argument when dealing with complex inputs. This resolves a limitation of basis conversion discussed in an email thread titled _Re: Possible pyGSTi bugs w/rt converting between matrix bases?_ that Robin started on Feb 23 of this year.
* I rewrote our implementation for computing state fidelity. It no longer needs the ``_hack_sqrtm`` function. It also has $O(n^2)$ time checks for the fidelity formulas when one of the arguments is rank-1. The overhead of these checks might actually degrade performance for 2-by-2 matrices, but for anything bigger we should be fine. If the overhead in the 2-by-2 case becomes an issue down the line then we can special-case that codepath.



### Old text
Some tests are failing. I'm not sure why. Maybe they're related to the conjugation that's applied when using ``vdot`` in the basis conversion? If so, I would guess that the failing tests are comparing to a nominal value which actually was not correct to begin with. Thoughts, @coreyostrove, @sserita, @enielse?
```shell
FAILED test_packages/extras/test_interpygate.py::InterpygateTestCase::test_timedep_factory - AssertionError: 0.005780277171757022 != 0 within 7 places (0.005780277171757022 difference)
FAILED test_packages/extras/test_interpygate.py::InterpygateTestCase::test_timedep_op - AssertionError: 0.00048145808272016756 != 0 within 7 places (0.00048145808272016756 difference)
FAILED test_packages/extras/test_interpygate.py::InterpygateTestCase::test_timeindep_factory - AssertionError: 0.005780277171757022 != 0 within 7 places (0.005780277171757022 difference)
FAILED test_packages/extras/test_interpygate.py::InterpygateTestCase::test_timeindep_op - AssertionError: 0.00048145808272016756 != 0 within 7 places (0.00048145808272016756 difference)
```

-- No one was able to reproduce these errors (including me, later on!).