### PR TITLE
RBDesign bugfixes and improvements

### DIFF
--- a/pygsti/algorithms/randomcircuit.py
+++ b/pygsti/algorithms/randomcircuit.py
@@ -2137,10 +2137,129 @@ def create_direct_rb_circuit(pspec, clifford_compilations, length, qubit_labels=
 
 #     return experiment_dict
 
+def _sample_clifford_circuit(pspec, clifford_compilations, qubit_labels, citerations,
+        compilerargs, exact_compilation_key, srep_cache, rand_state):
+    """Helper function to compile a random Clifford circuit.
+
+    Parameters
+    ----------
+    pspec : QubitProcessorSpec
+        The QubitProcessorSpec for the device that the circuit is being sampled for, which defines the
+        "native" gate-set and the connectivity of the device. The returned CRB circuit will be over
+        the gates in `pspec`, and will respect the connectivity encoded by `pspec`.
+
+    clifford_compilations : dict
+        A dictionary with at least the potential keys `'absolute'` and `'paulieq'` and corresponding
+        :class:`CompilationRules` values.  These compilation rules specify how to compile the
+        "native" gates of `pspec` into Clifford gates. Additional :class:`CompilationRules` can be
+        provided, particularly for use with `exact_compilation_key`.
+
+    qubit_labels : list
+        A list of the qubits that the RB circuit is to be sampled for.
+
+    citerations : int
+        Some of the Clifford compilation algorithms in pyGSTi (including the default algorithm) are
+        randomized, and the lowest-cost circuit is chosen from all the circuit generated in the
+        iterations of the algorithm. This is the number of iterations used. The time required to
+        generate a CRB circuit is linear in `citerations` * (`length` + 2). Lower-depth / lower 2-qubit
+        gate count compilations of the Cliffords are important in order to successfully implement
+        CRB on more qubits.
+
+    compilerargs : list
+        A list of arguments that are handed to compile_clifford() function, which includes all the
+        optional arguments of compile_clifford() *after* the `iterations` option (set by `citerations`).
+        In order, this list should be values for:
+        
+        algorithm : str. A string that specifies the compilation algorithm. The default in
+        compile_clifford() will always be whatever we consider to be the 'best' all-round
+        algorithm
+        
+        aargs : list. A list of optional arguments for the particular compilation algorithm.
+        
+        costfunction : 'str' or function. The cost-function from which the "best" compilation
+        for a Clifford is chosen from all `citerations` compilations. The default costs a
+        circuit as 10x the num. of 2-qubit gates in the circuit + 1x the depth of the circuit.
+        
+        prefixpaulis : bool. Whether to prefix or append the Paulis on each Clifford.
+        
+        paulirandomize : bool. Whether to follow each layer in the Clifford circuit with a
+        random Pauli on each qubit (compiled into native gates). I.e., if this is True the
+        native gates are Pauli-randomized. When True, this prevents any coherent errors adding
+        (on average) inside the layers of each compiled Clifford, at the cost of increased
+        circuit depth. Defaults to False.
+        
+        For more information on these options, see the `:func:compile_clifford()` docstring.
+    
+    exact_compilation_key: str, optional
+        The key into `clifford_compilations` to use for exact deterministic complation of Cliffords.
+        The underlying :class:`CompilationRules` object must provide compilations for all possible
+        n-qubit Cliffords that will be generated. This also requires the pspec is able to generate the
+        symplectic representations for all n-qubit Cliffords in :meth:`compute_clifford_symplectic_reps`.
+        This is currently generally intended for use out-of-the-box with 1-qubit Clifford RB;
+        however, larger number of qubits can be used so long as the user specifies the processor spec and
+        compilation rules properly.
+
+    srep_cache: dict
+        Keys are gate labels and values are precomputed symplectic representations.
+    
+    rand_state: np.random.RandomState
+        A RandomState to use for RNG
+
+    Returns
+    -------
+    clifford_circuit : Circuit
+        The compiled Clifford circuit
+    
+    s:
+        The symplectic matrix of the Clifford
+    
+    p:
+        The symplectic phase vector of the Clifford
+    """
+    # Find the labels of the qubits to create the circuit for.
+    if qubit_labels is not None: qubits = qubit_labels[:]  # copy this list
+    else: qubits = pspec.qubit_labels[:]  # copy this list
+    # The number of qubits the circuit is over.
+    n = len(qubits)
+
+    if exact_compilation_key is not None:
+        # Deterministic compilation based on a provided clifford compilation
+        assert exact_compilation_key in clifford_compilations, \
+                f"{exact_compilation_key} not provided in `clifford_compilations`"
+        
+        # Pick clifford
+        cidx = rand_state.randint(_symp.compute_num_cliffords(n))
+        lbl = _lbl.Label(f'C{cidx}', qubits)
+        
+        # Try to do deterministic compilation
+        try:
+            circuit = clifford_compilations[exact_compilation_key].retrieve_compilation_of(lbl)
+        except AssertionError:
+            raise ValueError(
+                f"Failed to compile n-qubit Clifford 'C{cidx}'. Ensure this is provided in the " + \
+                "compilation rules, or use a compilation algorithm to synthesize it by not " + \
+                "specifying `exact_compilation_key`."
+            )
+    
+        # compute the symplectic rep of the chosen clifford
+        # TODO: Note that this is inefficient. For speed, we could implement the pair to
+        # _symp.compute_symplectic_matrix and just calculate s and p directly
+        s, p = _symp.symplectic_rep_of_clifford_circuit(circuit, srep_cache)
+    else:
+        # Random compilation
+        s, p = _symp.random_clifford(n, rand_state=rand_state)
+        circuit = _cmpl.compile_clifford(s, p, pspec,
+                                        clifford_compilations.get('absolute', None),
+                                        clifford_compilations.get('paulieq', None),
+                                        qubit_labels=qubit_labels, iterations=citerations, *compilerargs,
+                                            rand_state=rand_state)
+    
+    return circuit, s, p
+
 
 def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_labels=None, randomizeout=False,
                                citerations=20, compilerargs=None, interleaved_circuit=None, seed=None,
-                               return_num_native_gates=False, exact_compilation_key=None):
+                               return_native_gate_counts=False, exact_compilation_key=None):
     """
     Generates a "Clifford randomized benchmarking" (CRB) circuit.
 
@@ -2226,7 +2345,7 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
         A seed to initialize the random number generator used for creating random clifford
         circuits.
     
-    return_num_native_gates: bool, optional
+    return_native_gate_counts: bool, optional
         Whether to return the number of native gates in the first `length`+1 compiled Cliffords
     
     exact_compilation_key: str, optional
@@ -2251,9 +2370,9 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
         In both cases, the ith element of the tuple corresponds to the error-free outcome for the
         qubit on the ith wire of the output circuit.
     
-    num_native_gates: int
-        Total number of native gates in the first `length`+1 compiled Cliffords.
-        Only returned when `return_num_native_gates` is True
+    native_gate_counts: dict
+        Total number of native gates, native 2q gates, and native circuit size in the
+        first `length`+1 compiled Cliffords. Only returned when `return_num_native_gates` is True
     """
     if compilerargs is None:
         compilerargs = []
@@ -2263,6 +2382,7 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
     # The number of qubits the circuit is over.
     n = len(qubits)
 
+    srep_cache = {}
     if exact_compilation_key is not None:
         # Precompute some of the symplectic reps if we are doing exact compilation
         srep_cache = _symp.compute_internal_gate_symplectic_representations()
@@ -2279,37 +2399,15 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
     # Sample length+1 uniformly random Cliffords (we want a circuit of length+2 Cliffords, in total), compile
     # them, and append them to the current circuit.
     num_native_gates = 0
+    num_native_2q_gates = 0
+    native_size = 0
     for _ in range(0, length + 1):
-        if exact_compilation_key is not None:
-            # Deterministic compilation based on a provided clifford compilation
-            assert exact_compilation_key in clifford_compilations, \
-                    f"{exact_compilation_key} not provided in `clifford_compilations`"
-            
-            # Pick clifford
-            cidx = rand_state.randint(24**n)
-            lbl = _lbl.Label(f'C{cidx}', qubits)
-            
-            # Try to do deterministic compilation
-            try:
-                circuit = clifford_compilations[exact_compilation_key].retrieve_compilation_of(lbl)
-            except AssertionError:
-                raise ValueError(
-                    f"Failed to compile n-qubit Clifford 'C{cidx}'. Ensure this is provided in the " + \
-                    "compilation rules, or use a compilation algorithm to synthesize it by not " + \
-                    "specifying `exact_compilation_key`."
-                )
-        
-            # compute the symplectic rep of the chosen clifford
-            s, p = _symp.symplectic_rep_of_clifford_circuit(circuit, srep_cache)
-        else:
-            # Random compilation
-            s, p = _symp.random_clifford(n, rand_state=rand_state)
-            circuit = _cmpl.compile_clifford(s, p, pspec,
-                                            clifford_compilations.get('absolute', None),
-                                            clifford_compilations.get('paulieq', None),
-                                            qubit_labels=qubit_labels, iterations=citerations, *compilerargs,
-                                            rand_state=rand_state)
+        # Perform sampling
+        circuit, s, p = _sample_clifford_circuit(pspec, clifford_compilations, qubit_labels, citerations,
+                                 compilerargs, exact_compilation_key, srep_cache, rand_state)
         num_native_gates += circuit.num_gates
+        num_native_2q_gates += circuit.num_nq_gates(2)
+        native_size += circuit.size
 
         # Keeps track of the current composite Clifford
         s_composite, p_composite = _symp.compose_cliffords(s_composite, p_composite, s, p)
@@ -2355,8 +2453,14 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
 
     full_circuit.done_editing()
 
-    if return_num_native_gates:
-        return full_circuit, idealout, num_native_gates
+    native_gate_counts = {
+        "native_gate_count": num_native_gates,
+        "native_2q_gate_count": num_native_2q_gates,
+        "native_size": native_size
+    }
+
+    if return_native_gate_counts:
+        return full_circuit, idealout, native_gate_counts
     return full_circuit, idealout
 
 

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -3405,6 +3405,30 @@ class Circuit(object):
         """
         return self.num_nq_gates(2)
 
+    @property
+    def num_gates(self):
+        """
+        The number of gates in the circuit.
+
+        Returns
+        -------
+        int
+        """
+        if self._static:
+            def cnt(lbl):  # obj a Label, perhaps compound
+                if lbl.is_simple():  # a simple label
+                    return 1 if (lbl.sslbls is not None) else 0
+                else:
+                    return sum([cnt(sublbl) for sublbl in lbl.components])
+        else:
+            def cnt(obj):  # obj is either a simple label or a list
+                if isinstance(obj, _Label):  # all Labels are simple labels
+                    return 1 if (obj.sslbls is not None) else 0
+                else:
+                    return sum([cnt(sub) for sub in obj])
+
+        return sum([cnt(layer_lbl) for layer_lbl in self._labels])
+
     def num_nq_gates(self, nq):
         """
         The number of `nq`-qubit gates in the circuit.

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -203,6 +203,7 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
                  interleaved_circuit=None, citerations=20, compilerargs=(), exact_compilation_key=None,
                  descriptor='A Clifford RB experiment', add_default_protocol=False, seed=None, verbosity=1, num_processes=1):
         if qubit_labels is None: qubit_labels = tuple(pspec.qubit_labels)
+        assert len(qubit_labels) == len(pspec.qubit_labels), "Must provide qubit labels that match number of qubits in pspec"
         circuit_lists = []
         ideal_outs = []
         num_native_gates = []

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -200,8 +200,8 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
         return self
 
     def __init__(self, pspec, clifford_compilations, depths, circuits_per_depth, qubit_labels=None, randomizeout=False,
-                 interleaved_circuit=None, citerations=20, compilerargs=(), descriptor='A Clifford RB experiment',
-                 add_default_protocol=False, seed=None, verbosity=1, num_processes=1):
+                 interleaved_circuit=None, citerations=20, compilerargs=(), exact_compilation_key=None,
+                 descriptor='A Clifford RB experiment', add_default_protocol=False, seed=None, verbosity=1, num_processes=1):
         if qubit_labels is None: qubit_labels = tuple(pspec.qubit_labels)
         circuit_lists = []
         ideal_outs = []
@@ -221,7 +221,8 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
             args_list = [(pspec, clifford_compilations, l)] * circuits_per_depth
             kwargs_list = [dict(qubit_labels=qubit_labels, randomizeout=randomizeout, citerations=citerations,
                                 compilerargs=compilerargs, interleaved_circuit=interleaved_circuit,
-                                seed=lseed + i, return_num_native_gates=True) for i in range(circuits_per_depth)]
+                                seed=lseed + i, return_num_native_gates=True, exact_compilation_key=exact_compilation_key)
+                                for i in range(circuits_per_depth)]
             results = _tools.mptools.starmap_with_kwargs(_rc.create_clifford_rb_circuit, circuits_per_depth,
                                                          num_processes, args_list, kwargs_list)
 
@@ -243,7 +244,7 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
 
     def _init_foundation(self, depths, circuit_lists, ideal_outs, circuits_per_depth, qubit_labels,
                          randomizeout, citerations, compilerargs, descriptor, add_default_protocol,
-                         interleaved_circuit, num_native_gates=None):
+                         interleaved_circuit, num_native_gates=None, exact_compilation_key=None):
         self.num_native_gate_lists = num_native_gates
         if self.num_native_gate_lists is not None:
             # If we have native gate information, pair this with circuit data so that we serialize/truncate properly
@@ -256,6 +257,7 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
         self.compilerargs = compilerargs
         self.descriptor = descriptor
         self.interleaved_circuit = interleaved_circuit
+        self.exact_compilation_key = exact_compilation_key
         if add_default_protocol:
             if randomizeout:
                 defaultfit = 'A-fixed'

--- a/pygsti/protocols/vb.py
+++ b/pygsti/protocols/vb.py
@@ -200,9 +200,14 @@ class BenchmarkingDesign(ByDepthDesign):
             paired_attrs = [pal[list_idx] for pal in paired_attr_lists_list]
             # Do the same filtering as CircuitList.truncate, but drag along any paired attributes
             new_data = list(zip(*filter(lambda ci: ci[0] in set(circuits_to_keep), zip(circuits, *paired_attrs))))
-            truncated_circuit_lists.append(new_data[0])
-            for i, attr_data in enumerate(new_data[1:]):
-                truncated_paired_attr_lists_list[i].append(attr_data)
+            if len(new_data):
+                truncated_circuit_lists.append(new_data[0])
+                for i, attr_data in enumerate(new_data[1:]):
+                    truncated_paired_attr_lists_list[i].append(attr_data)
+            else:
+                # If we have truncated all circuits, append empty lists
+                truncated_circuit_lists.append([])
+                truncated_paired_attr_lists_list.append([[] for _ in range(len(self.paired_with_circuit_attrs))])
 
         self.circuit_lists = truncated_circuit_lists
         for paired_attr, paired_attr_lists in zip(self.paired_with_circuit_attrs, truncated_paired_attr_lists_list):
@@ -217,9 +222,14 @@ class BenchmarkingDesign(ByDepthDesign):
             paired_attrs = [pal[list_idx] for pal in paired_attr_lists_list]
             # Do the same filtering as CircuitList.truncate, but drag along any paired attributes
             new_data = list(zip(*filter(lambda ci: ci[0] in set(other_design.circuit_lists[list_idx]), zip(circuits, *paired_attrs))))
-            truncated_circuit_lists.append(new_data[0])
-            for i, attr_data in enumerate(new_data[1:]):
-                truncated_paired_attr_lists_list[i].append(attr_data)
+            if len(new_data):
+                truncated_circuit_lists.append(new_data[0])
+                for i, attr_data in enumerate(new_data[1:]):
+                    truncated_paired_attr_lists_list[i].append(attr_data)
+            else:
+                # If we have truncated all circuits, append empty lists
+                truncated_circuit_lists.append([])
+                truncated_paired_attr_lists_list.append([[] for _ in range(len(self.paired_with_circuit_attrs))])
 
         self.circuit_lists = truncated_circuit_lists
         for paired_attr, paired_attr_lists in zip(self.paired_with_circuit_attrs, truncated_paired_attr_lists_list):

--- a/test/unit/protocols/test_rb.py
+++ b/test/unit/protocols/test_rb.py
@@ -102,7 +102,9 @@ class TestCliffordRBDesign(BaseCase):
             self.assertTrue(set(clist) == set([pygsti.circuits.Circuit([], self.qubit_labels1Q)]))
 
         # Also a handy place to test native gate counts since it should be 0
-        self.assertTrue(idle_design.average_native_gates_per_clifford() == 0)
+        avg_gate_counts = idle_design.average_native_gates_per_clifford()
+        for v in avg_gate_counts.values():
+            self.assertTrue(v == 0)
 
 class TestDirectRBDesign(BaseCase):
 


### PR DESCRIPTION
Fixes several RB issues. I still plan to write a few tests for these, but it is at least ready to review from the RB codeowners to ensure that these are good solutions to the features.

### Deterministic Clifford compilation (#314)

The desire was to be able to do deterministic Clifford compilation when generating `CliffordRBDesign` objects. We actually already had a partial way to do this because the `CliffordCompilationRules` are more or less exactly this - a rule for how to build up a circuit from native gates that implement a Clifford. So my implementation is just to add a `exact_compilation_key` kwarg which uses the compilation rules to do this deterministic compilation when provided, and otherwise to do the previous behavior of synthesizing using the random algorithms.

An example:

```
import pygsti
from pygsti.processors import QubitProcessorSpec as QPS
from pygsti.processors import CliffordCompilationRules as CCR

n_qubits = 1
qubit_labels = ['Q'+str(i) for i in range(n_qubits)] 
gate_names = ['Gi', 'Gxpi2', 'Gxpi', 'Gxmpi2', 'Gypi2', 'Gypi', 'Gympi2', 
              'Gzpi2', 'Gzpi', 'Gzmpi2', 'Gcphase']
availability = {'Gcphase':[('Q'+str(i),'Q'+str((i+1) % n_qubits)) for i in range(n_qubits)]}
pspec = QPS(n_qubits, gate_names, availability=availability, qubit_labels=qubit_labels)
compilations = {'absolute': CCR.create_standard(pspec, 'absolute', ('paulis', '1Qcliffords'), verbosity=0),            
                'paulieq': CCR.create_standard(pspec, 'paulieq', ('1Qcliffords', 'allcnots'), verbosity=0)}
depths = [0, 2]
k = 10
qubits = qubit_labels
```

This will create the design as before, with random Clifford synthesis:
```
design = pygsti.protocols.CliffordRBDesign(pspec, compilations, depths, k, qubit_labels=qubits, 
                                           randomizeout=False, seed=20240522)
```

This will create a design using the `absolute` compilation of each Clifford instead:
```
design = pygsti.protocols.CliffordRBDesign(pspec, compilations, depths, k, qubit_labels=qubits, 
                                           randomizeout=False, seed=20240522, exact_compilation_key="absolute")
```

Or similarly, we could do a compilation up to Pauli equivalence with the `paulieq` compilation:

```
design = pygsti.protocols.CliffordRBDesign(pspec, compilations, depths, k, qubit_labels=qubits, 
                                           randomizeout=False, seed=20240522, exact_compilation_key="paulieq")
```

A non-standard compilation rule could also be done:
```
compilations["nonstd"] = pygsti.processors.CompilationRules({some dict of clifford names -> circuit templates})
design = pygsti.protocols.CliffordRBDesign(pspec, compilations, depths, k, qubit_labels=qubits, 
                                           randomizeout=False, seed=20240522, exact_compilation_key="nonstd")
```

### Native gate per Clifford statistics (#315)

The `CliffordRBDesign` now keeps track of how many native gates are in the first `length`+1 Cliffords, i.e. excluding the inversion Clifford, stores them in a `native_gate_count_lists` member variable, and provides convenience functions to compute the averages.

```
design = pygsti.protocols.CliffordRBDesign(pspec, compilations, [0, 2], 5, qubit_labels=qubits, 
                                           randomizeout=False, citerations=10)
design.native_gate_count_lists # A list of lists of the number of native gates for the compiled Cliffords (without inversion)
design.average_native_gates_per_clifford()  # Compute average over all circuits
```

As an aside, I also added a `num_gates` utility function to `Circuit` that was apparently missing. There was `num_nq_gates` and `num_multiq_gates` so you could have done `num_nq_gates(1) + num_multiq_gates`, but might as well provide it.

### Truncation bugfix for RBDesigns (#408)

The various `BenchmarkingDesign` classes often have lists that are intended to be paired with the `circuit_lists` member attribute. These paired attributes were not being truncated properly.

To fix this, the `BenchmarkingDesign` now has a `paired_with_circuit_attrs` member variable which lists the names of any attribute that is intended to correspond 1-to-1 with the `circuit_lists`. During truncation, these paired attributes are zipped up with the circuits during filtering, and then unzipped into the new truncated lists. Paired attributes are also serialized separately to JSON files, as we often want to look at them independently.

A currently exhaustive list of paired attributes (paired attributes propogate to derived classes):

- `BenchmarkingDesign`: `idealout_lists`
- `CliffordRBDesign`: `num_native_gate_lists` (due to the #315 fix above)
- `BinaryRBDesign`: `measurements`, `signs`