### PR TITLE
Bugfix reparameterize

### DIFF
--- a/pygsti/modelmembers/states/__init__.py
+++ b/pygsti/modelmembers/states/__init__.py
@@ -266,8 +266,8 @@ def convert(state, to_type, basis, ideal_state=None, flatten_structure=False):
                         errorgen.from_vector(v)
                         return _np.linalg.norm(_spl.expm(errorgen.to_dense()) @ dense_st - dense_state)
                     #def callback(x): print("callbk: ",_np.linalg.norm(x),_objfn(x))  # REMOVE
-                    soln = _spo.minimize(_objfn, _np.zeros(errorgen.num_params, 'd'), method="CG", options={},
-                                         tol=1e-8)  # , callback=callback)
+                    soln = _spo.minimize(_objfn, _np.zeros(errorgen.num_params, 'd'), method="Nelder-Mead", options={},
+                                         tol=1e-12)  # , callback=callback)
                     #print("DEBUG: opt done: ",soln.success, soln.fun, soln.x)  # REMOVE
                     if not soln.success and soln.fun > 1e-6:  # not "or" because success is often not set correctly
                         raise ValueError("Failed to find an errorgen such that exp(errorgen)|ideal> = |state>")

--- a/pygsti/models/modelparaminterposer.py
+++ b/pygsti/models/modelparaminterposer.py
@@ -66,7 +66,7 @@ class LinearInterposer(ModelParamsInterposer):
         self.transform_matrix = transform_matrix  # cols specify a model parameter in terms of op params.
         self.inv_transform_matrix = _np.linalg.pinv(self.transform_matrix)
         super().__init__(transform_matrix.shape[1], transform_matrix.shape[0])
-
+    
     def model_paramvec_to_ops_paramvec(self, v):
         return _np.dot(self.transform_matrix, v)
 


### PR DESCRIPTION
convert() function has been changed for POVM elements and state preparation. They now support proper conversion from full TP to GLND parameterization. The optimization is now done over non-gauge directions, which are found through Jacobians.

This function still needs to be changed to appropriately handle other reparameterizations. 

Lastly, this is not guaranteed to work for POVMs, just because the number of degrees of freedom of a POVM can be greater than the number of error generators that span TP maps for a given number of qubits. By pigeon hole principle, we may not be able to find a description for a POVM consisting of Ideal_POVM + error generators.

