### PR TITLE
Bugfix guard signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ doc/build
 *gst_checkpoints*
 *model_test_checkpoints*
 *standard_gst_checkpoints*
+*ibmqexperiment_checkpoint*
 
 # Serialization Testing Artifacts #
 ###################################
@@ -43,6 +44,7 @@ test/output/pylint/*
 test/output/individual_coverage/*/*
 test/test_packages/cmp_chk_files/Fake_Dataset_none.txt.cache
 **.noseids
+**test_ibmq**
 
 # Tutorial Notebook Untracked Files #
 ####################################

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -3447,7 +3447,7 @@ class Circuit(object):
         """
         if self._static:
             def cnt(lbl):  # obj a Label, perhaps compound
-                if lbl.is_simple():  # a simple label
+                if lbl.IS_SIMPLE:  # a simple label
                     return 1 if (lbl.sslbls is not None) else 0
                 else:
                     return sum([cnt(sublbl) for sublbl in lbl.components])

--- a/pygsti/optimize/customlm.py
+++ b/pygsti/optimize/customlm.py
@@ -10,6 +10,7 @@ Custom implementation of the Levenberg-Marquardt Algorithm
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+import os as _os
 import signal as _signal
 import time as _time
 
@@ -25,7 +26,10 @@ from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySeri
 # from scipy.optimize import OptimizeResult as _optResult
 
 #Make sure SIGINT will generate a KeyboardInterrupt (even if we're launched in the background)
-_signal.signal(_signal.SIGINT, _signal.default_int_handler)
+#This may be problematic for multithreaded parallelism above pyGSTi, e.g. Dask,
+#so this can be turned off by setting the PYGSTI_NO_CUSTOMLM_SIGINT environment variable
+if 'PYGSTI_NO_CUSTOMLM_SIGINT' in _os.environ:
+    _signal.signal(_signal.SIGINT, _signal.default_int_handler)
 
 #constants
 _MACH_PRECISION = 1e-12

--- a/pygsti/optimize/customlm.py
+++ b/pygsti/optimize/customlm.py
@@ -28,7 +28,7 @@ from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySeri
 #Make sure SIGINT will generate a KeyboardInterrupt (even if we're launched in the background)
 #This may be problematic for multithreaded parallelism above pyGSTi, e.g. Dask,
 #so this can be turned off by setting the PYGSTI_NO_CUSTOMLM_SIGINT environment variable
-if 'PYGSTI_NO_CUSTOMLM_SIGINT' in _os.environ:
+if 'PYGSTI_NO_CUSTOMLM_SIGINT' not in _os.environ:
     _signal.signal(_signal.SIGINT, _signal.default_int_handler)
 
 #constants


### PR DESCRIPTION
Small bugfixes:

- Guarding setting SIGINT via `signal` in the customlm code. Needed in order to use pyGSTi with some external parallelization frameworks, such as Dask.
- Fixing unit tests by including a `Label.is_simple()` to `Label.IS_SIMPLE` that was missed.