### PR TITLE
Bugfix esplodeded fogi labels

### DIFF
--- a/pygsti/models/model.py
+++ b/pygsti/models/model.py
@@ -489,6 +489,13 @@ class OpModel(Model):
     ##########################################
 
     @property
+    def parameter_labels(self):
+        """
+        A list of labels, usually of the form `(op_label, string_description)` describing this model's parameters.
+        """
+        return self._ops_paramlbls_to_model_paramlbls(self._paramlbls)
+
+    @property
     def sim(self):
         """ Forward simulator for this model """
         self._clean_paramvec()  # clear opcache and rebuild paramvec when needed
@@ -1037,7 +1044,7 @@ class OpModel(Model):
                 obj.set_gpindices(new_inds, self, memo)
 
         self._paramvec = self._ops_paramvec_to_model_paramvec(w)
-        self._paramlbls = self._ops_paramlbls_to_model_paramlbls(wl)
+        self._paramlbls = wl
         self._param_bounds = wb if _param_bounds_are_nontrivial(wb) else None
         if debug: print("DEBUG: Done rebuild: %d op params" % len(w))
 

--- a/pygsti/models/modelparaminterposer.py
+++ b/pygsti/models/modelparaminterposer.py
@@ -77,7 +77,7 @@ class LinearInterposer(ModelParamsInterposer):
         # This can and should be improved later - particularly this will be awful when labels (els of wl) are tuples.
         ret = []
         for irow in range(self.inv_transform_matrix.shape[0]):
-            lbl = ' + '.join(["%g%s" % (coeff, str(lbl)) for coeff, lbl in zip(self.inv_transform_matrix[irow, :], wl)])
+            lbl = ' + '.join(["%g%s" % (coeff, str(lbl)) for coeff, lbl in zip(self.inv_transform_matrix[irow, :], wl) if abs(coeff)>1e-10])
             ret.append(lbl)
         return ret
 

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1133,6 +1133,9 @@ class GSTGaugeOptSuite(_NicelySerializable):
             for lbl, goparams in self.gaugeopt_argument_dicts.items():
                 goparams_list = [goparams] if hasattr(goparams, 'keys') else goparams
                 serialize_list = []
+                if lbl == 'trivial_gauge_opt':
+                    dicts_to_serialize[lbl] = None
+                    continue
                 for goparams_dict in goparams_list:
                     to_add = goparams_dict.copy()
                     if 'target_model' in to_add:
@@ -1164,6 +1167,9 @@ class GSTGaugeOptSuite(_NicelySerializable):
     def _from_nice_serialization(cls, state):  # memo holds already de-serialized objects
         gaugeopt_argument_dicts = {}
         for lbl, serialized_goparams_list in state['gaugeopt_argument_dicts'].items():
+            if lbl == 'trivial_gauge_opt':
+                gaugeopt_argument_dicts[lbl] = None
+                continue
             goparams_list = []
             for serialized_goparams in serialized_goparams_list:
                 to_add = serialized_goparams.copy()


### PR DESCRIPTION
This PR fixes two bugs. The first was reported here: #486, and was related to the parameter label management when using parameter interposers. Previously the behavior in the `OpModel` method `_rebuild_paramvec` resulted in the model's parameter label vector being set to the output of `_ops_paramlbls_to_model_paramlbls`. What would happen though is that on subsequent calls to `_rebuild_paramvec` that same output would get passed through the same method (growing larger in size each time) until the size of the labels exploded and memory ran out. The changes the behavior of the parameter label management and makes it so that the value of the internal `_paramlbls` vector is always that of the operations (modulo any parameter collection). When querying the value of the `parameter_labels` property for `OpModel` we now call `_ops_paramlbls_to_model_paramlbls` on the fly and return that value, so to the end-user they should see the same thing they are used to (but there may still be edge cases).

Unrelated to that bug, in the same context where the bug above arose I ran into another related to json serializing `GSTGaugeOptSuite` objects when the 'none' gauge optimization suite option was used, which should be fixed with this patch.
