### PR TITLE
Fix docstrings and gate attribute

### DIFF
--- a/pygsti/modelpacks/smq2Q_XY.py
+++ b/pygsti/modelpacks/smq2Q_XY.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CPHASE.
+I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
@@ -17,9 +17,9 @@ from pygsti.modelpacks._modelpack import GSTModelPack
 
 
 class _Module(GSTModelPack):
-    description = "I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CPHASE gates"
+    description = "I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I"
 
-    gates = [('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gcphase', 0, 1)]
+    gates = [('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0)]
 
     _sslbls = (0, 1)
 

--- a/pygsti/modelpacks/smq2Q_XYI.py
+++ b/pygsti/modelpacks/smq2Q_XYI.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CPHASE.
+I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and Idle.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
@@ -19,7 +19,7 @@ from pygsti.modelpacks._modelpack import GSTModelPack
 
 
 class _Module(GSTModelPack):
-    description = "I*I, I*X(pi/2), I*Y(pi/2), X(pi/2)*I, and Y(pi/2)*I gates"
+    description = "I*I, I*X(pi/2), I*Y(pi/2), X(pi/2)*I, and Y(pi/2)*I gates and Idle"
 
     gates = [(), ('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0)]
 

--- a/pygsti/modelpacks/smq2Q_XYICNOT.py
+++ b/pygsti/modelpacks/smq2Q_XYICNOT.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CNOT.
+I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, CNOT and idle.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
@@ -17,9 +17,9 @@ from pygsti.modelpacks._modelpack import GSTModelPack
 
 
 class _Module(GSTModelPack):
-    description = "I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CNOT gates"
+    description = "I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, CNOT and idle gates"
 
-    gates = [('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gcnot', 0, 1)]
+    gates = [(), ('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gcnot', 0, 1)]
 
     _sslbls = (0, 1)
 

--- a/pygsti/modelpacks/smq2Q_XYICPHASE.py
+++ b/pygsti/modelpacks/smq2Q_XYICPHASE.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CPHASE.
+I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, CPHASE, and idle.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
@@ -17,9 +17,9 @@ from pygsti.modelpacks._modelpack import GSTModelPack
 
 
 class _Module(GSTModelPack):
-    description = "I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, and CPHASE gates"
+    description = "I*X(pi/2), I*Y(pi/2), X(pi/2)*I, Y(pi/2)*I, CPHASE and idle gates"
 
-    gates = [('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gcphase', 0, 1)]
+    gates = [(), ('Gxpi2', 1), ('Gypi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gcphase', 0, 1)]
 
     _sslbls = (0, 1)
 

--- a/pygsti/modelpacks/smq2Q_XYZICNOT.py
+++ b/pygsti/modelpacks/smq2Q_XYZICNOT.py
@@ -2,7 +2,7 @@
 A standard multi-qubit gate set module.
 
 Variables for working with the 2-qubit model containing the gates
-I*X(pi/2), I*Y(pi/2), I*Z(pi/2), X(pi/2)*I, Y(pi/2)*I, Z(pi/2)*I and CNOT.
+I*X(pi/2), I*Y(pi/2), I*Z(pi/2), X(pi/2)*I, Y(pi/2)*I, Z(pi/2)*I, CNOT and idle.
 """
 #***************************************************************************************************
 # Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
@@ -17,9 +17,9 @@ from pygsti.modelpacks._modelpack import GSTModelPack
 
 
 class _Module(GSTModelPack):
-    description = "I*X(pi/2), I*Y(pi/2), I*Z(pi/2), X(pi/2)*I, Y(pi/2)*I, Z(pi/2)*I and CNOT gates"
+    description = "I*X(pi/2), I*Y(pi/2), I*Z(pi/2), X(pi/2)*I, Y(pi/2)*I, Z(pi/2)*I, CNOT and idle gates"
 
-    gates = [('Gxpi2', 1), ('Gypi2', 1), ('Gzpi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gzpi2', 0), ('Gcnot', 0, 1)]
+    gates = [(), ('Gxpi2', 1), ('Gypi2', 1), ('Gzpi2', 1), ('Gxpi2', 0), ('Gypi2', 0), ('Gzpi2', 0), ('Gcnot', 0, 1)]
 
     _sslbls = (0, 1)
 


### PR DESCRIPTION
This PR fixes some mismatches between the documentation for some of the two-qubit modelpacks, as well as the gate list attribute, and their actual contents.

This issue was reported in #497. Thanks to @eendebakpt for bringing the issue to our attention!

