### PR TITLE
Remove unused isin 

### DIFF
--- a/pygsti/modelmembers/states/__init__.py
+++ b/pygsti/modelmembers/states/__init__.py
@@ -15,8 +15,6 @@ import scipy.linalg as _spl
 import scipy.optimize as _spo
 import warnings as _warnings
 
-from numpy.lib.arraysetops import isin
-
 from pygsti.modelmembers.povms.computationalpovm import ComputationalBasisPOVM
 
 from .composedstate import ComposedState


### PR DESCRIPTION
The import of `isin` used is not availabe in numpy 2.0. If the import is required for backwards compatibility, then I suggest to replace it with `from numpy import isin`