### PR TITLE
CPTP Serialization Sign Change Fix

### DIFF
--- a/test/test_packages/drivers/test_drivers.py
+++ b/test/test_packages/drivers/test_drivers.py
@@ -312,15 +312,12 @@ class TestDriversMethods(DriversTestCase):
                                                                   advanced_options= {'max_iterations':3})
 
         #Assert that this gives the same result as before:
-        #diff = norm(result_standardgst.estimates['CPTPLND'].models['final iteration estimate'].to_vector()- 
-        #                 result_standardgst_warmstart.estimates['CPTPLND'].models['final iteration estimate'].to_vector())
-        diff = pygsti.tools.logl(result_standardgst.estimates['CPTPLND'].models['final iteration estimate'], ds)- \
-               pygsti.tools.logl(result_standardgst_warmstart.estimates['CPTPLND'].models['final iteration estimate'], ds)
-               
+        diff = norm(result_standardgst.estimates['CPTPLND'].models['final iteration estimate'].to_vector()- 
+                         result_standardgst_warmstart.estimates['CPTPLND'].models['final iteration estimate'].to_vector())               
         diff1 = norm(result_standardgst.estimates['full TP'].models['final iteration estimate'].to_vector()- 
                      result_standardgst_warmstart.estimates['full TP'].models['final iteration estimate'].to_vector())
         
-        self.assertTrue(abs(diff)<=1e-6)
+        self.assertTrue(abs(diff)<=1e-10)
         self.assertTrue(diff1<=1e-10)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a bug/unexpected behavior in the serialization/deserialization of CPTP parameterized models which use the cholesky decomposition to store the values of the SCA coefficient block. Due to sign ambiguity it was the case that serializing and deserializing a model could result in a sign change for some parameters. While this wasn't necessarily wrong (both choices of sign map to the same operation), not being able to rely on these being the same could lead to weird edge cases and unexpected behavior. This addresses that by adding the parameter value attribute for the error generator to the serialized json.

Fixes issue #341.