### PR TITLE
Interleaved RB

### DIFF
--- a/jupyter_notebooks/Tutorials/algorithms/RB-CliffordRB.ipynb
+++ b/jupyter_notebooks/Tutorials/algorithms/RB-CliffordRB.ipynb
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function #python 2 & 3 compatibility\n",
     "import pygsti\n",
     "from pygsti.processors import QubitProcessorSpec as QPS\n",
-    "from pygsti.processors import CliffordCompilationRules as CCR"
+    "from pygsti.processors import CliffordCompilationRules as CCR\n",
+    "import numpy as np"
    ]
   },
   {
@@ -53,14 +53,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "n_qubits = 4\n",
-    "qubit_labels = ['Q0','Q1','Q2','Q3'] \n",
+    "n_qubits = 2\n",
+    "qubit_labels = ['Q0','Q1'] \n",
     "gate_names = ['Gxpi2', 'Gxmpi2', 'Gypi2', 'Gympi2', 'Gcphase'] \n",
-    "availability = {'Gcphase':[('Q0','Q1'), ('Q1','Q2'), ('Q2','Q3'), ('Q3','Q0')]}\n",
+    "availability = {'Gcphase':[('Q0','Q1')]}\n",
     "pspec = QPS(n_qubits, gate_names, availability=availability, qubit_labels=qubit_labels)\n",
     "\n",
     "compilations = {'absolute': CCR.create_standard(pspec, 'absolute', ('paulis', '1Qcliffords'), verbosity=0),            \n",
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,51 +127,18 @@
     "def simulate_taking_data(data_template_filename):\n",
     "    \"\"\"Simulate taking data and filling the results into a template dataset.txt file\"\"\"\n",
     "    noisemodel = pygsti.models.create_crosstalk_free_model(pspec, depolarization_strengths={g:0.01 for g in pspec.gate_names})\n",
+    "    noisemodel.sim = 'map'\n",
     "    pygsti.io.fill_in_empty_dataset_with_fake_data(data_template_filename, noisemodel, num_samples=1000, seed=1234)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "- Sampling 10 circuits at CRB length 0 (1 of 5 depths) with seed 75116\n",
-      "- Sampling 10 circuits at CRB length 1 (2 of 5 depths) with seed 75126\n",
-      "- Sampling 10 circuits at CRB length 2 (3 of 5 depths) with seed 75136\n",
-      "- Sampling 10 circuits at CRB length 4 (4 of 5 depths) with seed 75146\n",
-      "- Sampling 10 circuits at CRB length 8 (5 of 5 depths) with seed 75156\n"
-     ]
-    },
-    {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: '../tutorial_files/test_rb_dir/data/dataset_crb.txt'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "File \u001b[1;32m~\\Documents\\pyGSTi_random_bugfixes\\pygsti\\io\\readers.py:98\u001b[0m, in \u001b[0;36mread_dataset\u001b[1;34m(filename, cache, collision_action, record_zero_counts, ignore_zero_count_lines, with_times, circuit_parse_cache, verbosity)\u001b[0m\n\u001b[0;32m     96\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m     97\u001b[0m     \u001b[38;5;66;03m# a saved Dataset object is ok\u001b[39;00m\n\u001b[1;32m---> 98\u001b[0m     ds \u001b[38;5;241m=\u001b[39m \u001b[43m_data\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mDataSet\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfile_to_load_from\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mfilename\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     99\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m:\n\u001b[0;32m    100\u001b[0m \n\u001b[0;32m    101\u001b[0m     \u001b[38;5;66;03m#Parser functions don't take a VerbosityPrinter yet, and so\u001b[39;00m\n\u001b[0;32m    102\u001b[0m     \u001b[38;5;66;03m# always output to stdout (TODO)\u001b[39;00m\n",
-      "File \u001b[1;32m~\\Documents\\pyGSTi_random_bugfixes\\pygsti\\data\\dataset.py:1003\u001b[0m, in \u001b[0;36mDataSet.__init__\u001b[1;34m(self, oli_data, time_data, rep_data, circuits, circuit_indices, outcome_labels, outcome_label_indices, static, file_to_load_from, collision_action, comment, aux_info)\u001b[0m\n\u001b[0;32m   1000\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m(oli_data \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m time_data \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m rep_data \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m   1001\u001b[0m        \u001b[38;5;129;01mand\u001b[39;00m circuits \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m circuit_indices \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m   1002\u001b[0m        \u001b[38;5;129;01mand\u001b[39;00m outcome_labels \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m outcome_label_indices \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[1;32m-> 1003\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_binary\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfile_to_load_from\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m   1004\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m\n",
-      "File \u001b[1;32m~\\Documents\\pyGSTi_random_bugfixes\\pygsti\\data\\dataset.py:2950\u001b[0m, in \u001b[0;36mDataSet.read_binary\u001b[1;34m(self, file_or_filename)\u001b[0m\n\u001b[0;32m   2949\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m-> 2950\u001b[0m         f \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mfile_or_filename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mrb\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m   2951\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
-      "\u001b[1;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '../tutorial_files/test_rb_dir/data/dataset_crb.txt'",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[6], line 7\u001b[0m\n\u001b[0;32m      4\u001b[0m pygsti\u001b[38;5;241m.\u001b[39mio\u001b[38;5;241m.\u001b[39mwrite_empty_protocol_data(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m../tutorial_files/test_rb_dir\u001b[39m\u001b[38;5;124m'\u001b[39m, design, clobber_ok\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[0;32m      6\u001b[0m \u001b[38;5;66;03m# -- fill in the dataset file in tutorial_files/test_rb_dir/data/dataset.txt --\u001b[39;00m\n\u001b[1;32m----> 7\u001b[0m \u001b[43msimulate_taking_data\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43m../tutorial_files/test_rb_dir/data/dataset_crb.txt\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m \u001b[38;5;66;03m# REPLACE with actual data-taking\u001b[39;00m\n\u001b[0;32m      9\u001b[0m data \u001b[38;5;241m=\u001b[39m pygsti\u001b[38;5;241m.\u001b[39mio\u001b[38;5;241m.\u001b[39mread_data_from_dir(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m../tutorial_files/test_rb_dir\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m     11\u001b[0m protocol \u001b[38;5;241m=\u001b[39m pygsti\u001b[38;5;241m.\u001b[39mprotocols\u001b[38;5;241m.\u001b[39mRB() \n",
-      "Cell \u001b[1;32mIn[5], line 5\u001b[0m, in \u001b[0;36msimulate_taking_data\u001b[1;34m(data_template_filename)\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Simulate taking data and filling the results into a template dataset.txt file\"\"\"\u001b[39;00m\n\u001b[0;32m      4\u001b[0m noisemodel \u001b[38;5;241m=\u001b[39m pygsti\u001b[38;5;241m.\u001b[39mmodels\u001b[38;5;241m.\u001b[39mcreate_crosstalk_free_model(pspec, depolarization_strengths\u001b[38;5;241m=\u001b[39m{g:\u001b[38;5;241m0.01\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m g \u001b[38;5;129;01min\u001b[39;00m pspec\u001b[38;5;241m.\u001b[39mgate_names})\n\u001b[1;32m----> 5\u001b[0m \u001b[43mpygsti\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mio\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfill_in_empty_dataset_with_fake_data\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata_template_filename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnoisemodel\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnum_samples\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1000\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mseed\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m1234\u001b[39;49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[1;32m~\\Documents\\pyGSTi_random_bugfixes\\pygsti\\io\\writers.py:631\u001b[0m, in \u001b[0;36mfill_in_empty_dataset_with_fake_data\u001b[1;34m(dataset_filename, model, num_samples, sample_error, seed, rand_state, alias_dict, collision_action, record_zero_counts, comm, mem_limit, times, fixed_column_mode)\u001b[0m\n\u001b[0;32m    628\u001b[0m     model, dataset_filename \u001b[38;5;241m=\u001b[39m dataset_filename, model\n\u001b[0;32m    630\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mpygsti\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdata\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdatasetconstruction\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m simulate_data \u001b[38;5;28;01mas\u001b[39;00m _simulate_data\n\u001b[1;32m--> 631\u001b[0m ds_template \u001b[38;5;241m=\u001b[39m \u001b[43m_readers\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_dataset\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdataset_filename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mignore_zero_count_lines\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mwith_times\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mverbosity\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m    632\u001b[0m ds \u001b[38;5;241m=\u001b[39m _simulate_data(model, \u001b[38;5;28mlist\u001b[39m(ds_template\u001b[38;5;241m.\u001b[39mkeys()), num_samples,\n\u001b[0;32m    633\u001b[0m                     sample_error, seed, rand_state, alias_dict,\n\u001b[0;32m    634\u001b[0m                     collision_action, record_zero_counts, comm,\n\u001b[0;32m    635\u001b[0m                     mem_limit, times)\n\u001b[0;32m    636\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m fixed_column_mode \u001b[38;5;241m==\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mauto\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n",
-      "File \u001b[1;32m~\\Documents\\pyGSTi_random_bugfixes\\pygsti\\io\\readers.py:133\u001b[0m, in \u001b[0;36mread_dataset\u001b[1;34m(filename, cache, collision_action, record_zero_counts, ignore_zero_count_lines, with_times, circuit_parse_cache, verbosity)\u001b[0m\n\u001b[0;32m    130\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m    131\u001b[0m     \u001b[38;5;66;03m# otherwise must use standard dataset file format\u001b[39;00m\n\u001b[0;32m    132\u001b[0m     parser \u001b[38;5;241m=\u001b[39m _stdinput\u001b[38;5;241m.\u001b[39mStdInputParser()\n\u001b[1;32m--> 133\u001b[0m     ds \u001b[38;5;241m=\u001b[39m \u001b[43mparser\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mparse_datafile\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbToStdout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    134\u001b[0m \u001b[43m                               \u001b[49m\u001b[43mcollision_action\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcollision_action\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    135\u001b[0m \u001b[43m                               \u001b[49m\u001b[43mrecord_zero_counts\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mrecord_zero_counts\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    136\u001b[0m \u001b[43m                               \u001b[49m\u001b[43mignore_zero_count_lines\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mignore_zero_count_lines\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    137\u001b[0m \u001b[43m                               \u001b[49m\u001b[43mwith_times\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mwith_times\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m    138\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m ds\n",
-      "File \u001b[1;32m~\\Documents\\pyGSTi_random_bugfixes\\pygsti\\io\\stdinput.py:403\u001b[0m, in \u001b[0;36mStdInputParser.parse_datafile\u001b[1;34m(self, filename, show_progress, collision_action, record_zero_counts, ignore_zero_count_lines, with_times)\u001b[0m\n\u001b[0;32m    401\u001b[0m preamble_directives \u001b[38;5;241m=\u001b[39m {}\n\u001b[0;32m    402\u001b[0m preamble_comments \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m--> 403\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mr\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m datafile:\n\u001b[0;32m    404\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m line \u001b[38;5;129;01min\u001b[39;00m datafile:\n\u001b[0;32m    405\u001b[0m         line \u001b[38;5;241m=\u001b[39m line\u001b[38;5;241m.\u001b[39mstrip()\n",
-      "\u001b[1;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '../tutorial_files/test_rb_dir/data/dataset_crb.txt'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "design = pygsti.protocols.CliffordRBDesign(pspec, compilations, depths, k, qubit_labels=qubits, \n",
     "                                           randomizeout=randomizeout, citerations=citerations)\n",
-    "\n",
     "pygsti.io.write_empty_protocol_data('../tutorial_files/test_crb_dir', design, clobber_ok=True)\n",
     "\n",
     "# -- fill in the dataset file in tutorial_files/test_rb_dir/data/dataset.txt --\n",
@@ -183,7 +150,7 @@
     "results = protocol.run(data)\n",
     "ws = pygsti.report.Workspace()\n",
     "ws.init_notebook_mode(autodisplay=True)\n",
-    "ws.RandomizedBenchmarkingPlot(results)"
+    "rb_fig = ws.RandomizedBenchmarkingPlot(results)"
    ]
   },
   {
@@ -191,14 +158,225 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "#If the figure doesn't appear in the output above, try uncommenting the contents of this cell and running it.\n",
+    "#rb_fig.figs[0].plotlyfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interleaved Randomized Benchmarking\n",
+    "In this subsection we'll discuss built-in support for performing interleaved randomized benchmarking (IRB). IRB is a method for estimating the error rate of a particular clifford of interest using CRB as a subroutine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pygsti.protocols.rb import InterleavedRBDesign, InterleavedRandomizedBenchmarking\n",
+    "from pygsti.circuits import Circuit\n",
+    "from pygsti.baseobjs import Label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The creation of an IRB design largely follows that of CRB, with the addition of the specification of an interleaved circuit. That is, the clifford which we want to estimate the individual error rate for."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_qubits = 1\n",
+    "qubit_labels = ['Q0']\n",
+    "gate_names = ['Gxpi2', 'Gxmpi2', 'Gypi2', 'Gympi2']\n",
+    "pspec = QPS(n_qubits, gate_names, qubit_labels=qubit_labels)\n",
+    "compilations = {'absolute': CCR.create_standard(pspec, 'absolute', ('paulis', '1Qcliffords'), verbosity=0),            \n",
+    "                'paulieq': CCR.create_standard(pspec, 'paulieq', ('1Qcliffords', 'allcnots'), verbosity=0)}\n",
+    "depths = [0,1,2,4,8,16,32]\n",
+    "k = 50\n",
+    "interleaved_circuit = Circuit([Label('Gxpi2', 'Q0')], line_labels=('Q0',))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "irb_design = InterleavedRBDesign(pspec, compilations, depths, k, interleaved_circuit, qubit_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`InterleavedRBDesign` is structured somewhat differently than `CliffordRBDesign`, instead acting as a container class which constructs and stores a pair of CRB experiment designs (one interleaved with the specified `interleaved_circuit`) with settings as specified by the given arguments. `InterleavedRBDesign` is a subclass of the more general `CombinedExperimentDesign`, and like `CombinedExperimentDesign` its child subdesigns can be accessed by indexing into it like a dictionary, as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(irb_design.keys())\n",
+    "print(irb_design['crb'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we construct an error model with 1% local depolarization on each qubit after each one-qubit gate, except for Gxpi2 which has a 2% depolarization rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def simulate_taking_data_irb(data_template_filename):\n",
+    "    \"\"\"Simulate taking data and filling the results into a template dataset.txt file\"\"\"\n",
+    "    depolarization_strengths={g:0.01 for g in pspec.gate_names if g!= 'Gxpi2'}\n",
+    "    depolarization_strengths['Gxpi2'] = .02\n",
+    "    noisemodel = pygsti.models.create_crosstalk_free_model(pspec, depolarization_strengths=depolarization_strengths)\n",
+    "    noisemodel.sim = 'map'\n",
+    "    pygsti.io.fill_in_empty_dataset_with_fake_data(data_template_filename, noisemodel, num_samples=1000, seed=1234)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pygsti.io.write_empty_protocol_data('../tutorial_files/test_irb_dir', irb_design, clobber_ok=True)\n",
+    "\n",
+    "# -- fill in the dataset file in tutorial_files/test_rb_dir/data/dataset.txt --\n",
+    "simulate_taking_data_irb('../tutorial_files/test_irb_dir/data/dataset.txt') # REPLACE with actual data-taking\n",
+    "data_irb = pygsti.io.read_data_from_dir('../tutorial_files/test_irb_dir')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "protocol_irb = InterleavedRandomizedBenchmarking()\n",
+    "results_irb = protocol_irb.run(data_irb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have the results we can index into them to get the estimated IRB numbers and bounds. In this context, 'bounds' really refers to the half-width of the bounds as described in equation 5 of the original IRB paper from Magesan et al. https://arxiv.org/pdf/1203.4550.\n",
+    "The object that is returned by `InterleavedRandomizedBenchmarking` is a so-called `ProtocolResultsDir`, and this object stores both the IRB specific estimates as well as the results objects associated with each of the subexperiments used to perform IRB. This makes extracting the values slightly more cumbersome than usual, but ensures that the relevant results remain grouped together at all times. Below we show how to access the IRB numbers and bounds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_irb.for_protocol['InterleavedRandomizedBenchmarking'].irb_numbers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_irb.for_protocol['InterleavedRandomizedBenchmarking'].irb_bounds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access the results objects of the standard and interleaved CRB experiments that we performed we can index into `results_irb` like a dictionary. The relevant keys are 'crb' and 'icrb', respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_irb['crb'].for_protocol['RandomizedBenchmarking']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_irb['icrb'].for_protocol['RandomizedBenchmarking']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From which we can access various information about the fits as well as other useful RB related estimates. E.g. below we extract the rb number and the estimated exponential decay parameters for one of the RB fits performed on the CRB subexperiment|."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(results_irb['crb'].for_protocol['RandomizedBenchmarking'].fits['full'].estimates)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we'll note that this results object for IRB can be written to and read from disk using the `write` method and the function `pygsti.io.read_results_from_dir`, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results_irb.write('../tutorial_files/test_irb_results')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "irb_results_from_disk = pygsti.io.read_results_from_dir('../tutorial_files/test_irb_results')\n",
+    "print(irb_results_from_disk['crb'].for_protocol['RandomizedBenchmarking'].fits['full'].estimates)\n",
+    "#As expected these values are the same as above when we accessed them in `results_irb`"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "random_pygsti_debugging",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "random_pygsti_debugging"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -1212,7 +1212,8 @@ class InterleavedRBDesign(_proto.CombinedExperimentDesign):
         print('Constructing Interleaved CRB Subdesign:')
         icrb_subdesign = CliffordRBDesign(pspec, clifford_compilations, depths, circuits_per_depth, qubit_labels, randomizeout,
                                               interleaved_circuit, citerations, compilerargs, exact_compilation_key,
-                                              descriptor + ' (Interleaved)', add_default_protocol, seed+1, verbosity, num_processes)
+                                              descriptor + ' (Interleaved)', add_default_protocol, seed+1 if seed is not None else None, 
+                                              verbosity, num_processes)
 
         self._init_foundation(crb_subdesign, icrb_subdesign, circuits_per_depth, interleaved_circuit, randomizeout,
                               citerations, compilerargs, exact_compilation_key, interleave)

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -1188,7 +1188,8 @@ class InterleavedRBDesign(_proto.CombinedExperimentDesign):
 
     seed : int, optional
         A seed to initialize the random number generator used for creating random clifford
-        circuits.
+        circuits. The first of the two subdesigns will use the specified seed directly,
+        while the second will use seed+1.
 
     verbosity : int, optional
         If > 0 the number of circuits generated so far is shown.
@@ -1211,7 +1212,7 @@ class InterleavedRBDesign(_proto.CombinedExperimentDesign):
         print('Constructing Interleaved CRB Subdesign:')
         icrb_subdesign = CliffordRBDesign(pspec, clifford_compilations, depths, circuits_per_depth, qubit_labels, randomizeout,
                                               interleaved_circuit, citerations, compilerargs, exact_compilation_key,
-                                              descriptor + ' (Interleaved)', add_default_protocol, seed, verbosity, num_processes)
+                                              descriptor + ' (Interleaved)', add_default_protocol, seed+1, verbosity, num_processes)
 
         self._init_foundation(crb_subdesign, icrb_subdesign, circuits_per_depth, interleaved_circuit, randomizeout,
                               citerations, compilerargs, exact_compilation_key, interleave)

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -1745,7 +1745,6 @@ class InterleavedRandomizedBenchmarking(_proto.Protocol):
             #So if we want EI use the standard dimensional conversion factor.
             if self.rtype == 'EI':
                 possible_bound_2 = ((dim + 1)/dim)*possible_bound_2
-                
             irb_bounds[fit_key] = min(possible_bound_1, possible_bound_2)
         
         children = {'crb': _proto.ProtocolResultsDir(data['crb'], crb_results),

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -1287,7 +1287,7 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
     """
 
     def __init__(self, datatype='success_probabilities', defaultfit='full', asymptote='std', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None):
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None):
         """
         Initialize an RB protocol for analyzing RB data.
 
@@ -1350,7 +1350,6 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
         self.rtype = rtype
         self.datatype = datatype
         self.defaultfit = defaultfit
-        self.square_mean_root = square_mean_root #undocumented
         if self.datatype == 'energies':
             self.energies = True
         else:
@@ -1409,10 +1408,7 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
             adj_sps = []
             for depth in depths:
                 percircuitdata = circuitdata_per_depth[depth]
-                if self.square_mean_root:
-                    adj_sps.append(_np.nanmean(_np.sqrt(percircuitdata))**2)
-                else:
-                    adj_sps.append(_np.nanmean(percircuitdata))  # average [adjusted] success probabilities or energies
+                adj_sps.append(_np.nanmean(percircuitdata))  # average [adjusted] success probabilities or energies
 
             # Don't think this needs changed
             full_fit_results, fixed_asym_fit_results = _rbfit.std_least_squares_fit(
@@ -1642,7 +1638,7 @@ class InterleavedRandomizedBenchmarking(_proto.Protocol):
     """
 
     def __init__(self, defaultfit='full', asymptote='std', rtype='EI', seed=(0.8, 0.95), 
-                 bootstrap_samples=200, depths='all', square_mean_root=False, name=None):
+                 bootstrap_samples=200, depths='all', name=None):
         """
         Initialize an RB protocol for analyzing RB data.
 
@@ -1688,7 +1684,6 @@ class InterleavedRandomizedBenchmarking(_proto.Protocol):
         self.rtype = rtype
         self.datatype = 'success_probabilities'
         self.defaultfit = defaultfit
-        self.square_mean_root = square_mean_root #undocumented
 
     def run(self, data, memlimit=None, comm=None):
         """
@@ -1715,7 +1710,7 @@ class InterleavedRandomizedBenchmarking(_proto.Protocol):
         #initialize a RandomizedBenchmarking protocol to use as a helper
         #for performing analysis on the two subexperiments.
         rb_protocol = RandomizedBenchmarking('success_probabilities', self.defaultfit, self.asymptote, self.rtype,
-                                             self.seed, self.bootstrap_samples, self.depths, self.square_mean_root, name=None)
+                                             self.seed, self.bootstrap_samples, self.depths, name=None)
 
         #run the RB protocol on both subdesigns.
         crb_results = rb_protocol.run(data['crb'])

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -66,6 +66,10 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
         the ideal output a circuit is randomized to a uniformly random bit-string. This setting is
         useful for, e.g., detecting leakage/loss/measurement-bias etc.
 
+    interleaved_circuit : Circuit, optional (default None)
+        Circuit to use in the constuction of an interleaved CRB experiment. When specified each
+        random clifford operation is interleaved with the specified circuit.
+
     citerations : int, optional
         Some of the Clifford compilation algorithms in pyGSTi (including the default algorithm) are
         randomized, and the lowest-cost circuit is chosen from all the circuit generated in the
@@ -265,6 +269,9 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
             else:
                 defaultfit = 'full'
             self.add_default_protocol(RB(name='RB', defaultfit=defaultfit))
+        
+        #set some auxfile information for interleaved_circuit
+        self.auxfile_types['interleaved_circuit'] = 'circuit-str-json'
 
     def average_native_gates_per_clifford_for_circuit(self, list_idx, circ_idx):
         """The average number of native gates per Clifford for a specific circuit
@@ -1094,6 +1101,182 @@ class BinaryRBDesign(_vb.BenchmarkingDesign):
         defaultfit = 'A-fixed'
         self.add_default_protocol(RB(name='RB', defaultfit=defaultfit))
 
+
+class InterleavedRBDesign(_proto.CombinedExperimentDesign):
+    """
+    Experiment design for interleaved randomized benchmarking (IRB).
+
+    IRB encapsulates a pair of "Clifford randomized benchmarking" (CRB) experiments.
+    One of these CRB designs is a 'standard' one, but the other interleaves some
+    clifford gate of interest between each random clifford operation. 
+    The circuits created by this function will respect the connectivity and gate-set of the device encoded by 
+    `pspec` (see the :class:`QubitProcessorSpec` object docstring for how to construct the relevant `pspec` 
+    for a device).
+
+    Parameters
+    ----------
+    pspec : QubitProcessorSpec
+       The QubitProcessorSpec for the device that the CRB experiment is being generated for, which defines the 
+       "native" gate-set and the connectivity of the device. The returned CRB circuits will be over the gates in 
+       `pspec`, and will respect the connectivity encoded by `pspec`.
+
+    clifford_compilations : dict
+        A dictionary with the potential keys `'absolute'` and `'paulieq'` and corresponding class:`CompilationRules` values. 
+        These compilation rules specify how to compile the "native" gates of `pspec` into Clifford gates.
+
+    depths : list of ints
+        The "CRB depths" of the circuit; a list of integers >= 0. The CRB length is the number of Cliffords in the 
+        circuit - 2 *before* each Clifford is compiled into the native gate-set.
+
+    circuits_per_depth : int
+        The number of (possibly) different CRB circuits sampled at each length.
+
+    interleaved_circuit : Circuit
+        Circuit to use in the constuction of the interleaved CRB experiment. This is the circuit
+        whose error rate is to be estimated by the IRB experiment.
+
+    qubit_labels : list, optional
+        If not None, a list of the qubits that the RB circuits are to be sampled for. This should
+        be all or a subset of the qubits in the device specified by the QubitProcessorSpec `pspec`.
+        If None, it is assumed that the RB circuit should be over all the qubits. Note that the
+        ordering of this list is the order of the "wires" in the returned circuit, but is otherwise
+        irrelevant. If desired, a circuit that explicitly idles on the other qubits can be obtained
+        by using methods of the Circuit object.
+
+    randomizeout : bool, optional
+        If False, the ideal output of the circuits (the "success" or "survival" outcome) is always
+        the all-zeros bit string. This is probably considered to be the "standard" in CRB. If True,
+        the ideal output a circuit is randomized to a uniformly random bit-string. This setting is
+        useful for, e.g., detecting leakage/loss/measurement-bias etc.
+
+    citerations : int, optional
+        Some of the Clifford compilation algorithms in pyGSTi (including the default algorithm) are
+        randomized, and the lowest-cost circuit is chosen from all the circuit generated in the
+        iterations of the algorithm. This is the number of iterations used. The time required to
+        generate a CRB circuit is linear in `citerations * (CRB length + 2)`. Lower-depth / lower 2-qubit
+        gate count compilations of the Cliffords are important in order to successfully implement
+        CRB on more qubits.
+
+    compilerargs : list, optional
+        A list of arguments that are handed to compile_clifford() function, which includes all the
+        optional arguments of compile_clifford() *after* the `iterations` option (set by `citerations`).
+        In order, this list should be values for:
+        
+        * algorithm : str. A string that specifies the compilation algorithm. The default in
+          compile_clifford() will always be whatever we consider to be the 'best' all-round
+          algorithm.
+        * aargs : list. A list of optional arguments for the particular compilation algorithm.
+        * costfunction : 'str' or function. The cost-function from which the "best" compilation
+          for a Clifford is chosen from all `citerations` compilations. The default costs a
+          circuit as 10x the num. of 2-qubit gates in the circuit + 1x the depth of the circuit.
+        * prefixpaulis : bool. Whether to prefix or append the Paulis on each Clifford.
+        * paulirandomize : bool. Whether to follow each layer in the Clifford circuit with a
+          random Pauli on each qubit (compiled into native gates). I.e., if this is True the
+          native gates are Pauli-randomized. When True, this prevents any coherent errors adding
+          (on average) inside the layers of each compiled Clifford, at the cost of increased
+          circuit depth. Defaults to False.
+        
+        For more information on these options, see the compile_clifford() docstring.
+
+    descriptor : str, optional
+        A string describing the experiment generated, which will be stored in the returned
+        dictionary.
+
+    add_default_protocol : bool, optional
+        Whether to add a default RB protocol to the experiment design, which can be run
+        later (once data is taken) by using a :class:`DefaultProtocolRunner` object.
+
+    seed : int, optional
+        A seed to initialize the random number generator used for creating random clifford
+        circuits.
+
+    verbosity : int, optional
+        If > 0 the number of circuits generated so far is shown.
+
+    interleave : bool, optional
+        Whether the circuits of the standard CRB and IRB sub designs should be interleaved to
+        form the circuit ordering of this experiment design. E.g. when calling the `all_circuits_needing_data`
+        attribute.
+    """
+
+    def __init__(self, pspec, clifford_compilations, depths, circuits_per_depth, interleaved_circuit, qubit_labels=None, randomizeout=False,
+                 citerations=20, compilerargs=(), exact_compilation_key=None,
+                 descriptor='An Interleaved RB experiment', add_default_protocol=False, seed=None, verbosity=1, num_processes=1,
+                 interleave = False):
+        #Farm out the construction of the experiment designs to CliffordRBDesign:
+        print('Constructing Standard CRB Subdesign:')
+        crb_subdesign = CliffordRBDesign(pspec, clifford_compilations, depths, circuits_per_depth, qubit_labels, randomizeout,
+                                              None, citerations, compilerargs, exact_compilation_key,
+                                              descriptor + ' (Standard)', add_default_protocol, seed, verbosity, num_processes)
+        print('Constructing Interleaved CRB Subdesign:')
+        icrb_subdesign = CliffordRBDesign(pspec, clifford_compilations, depths, circuits_per_depth, qubit_labels, randomizeout,
+                                              interleaved_circuit, citerations, compilerargs, exact_compilation_key,
+                                              descriptor + ' (Interleaved)', add_default_protocol, seed, verbosity, num_processes)
+
+        self._init_foundation(crb_subdesign, icrb_subdesign, circuits_per_depth, interleaved_circuit, randomizeout,
+                              citerations, compilerargs, exact_compilation_key, interleave)
+
+    @classmethod
+    def from_existing_designs(cls, crb_subdesign, icrb_subdesign, circuits_per_depth, interleaved_circuit, randomizeout=False,
+                              citerations=20, compilerargs=(), exact_compilation_key=None, interleave=False):        
+        self = cls.__new__(cls)
+        self._init_foundation(self, crb_subdesign, icrb_subdesign, circuits_per_depth, interleaved_circuit, randomizeout,
+                              citerations, compilerargs, exact_compilation_key, interleave)
+
+    #helper method for reducing code duplication on different class constructors.
+    def _init_foundation(self, crb_subdesign, icrb_subdesign, circuits_per_depth, interleaved_circuit, randomizeout,
+                              citerations, compilerargs, exact_compilation_key, interleave):
+        super().__init__({'crb':crb_subdesign, 
+                          'icrb':icrb_subdesign}, interleave=interleave)
+        self.circuits_per_depth = circuits_per_depth
+        self.randomizeout = randomizeout
+        self.citerations = citerations
+        self.compilerargs = compilerargs
+        self.interleaved_circuit = interleaved_circuit
+        self.exact_compilation_key = exact_compilation_key
+
+        #set some auxfile information for serializing interleaved_circuit
+        self.auxfile_types['interleaved_circuit'] = 'circuit-str-json'
+
+    def average_native_gates_per_clifford(self):
+        """
+        The average number of native gates per Clifford for all circuits
+
+        Returns
+        -------
+        tuple of floats
+            A tuple of the average number of native gates per Clifford
+            for the contained standard CRB design, and interleaved CRB design,
+            respectively.
+        """
+        avg_gate_counts_crb = self['crb'].average_native_gates_per_clifford()
+        avg_gate_counts_icrb = self['icrb'].average_native_gates_per_clifford()
+        
+        return (avg_gate_counts_crb, avg_gate_counts_icrb)
+
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        InterleavedRBDesign
+        """
+
+        mapped_crb_design = self['crb'].map_qubit_labels(mapper)
+        mapped_icrb_design = self['icrb'].map_qubit_labels(mapper)
+
+        return InterleavedRBDesign.from_existing_designs(mapped_crb_design, mapped_icrb_design, self.circuits_per_depth, 
+                                                         self.randomizeout, self.citerations, self.compilerargs, self.interleaved_circuit,
+                                                         self.exact_compilation_key)
+
 class RandomizedBenchmarking(_vb.SummaryStatistics):
     """
     The randomized benchmarking protocol.
@@ -1101,51 +1284,6 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
     This same analysis protocol is used for Clifford, Direct and Mirror RB.
     The standard Mirror RB analysis is obtained by setting
     `datatype` = `adjusted_success_probabilities`.
-
-    Parameters
-    ----------
-    datatype: 'success_probabilities',  'adjusted_success_probabilities', or 'energies', optional
-        The type of summary data to extract, average, and the fit to an exponential decay. If
-        'success_probabilities' then the summary data for a circuit is the frequency that
-        the target bitstring is observed, i.e., the success probability of the circuit. If
-        'adjusted_success_probabilties' then the summary data for a circuit is
-        S = sum_{k = 0}^n (-1/2)^k h_k where h_k is the frequency at which the output bitstring is
-        a Hamming distance of k from the target bitstring, and n is the number of qubits.
-        This datatype is used in Mirror RB, but can also be used in Clifford and Direct RB. 
-        If 'energies',  then the summary data is Pauli operator measurement results. This datatype is
-        only used for Binary RB. 
-
-    defaultfit: 'A-fixed' or 'full'
-        The summary data is fit to A + Bp^m with A fixed and with A as a fit parameter.
-        If 'A-fixed' then the default results displayed are those from fitting with A
-        fixed, and if 'full' then the default results displayed are those where A is a
-        fit parameter.
-
-    asymptote : 'std' or float, optional
-        The summary data is fit to A + Bp^m with A fixed and with A has a fit parameter,
-        with the default results returned set by `defaultfit`. This argument specifies the
-        value used when 'A' is fixed. If left as 'std', then 'A' defaults to 1/2^n if
-        `datatype` is `success_probabilities` and to 1/4^n if `datatype` is
-        `adjusted_success_probabilities`.
-
-    rtype : 'EI' or 'AGI', optional
-        The RB error rate definition convention. 'EI' results in RB error rates that are associated
-        with the entanglement infidelity, which is the error probability with stochastic Pauli errors.
-        'AGI' results in RB error rates that are associated with the average gate infidelity.
-
-    seed : list, optional
-        Seeds for the fit of B and p (A is seeded to the asymptote defined by `asympote`).
-
-    bootstrap_samples : float, optional
-        The number of samples for generating bootstrapped error bars.
-
-    depths: list or 'all'
-        If not 'all', a list of depths to use (data at other depths is discarded).
-
-    name : str, optional
-        The name of this protocol, also used to (by default) name the
-        results produced by this protocol.  If None, the class name will
-        be used.
     """
 
     def __init__(self, datatype='success_probabilities', defaultfit='full', asymptote='std', rtype='EI',
@@ -1212,7 +1350,7 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
         self.rtype = rtype
         self.datatype = datatype
         self.defaultfit = defaultfit
-        self.square_mean_root = square_mean_root
+        self.square_mean_root = square_mean_root #undocumented
         if self.datatype == 'energies':
             self.energies = True
         else:
@@ -1246,8 +1384,6 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
         if self.datatype not in data.cache:
             summary_data_dict = self._compute_summary_statistics(data, energy = self.energies)
             data.cache.update(summary_data_dict)
-            #print('data cache updated')
-            #print(data.cache)
         src_data = data.cache[self.datatype]
         data_per_depth = src_data
 
@@ -1273,17 +1409,12 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
             adj_sps = []
             for depth in depths:
                 percircuitdata = circuitdata_per_depth[depth]
-                #print(percircuitdata)
                 if self.square_mean_root:
-                    #print(percircuitdata)
                     adj_sps.append(_np.nanmean(_np.sqrt(percircuitdata))**2)
-                    #print(adj_sps)
                 else:
                     adj_sps.append(_np.nanmean(percircuitdata))  # average [adjusted] success probabilities or energies
 
-            #print(adj_sps)
             # Don't think this needs changed
-            #print(asymptote)
             full_fit_results, fixed_asym_fit_results = _rbfit.std_least_squares_fit(
                 depths, adj_sps, nqubits, seed=self.seed, asymptote=asymptote,
                 ftype='full+FA', rtype=self.rtype)
@@ -1303,10 +1434,8 @@ class RandomizedBenchmarking(_vb.SummaryStatistics):
             failcount_faf = 0
 
             #Store bootstrap "cache" dicts (containing summary keys) as a list under data.cache
-            #print(len(data.cache['bootstraps']))
             if 'bootstraps' not in data.cache or len(data.cache['bootstraps']) < self.bootstrap_samples:
                 # TIM - finite counts always True here?
-                #print('adding bootstrap')
                 self._add_bootstrap_qtys(data.cache, self.bootstrap_samples, finitecounts=True)
             bootstrap_caches = data.cache['bootstraps']  # if finitecounts else 'infbootstraps'
 
@@ -1500,6 +1629,136 @@ class RandomizedBenchmarkingResults(_proto.ProtocolResults):
         data = _proto.ProtocolData(self.data.edesign, self.data.dataset)
         cpy = RandomizedBenchmarkingResults(data, self.protocol, self.fits, self.depths, self.defaultfit)
         return cpy
+    
+
+class InterleavedRandomizedBenchmarking(_proto.Protocol):
+    """
+    The interleaved randomized benchmarking protocol.
+
+    This object itself utilizes the RandomizedBenchmarking protocol to
+    perform the analysis for the standard CRB and interleaved RB subexperiments
+    that constitute the IRB process. As such, this class takes as input
+    the subset of RandomizedBenchmarking's arguments relevant for CRB.
+    """
+
+    def __init__(self, defaultfit='full', asymptote='std', seed=(0.8, 0.95), 
+                 bootstrap_samples=200, depths='all', square_mean_root=False, name=None):
+        """
+        Initialize an RB protocol for analyzing RB data.
+
+        Parameters
+        ----------
+        defaultfit: 'A-fixed' or 'full'
+            The summary data is fit to A + Bp^m with A fixed and with A as a fit parameter.
+            If 'A-fixed' then the default results displayed are those from fitting with A
+            fixed, and if 'full' then the default results displayed are those where A is a
+            fit parameter.
+
+        asymptote : 'std' or float, optional
+            The summary data is fit to A + Bp^m with A fixed and with A has a fit parameter,
+            with the default results returned set by `defaultfit`. This argument specifies the
+            value used when 'A' is fixed. If left as 'std', then 'A' defaults to 1/2^n if
+            `datatype` is `success_probabilities` and to 1/4^n if `datatype` is
+            `adjusted_success_probabilities`.
+
+        seed : list, optional
+            Seeds for the fit of B and p (A is seeded to the asymptote defined by `asympote`).
+
+        bootstrap_samples : float, optional
+            The number of samples for generating bootstrapped error bars.
+
+        depths: list or 'all'
+            If not 'all', a list of depths to use (data at other depths is discarded).
+
+        name : str, optional
+            The name of this protocol, also used to (by default) name the
+            results produced by this protocol.  If None, the class name will
+            be used.
+        """
+        super().__init__(name)
+        self.seed = seed
+        self.depths = depths
+        self.bootstrap_samples = bootstrap_samples
+        self.asymptote = asymptote
+        self.rtype = 'AGI'
+        self.datatype = 'success_probabilities'
+        self.defaultfit = defaultfit
+        self.square_mean_root = square_mean_root #undocumented
+
+    def run(self, data, memlimit=None, comm=None):
+        """
+        Run this protocol on `data`.
+
+        Parameters
+        ----------
+        data : ProtocolData
+            The input data.
+
+        memlimit : int, optional
+            A rough per-processor memory limit in bytes.
+
+        comm : mpi4py.MPI.Comm, optional
+            When not ``None``, an MPI communicator used to run this protocol
+            in parallel.
+
+        Returns
+        -------
+        RandomizedBenchmarkingResults
+        """
+        design = data.edesign
+        assert(isinstance(design, InterleavedRBDesign)), 'This protocol can only be run on InterleavedRBDesign.' 
+        #initialize a RandomizedBenchmarking protocol to use as a helper
+        #for performing analysis on the two subexperiments.
+        rb_protocol = RandomizedBenchmarking('success_probabilities', self.defaultfit, self.asymptote, self.rtype,
+                                             self.seed, self.bootstrap_samples, self.depths, self.square_mean_root, name=None)
+
+        #run the RB protocol on both subdesigns.
+        crb_results = rb_protocol.run(data['crb'])
+        icrb_results = rb_protocol.run(data['icrb'])
+
+        nqubits = len(design.qubit_labels)
+        #let the dimension depend on the value of rtype.
+        if self.rtype == 'AGI':
+            dim = 2**nqubits
+        else:
+            raise ValueError('Only AGI type IRB numbers are currently implemented.')
+
+        irb_numbers = dict()
+        irb_bounds = dict()
+        #use the crb and icrb results to get the irb number and the bounds.
+        for fit_key in crb_results.fits.keys():
+            p_crb = crb_results.fits[fit_key].estimates['p']
+            p_icrb = icrb_results.fits[fit_key].estimates['p']
+            irb_numbers[fit_key] = ((dim-1)/dim)*(1-(p_icrb/p_crb))
+            #Magesan paper gives the bounds as the minimum of two quantities.
+            possible_bound_1 = ((dim-1)/dim) * (abs(p_crb - (p_icrb/p_crb)) + (1 - p_crb))
+            possible_bound_2 = (2*(dim**2-1)*(1-p_crb))/(p_crb*dim**2) + (4*_np.sqrt(1-p_crb)*_np.sqrt(dim**2 - 1))/p_crb
+            irb_bounds[fit_key] = min(possible_bound_1, possible_bound_2)
+        
+        children = {'crb': _proto.ProtocolResultsDir(data['crb'], crb_results),
+                    'icrb': _proto.ProtocolResultsDir(data['icrb'], icrb_results)}
+
+        irb_top_results = InterleavedRandomizedBenchmarkingResults(data, self, irb_numbers, irb_bounds)
+
+        return _proto.ProtocolResultsDir(data, irb_top_results, children = children)
+
+class InterleavedRandomizedBenchmarkingResults(_proto.ProtocolResults):
+    """
+    Class for storing the results of an interleaved randomized benchmarking experiment.
+    This subclasses off of ProtocolResultsDir as this class acts primarily as both a container
+    class for holding the two subexperiment's results, as well as containing some specialized
+    information regarding the IRB number estimates.
+    """
+
+    def __init__(self, data, protocol, irb_numbers, irb_bounds):
+        #msg = 'rb_subexperiment_results should be a dictionary with values corresponding to the'\
+        #      +' standard CRB and interleaved CRB subexperiments used in performing IRB.'
+        #assert(isinstance(rb_subexperiment_results, dict)), msg
+        #super().__init__(data, rb_subexperiment_results)
+        super().__init__(data, protocol)
+
+        self.irb_numbers = irb_numbers
+        self.irb_bounds = irb_bounds
 
 
 RB = RandomizedBenchmarking

--- a/pygsti/protocols/vb.py
+++ b/pygsti/protocols/vb.py
@@ -1014,17 +1014,6 @@ class ByDepthSummaryStatistics(SummaryStatistics):
             results.statistics[statistic_nm] = statistic_per_dwc
         return results
 
-# This is currently not used I think
-# class PredictedByDepthSummaryStatsConstructor(ByDepthSummaryStatsConstructor):
-#     """
-#     Runs a volumetric benchmark on success/fail data predicted from a model
-
-#     """
-#     def __init__(self, model_or_summary_data, depths='all', statistic='mean',
-#                  dscomparator=None, name=None):
-#         super().__init__(depths, 'success_probabilities', statistic,
-#                          dscomparator, model_or_summary_data, name)
-
 
 class SummaryStatisticsResults(_proto.ProtocolResults):
     """

--- a/pygsti/protocols/vb.py
+++ b/pygsti/protocols/vb.py
@@ -456,10 +456,6 @@ class PeriodicMirrorCircuitDesign(BenchmarkingDesign):
                                                                   self.descriptor)
 
 
-
-
-
-
 class SummaryStatistics(_proto.Protocol):
     """
     A protocol that can construct "summary" quantities from raw data.

--- a/pygsti/tools/nameddict.py
+++ b/pygsti/tools/nameddict.py
@@ -88,7 +88,7 @@ class NamedDict(dict, _NicelySerializable):
             #TODO: serialize via _to_memoized_dict once we have a base class
             if x is None or isinstance(x, (float, int, str)):
                 return x
-            elif isinstance(x, _np.int64):
+            elif isinstance(x, (_np.int64, _np.int32)):
                 return int(x)
             elif isinstance(x, _NicelySerializable):
                 return x.to_nice_serialization()

--- a/test/unit/protocols/test_rb.py
+++ b/test/unit/protocols/test_rb.py
@@ -376,14 +376,14 @@ class TestBiRBProtocol(BaseCase):
         
     def test_birb_protocol_ideal(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='energies', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data)
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
         
     def test_birb_protocol_noisy(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='energies', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data_noisy)
 
@@ -432,7 +432,7 @@ class TestCliffordRBProtocol(BaseCase):
         
     def test_cliffordrb_protocol_ideal(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data)
 
@@ -440,7 +440,7 @@ class TestCliffordRBProtocol(BaseCase):
         
     def test_cliffordrb_protocol_noisy(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data_noisy)
 
@@ -492,14 +492,14 @@ class TestDirectRBProtocol(BaseCase):
         
     def test_directrb_protocol_ideal(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data)
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
         
     def test_directrb_protocol_noisy(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data_noisy)
 
@@ -547,13 +547,13 @@ class TestMirrorRBProtocol(BaseCase):
         
     def test_mirrorrb_protocol_ideal(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='adjusted_success_probabilities', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data)
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
         
     def test_mirrorrb_protocol_noisy(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='adjusted_success_probabilities', defaultfit='A-fixed', rtype='EI',
-                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', square_mean_root=False, name=None)
+                 seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data_noisy)

--- a/test/unit/protocols/test_rb.py
+++ b/test/unit/protocols/test_rb.py
@@ -6,6 +6,8 @@ import pygsti
 from pygsti.protocols import rb as _rb
 from pygsti.processors import CliffordCompilationRules as CCR
 from pygsti.processors import QubitProcessorSpec as QPS
+from pygsti.circuits import Circuit
+from pygsti.baseobjs import Label
 
 class TestCliffordRBDesign(BaseCase):
 
@@ -43,15 +45,15 @@ class TestCliffordRBDesign(BaseCase):
         self.seed = 2021
         self.verbosity = 0
 
-    def test_design_construction(self):
+    def test_parallel_design_construction(self):
         num_mp_procs = 4
-        
-        serial_design = _rb.CliffordRBDesign(
+        crb_design = _rb.CliffordRBDesign(
             self.pspec, self.compilations, self.depths, self.circuits_per_depth, qubit_labels=self.qubits,
             randomizeout=self.randomizeout, interleaved_circuit=self.interleaved_circuit,
             citerations=self.citerations, compilerargs=self.compiler_args, seed=self.seed,
             verbosity=self.verbosity, num_processes=1)
-        
+
+
         # Test parallel circuit generation works and is seeded properly
         mp_design = _rb.CliffordRBDesign(
             self.pspec, self.compilations, self.depths, self.circuits_per_depth, qubit_labels=self.qubits,
@@ -59,13 +61,8 @@ class TestCliffordRBDesign(BaseCase):
             citerations=self.citerations, compilerargs=self.compiler_args, seed=self.seed,
             verbosity=self.verbosity, num_processes=num_mp_procs)
 
-        # for sd_circ, md_circ in zip(serial_design.all_circuits_needing_data, mp_design.all_circuits_needing_data):
-        #     if str(sd_circ) != str(md_circ):
-        #         print('Mismatch found!')
-        #         print('  Serial circuit:   ' + str(sd_circ))
-        #         print('  Parallel circuit: ' + str(md_circ))
 
-        self.assertTrue(all([str(sd) == str(md) for sd, md in zip(serial_design.all_circuits_needing_data,
+        self.assertTrue(all([str(sd) == str(md) for sd, md in zip(crb_design.all_circuits_needing_data,
                                                         mp_design.all_circuits_needing_data)]))
 
         tmodel = pygsti.models.create_crosstalk_free_model(self.pspec)
@@ -105,6 +102,75 @@ class TestCliffordRBDesign(BaseCase):
         avg_gate_counts = idle_design.average_native_gates_per_clifford()
         for v in avg_gate_counts.values():
             self.assertTrue(v == 0)
+
+    def test_serialization(self):
+
+        crb_design = _rb.CliffordRBDesign(
+            self.pspec, self.compilations, self.depths, self.circuits_per_depth, qubit_labels=self.qubits,
+            randomizeout=self.randomizeout, interleaved_circuit=Circuit([Label('Gxpi2', 'Q0')], line_labels=('Q0','Q1')),
+            citerations=self.citerations, compilerargs=self.compiler_args, seed=self.seed,
+            verbosity=self.verbosity, num_processes=1)
+
+        crb_design.write('../../test_packages/temp_test_files/test_CliffordRBDesign_serialization')
+        #then read this back in
+        crb_design_read = _rb.CliffordRBDesign.from_dir('../../test_packages/temp_test_files/test_CliffordRBDesign_serialization')
+
+        self.assertEqual(crb_design.all_circuits_needing_data, crb_design_read.all_circuits_needing_data)
+        self.assertEqual(crb_design.interleaved_circuit, crb_design_read.interleaved_circuit)
+
+class TestInterleavedRBDesign(BaseCase):
+
+    def setUp(self):
+        self.num_qubits = 2
+        self.qubit_labels = ['Q'+str(i) for i in range(self.num_qubits)]
+        
+        gate_names = ['Gi', 'Gxpi2', 'Gxmpi2', 'Gypi2', 'Gympi2', 'Gcphase']
+        availability = {'Gcphase':[('Q'+str(i),'Q'+str((i+1) % self.num_qubits)) for i in range(self.num_qubits)]}
+
+        self.pspec = pygsti.processors.QubitProcessorSpec(self.num_qubits, gate_names, availability=availability,
+                                                          qubit_labels=self.qubit_labels)
+        self.compilations = {
+            'absolute': CCR.create_standard(self.pspec, 'absolute', ('paulis', '1Qcliffords'), verbosity=0),
+            'paulieq': CCR.create_standard(self.pspec, 'paulieq', ('1Qcliffords', 'allcnots'), verbosity=0)
+        }
+
+        # TODO: Test a lot of these, currently just the default from the tutorial
+        # Probably as pytest mark parameterize for randomizeout, compilerargs?
+        self.depths = [0, 2]
+        self.circuits_per_depth = 5
+        self.qubits = ['Q0', 'Q1']
+        self.citerations = 20
+        self.randomizeout = False
+        self.interleaved_circuit = Circuit([Label('Gxpi2', 'Q0')], line_labels=('Q0','Q1'))
+        self.compiler_args = ()
+        self.seed = 2021
+        self.verbosity = 0
+
+        self.irb_design = _rb.InterleavedRBDesign(
+            self.pspec, self.compilations, self.depths, self.circuits_per_depth, self.interleaved_circuit, qubit_labels=self.qubits,
+            randomizeout=self.randomizeout,
+            citerations=self.citerations, compilerargs=self.compiler_args, seed=self.seed,
+            verbosity=self.verbosity, num_processes=1)
+
+    def test_combined_design_access(self):
+        assert(isinstance(self.irb_design['crb'], _rb.CliffordRBDesign))
+        assert(isinstance(self.irb_design['icrb'], _rb.CliffordRBDesign))
+        
+        self.assertEqual(set(self.irb_design.all_circuits_needing_data), 
+                         set(self.irb_design['crb'].all_circuits_needing_data)|  set(self.irb_design['icrb'].all_circuits_needing_data))
+    
+        self.assertEqual(self.irb_design['icrb'].interleaved_circuit, self.interleaved_circuit)
+
+    def test_serialization(self):
+
+        self.irb_design.write('../../test_packages/temp_test_files/test_InterleavedRBDesign_serialization')
+        #then read this back in
+        irb_design_read = _rb.InterleavedRBDesign.from_dir('../../test_packages/temp_test_files/test_InterleavedRBDesign_serialization')
+
+        self.assertEqual(self.irb_design.all_circuits_needing_data, irb_design_read.all_circuits_needing_data)
+        self.assertEqual(self.irb_design['crb'].all_circuits_needing_data, irb_design_read['crb'].all_circuits_needing_data)
+        self.assertEqual(self.irb_design['icrb'].all_circuits_needing_data, irb_design_read['icrb'].all_circuits_needing_data)
+        self.assertEqual(self.irb_design.interleaved_circuit, irb_design_read.interleaved_circuit)
 
 class TestDirectRBDesign(BaseCase):
 
@@ -155,12 +221,6 @@ class TestDirectRBDesign(BaseCase):
         tmodel = pygsti.models.create_crosstalk_free_model(self.pspec)
 
         [[self.assertAlmostEqual(c.simulate(tmodel)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(mp_design.circuit_lists, mp_design.idealout_lists)]
-        
-        # for sd_circ, md_circ in zip(serial_design.all_circuits_needing_data, mp_design.all_circuits_needing_data):
-        #     if str(sd_circ) != str(md_circ): print('MISMATCH!')
-        #     print('  Serial circuit:   ' + str(sd_circ))
-        #     print('  Parallel circuit: ' + str(md_circ))
-        #     print()
 
         #Print more debugging info since this test can fail randomly but we can't reproduce this.
         unequal_circuits = []
@@ -179,7 +239,20 @@ class TestDirectRBDesign(BaseCase):
 
         self.assertTrue(all([str(sd) == str(md) for sd, md in zip(serial_design.all_circuits_needing_data,
                                                                   mp_design.all_circuits_needing_data)]))
+        
+    def test_serialization(self):
 
+        drb_design = _rb.DirectRBDesign(self.pspec, self.compilations, self.depths, self.circuits_per_depth,
+            qubit_labels=self.qubits, sampler=self.sampler, samplerargs=self.samplerargs,
+            addlocal=False, lsargs=(), randomizeout=self.randomizeout, cliffordtwirl=True,
+            conditionaltwirl=True, citerations=self.citerations, compilerargs=self.compiler_args,
+            partitioned=False, seed=self.seed, verbosity=self.verbosity, num_processes=1)
+
+        drb_design.write('../../test_packages/temp_test_files/test_DirectRBDesign_serialization')
+        #then read this back in
+        drb_design_read = _rb.DirectRBDesign.from_dir('../../test_packages/temp_test_files/test_DirectRBDesign_serialization')
+
+        self.assertEqual(drb_design.all_circuits_needing_data, drb_design_read.all_circuits_needing_data)
 
 class TestMirrorRBDesign(BaseCase):
 
@@ -222,12 +295,6 @@ class TestMirrorRBDesign(BaseCase):
             sampler=self.sampler, samplerargs=self.samplerargs,
             localclifford=True, paulirandomize=True, seed=self.seed, verbosity=self.verbosity,
             num_processes=num_mp_procs)
-
-        # for sd_circ, md_circ in zip(serial_design.all_circuits_needing_data, mp_design.all_circuits_needing_data):
-        #     if str(sd_circ) != str(md_circ): print('MISMATCH!')
-        #     print('  Serial circuit:   ' + str(sd_circ))
-        #     print('  Parallel circuit: ' + str(md_circ))
-        #     print()
             
         self.assertTrue(all([str(sd) == str(md) for sd, md in zip(serial_design.all_circuits_needing_data,
                                                         mp_design.all_circuits_needing_data)]))
@@ -248,7 +315,7 @@ class TestMirrorRBDesign(BaseCase):
 
         clifford_compilations = {'absolute': CCR.create_standard(pspec1, 'absolute', ('paulis', '1Qcliffords'), verbosity=0)}
 
-        design1 = pygsti.protocols.MirrorRBDesign(pspec1, depths, 3, qubit_labels=q_set, circuit_type='clifford',
+        design1 = _rb.MirrorRBDesign(pspec1, depths, 3, qubit_labels=q_set, circuit_type='clifford',
                                         clifford_compilations=clifford_compilations, sampler='edgegrab', samplerargs=(0.25,),
                                         localclifford=True, paulirandomize=True, descriptor='A mirror RB experiment',
                                         add_default_protocol=False, seed=None, num_processes=1, verbosity=0)
@@ -269,7 +336,7 @@ class TestMirrorRBDesign(BaseCase):
         q_set = ('Q0', 'Q1')
 
 
-        design2 = pygsti.protocols.MirrorRBDesign(pspec2, depths, 3, qubit_labels=q_set, circuit_type='clifford+zxzxz-haar',
+        design2 = _rb.MirrorRBDesign(pspec2, depths, 3, qubit_labels=q_set, circuit_type='clifford+zxzxz-haar',
                                        clifford_compilations=None, sampler='edgegrab', samplerargs=(0.25,),
                                        localclifford=True, paulirandomize=True, descriptor='A mirror RB experiment',
                                        add_default_protocol=False, seed=None, num_processes=1, verbosity=0)
@@ -291,13 +358,28 @@ class TestMirrorRBDesign(BaseCase):
         q_set = ('Q0', 'Q1')
 
         
-        design3 = pygsti.protocols.MirrorRBDesign(pspec3, depths, 3, qubit_labels=q_set, circuit_type='cz(theta)+zxzxz-haar',
+        design3 = _rb.MirrorRBDesign(pspec3, depths, 3, qubit_labels=q_set, circuit_type='cz(theta)+zxzxz-haar',
                                        clifford_compilations=None, sampler='edgegrab', samplerargs=(0.25,),
                                        localclifford=True, paulirandomize=True, descriptor='A mirror RB experiment',
                                        add_default_protocol=False, seed=None, num_processes=1, verbosity=0)
 
 
         [[self.assertAlmostEqual(c.simulate(tmodel3)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(design3.circuit_lists, design3.idealout_lists)]
+
+
+    def test_serialization(self):
+
+        mrb_design = _rb.MirrorRBDesign(self.pspec, self.depths, self.circuits_per_depth,
+            qubit_labels=self.qubits, circuit_type=self.circuit_type, clifford_compilations=self.clifford_compilations,
+            sampler=self.sampler, samplerargs=self.samplerargs,
+            localclifford=True, paulirandomize=True, seed=self.seed, verbosity=self.verbosity,
+            num_processes=1)
+
+        mrb_design.write('../../test_packages/temp_test_files/test_MirrorRBDesign_serialization')
+        #then read this back in
+        mrb_design_read = _rb.MirrorRBDesign.from_dir('../../test_packages/temp_test_files/test_MirrorRBDesign_serialization')
+
+        self.assertEqual(mrb_design.all_circuits_needing_data, mrb_design_read.all_circuits_needing_data)
 
 class TestBiRBDesign(BaseCase):
 
@@ -335,6 +417,18 @@ class TestBiRBDesign(BaseCase):
                                                  self.circuits_per_depth, qubit_labels=self.qubits, layer_sampling='alternating1q2q',
                                                  sampler=self.sampler, samplerargs=self.samplerargs, 
                                                  seed=self.seed, verbosity=0)
+        
+    def test_serialization(self):
+        birb_design = pygsti.protocols.BinaryRBDesign(self.pspec, self.clifford_compilations, self.depths, 
+                                                 self.circuits_per_depth, qubit_labels=self.qubits, layer_sampling='mixed1q2q',
+                                                 sampler=self.sampler, samplerargs=self.samplerargs, 
+                                                 seed=self.seed, verbosity=0)
+        
+        birb_design.write('../../test_packages/temp_test_files/test_BinaryRBDesign_serialization')
+        #then read this back in
+        birb_design_read = _rb.BinaryRBDesign.from_dir('../../test_packages/temp_test_files/test_BinaryRBDesign_serialization')
+
+        self.assertEqual(birb_design.all_circuits_needing_data, birb_design_read.all_circuits_needing_data)
         
 class TestBiRBProtocol(BaseCase):
     def setUp(self):
@@ -437,6 +531,10 @@ class TestCliffordRBProtocol(BaseCase):
         result = proto.run(self.data)
 
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
+
+        #also test writing and reading the results from disk.
+        result.write('../../test_packages/temp_test_files/test_RandomizedBenchmarking_results')
+        result_read = pygsti.io.read_results_from_dir('../../test_packages/temp_test_files/test_RandomizedBenchmarking_results')
         
     def test_cliffordrb_protocol_noisy(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
@@ -557,3 +655,64 @@ class TestMirrorRBProtocol(BaseCase):
                  seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
         
         result = proto.run(self.data_noisy)
+
+
+class TestInterleavedRBProtocol(BaseCase):
+    def setUp(self):
+        n_qubits = 1
+        qubit_labels = ['Q0']
+        gate_names = ['Gxpi2', 'Gxmpi2', 'Gypi2', 'Gympi2']
+        pspec = QPS(n_qubits, gate_names, qubit_labels=qubit_labels)
+        compilations = {'absolute': CCR.create_standard(pspec, 'absolute', ('paulis', '1Qcliffords'), verbosity=0),            
+                        'paulieq': CCR.create_standard(pspec, 'paulieq', ('1Qcliffords', 'allcnots'), verbosity=0)}
+        interleaved_circuit = Circuit([Label('Gxpi2', 'Q0')], line_labels=('Q0',))
+
+        # TODO: Test a lot of these, currently just the default from the tutorial
+        depths = [0, 1, 2, 4, 8, 16, 32]
+        circuits_per_depth = 30
+        citerations = 20
+        randomizeout = False
+        compiler_args = ()
+        seed = 1234
+        verbosity = 0
+
+        self.design = _rb.InterleavedRBDesign(pspec, compilations, depths, circuits_per_depth, interleaved_circuit, qubit_labels,
+                                           randomizeout=randomizeout, citerations=citerations, compilerargs=compiler_args, seed=seed,
+                                           verbosity=verbosity, num_processes=1)
+        
+        self.target_model =  pygsti.models.create_crosstalk_free_model(pspec)
+        self.target_model.sim = 'map'
+        depolarization_strengths={g:0.01 for g in pspec.gate_names if g!= 'Gxpi2'}
+        depolarization_strengths['Gxpi2'] = .02
+        self.noisy_model =  pygsti.models.create_crosstalk_free_model(pspec, depolarization_strengths=depolarization_strengths)
+        self.noisy_model.sim = 'map'
+        self.ds = pygsti.data.datasetconstruction.simulate_data(self.target_model, self.design.all_circuits_needing_data, 
+                                                                num_samples = 1000, seed=seed)
+        self.ds_noisy = pygsti.data.datasetconstruction.simulate_data(self.noisy_model, self.design.all_circuits_needing_data, 
+                                                                num_samples = 1000, seed=seed)
+        
+        self.data = pygsti.protocols.ProtocolData(self.design, self.ds)
+        self.data_noisy = pygsti.protocols.ProtocolData(self.design, self.ds_noisy)
+        
+    def test_interleavedrb_protocol_ideal(self):
+        #running with all default settings
+        proto = _rb.InterleavedRandomizedBenchmarking()
+        
+        result = proto.run(self.data)
+        estimated_irb_num = result.for_protocol['InterleavedRandomizedBenchmarking'].irb_numbers['full'] 
+        self.assertTrue(abs(estimated_irb_num) <= 1e-5)
+
+        #also test writing and reading the results from disk.
+        result.write('../../test_packages/temp_test_files/test_InterleavedRandomizedBenchmarking_results')
+        result_read = pygsti.io.read_results_from_dir('../../test_packages/temp_test_files/test_InterleavedRandomizedBenchmarking_results')
+        
+        
+    def test_interleavedrb_protocol_noisy(self):
+        #running with all default settings
+        proto = _rb.InterleavedRandomizedBenchmarking()
+        
+        result = proto.run(self.data_noisy)
+        estimated_irb_num = result.for_protocol['InterleavedRandomizedBenchmarking'].irb_numbers['full'] 
+        print(result.for_protocol['InterleavedRandomizedBenchmarking'].irb_numbers)
+
+        self.assertTrue(abs(estimated_irb_num-.02) <= 5e-3)


### PR DESCRIPTION
This PR adds first party support for interleaved randomized benchmarking (as described in the original 2012 paper from Magesan et al. https://arxiv.org/pdf/1203.4550) to the RB codebase. The analysis for IRB is incredibly simple, so from an implementation standpoint much of what has been added is aimed at streamlining the experiment design construction process, automating this analysis, and creating data structures for keeping the two relevant subexperiments stored together.

Specifically I have added the following:

1. `InterleavedRBDesign`: This class both performs the creation of the two subexperiment designs (a standard CRB experiment and one with a target gate interleaved between random cliffords) and acts as a container for these two experiment designs. This subclasses off of `CombinedExperimentDesign` which allows for use to index into each of the subdesigns as well as interact with them jointly (getting the combined `all_circuits_needing_data` value at data collection time, for example).
2. `InterleavedRandomizedBenchmarking`: This is a new protocol class which farms off the RB estimation for each of the subexperiments to `RandomizedBenchmarking` and then extracts the relevant results for calculating the IRB numbers and bounds. This returns a `ProtocolResultsDir` containing the IRB specific results along with the full results for each of the subexperiments.
3. `InterleavedRandomizedBenchmarkingResults`: This is a simple (mostly data) class for storing the IRB results at the top node of the aforementioned `ProtocolResultsDir`.

Aside from the code described above I have also added a new section to the Clifford RB tutorial notebook demonstrating the use of the new functionality. Also included are new unit tests, both for the IRB features added and for improving testing coverage on existing parts RB (particularly with regards to serialization). Lastly, there is a bug fix for a reported issue where serialization of CliffordRBDesign was failing when constructed using the (previously undocumented) `interleaved_circuit` kwarg.

Big thanks go out to @jordanh6 and @enielse for their valuable advice in the achitecting of these additions, and to @jordanh6 and @tjproct for their guidance on the IRB theory.