### PR TITLE
Fixes array-dimension bug within LindbladCoefficientBlock.superop_hessian_wrt_params()

### DIFF
--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -1124,7 +1124,10 @@ class LindbladCoefficientBlock(_NicelySerializable):
             if self._param_mode == "cholesky":
                 if superops_are_flat:  # then un-flatten
                     superops = superops.reshape((num_bels, num_bels, superops.shape[1], superops.shape[2]))
-                d2Odp2 = _np.zeros([superops.shape[2], superops.shape[3], nP, nP, nP, nP], 'complex')
+                sqrt_nP = _np.sqrt(nP)
+                snP = int(sqrt_nP)
+                assert snP == sqrt_nP == num_bels
+                d2Odp2 = _np.zeros([superops.shape[2], superops.shape[3], snP, snP, snP, snP], 'complex')
                 # yikes! maybe make this SPARSE in future?
 
                 #Note: correspondence w/Erik's notes: a=alpha, b=beta, q=gamma, r=delta
@@ -1136,11 +1139,11 @@ class LindbladCoefficientBlock(_NicelySerializable):
                         parameter indices s.t. ab > base and qr > base.  If
                         ab_inc_eq == True then the > becomes a >=, and likewise
                         for qr_inc_eq.  Used for looping over nonzero hessian els. """
-                    for _base in range(nP):
+                    for _base in range(snP):
                         start_ab = _base if ab_inc_eq else _base + 1
                         start_qr = _base if qr_inc_eq else _base + 1
-                        for _ab in range(start_ab, nP):
-                            for _qr in range(start_qr, nP):
+                        for _ab in range(start_ab, snP):
+                            for _qr in range(start_qr, snP):
                                 yield (_base, _ab, _qr)
 
                 for base, a, q in iter_base_ab_qr(True, True):  # Case1: base=b=r, ab=a, qr=q
@@ -1153,7 +1156,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
                     d2Odp2[:, :, base, b, base, r] = superops[b, r] + superops[r, b]
 
             elif self._param_mode == 'elements':  # unconstrained
-                d2Odp2 = _np.zeros([superops.shape[2], superops.shape[3], nP, nP, nP, nP], 'd')  # all params linear
+                d2Odp2 = _np.zeros([superops.shape[2], superops.shape[3], snP, snP, snP, snP], 'd')  # all params linear
             else:
                 raise ValueError("Internal error: invalid parameter mode (%s) for block type %s!"
                                  % (self._param_mode, self._block_type))


### PR DESCRIPTION
This code hasn't been accessed much or at all recently, and it's likely when we refactored code to create the `LindbladCoefficientBlock` a long time ago this function was incorrectly updated to use the full number of parameters in places where it should have used the square root of this number (!).  This commit fixes this error and allows `superop_hessian_wrt_params` to run at least without getting IndexErrors.

The code is also validated by giving very close output to the same call using the non-dense evotype code.  Specifically, I ran this:
```
import pygsti
import numpy as np

from pygsti.modelpacks import smq1Q_XY
from pygsti.evotypes import Evotype

circuits = smq1Q_XY.create_gst_experiment_design(1).all_circuits_needing_data
test_circuit = circuits[-1]

target_model = smq1Q_XY.target_model('CPTPLND', evotype=Evotype.cast('densitymx', True))
target_model.sim = 'matrix'
hprobs1 = target_model.sim.hprobs(test_circuit)

target_model = smq1Q_XY.target_model('CPTPLND', evotype=Evotype.cast('densitymx', False))
target_model.sim = 'matrix'
hprobs2 = target_model.sim.hprobs(test_circuit)

for outcome in hprobs1:
    print(f"{outcome}: Rel error = {np.linalg.norm(hprobs1[outcome] - hprobs2[outcome])/np.linalg.norm(hprobs1[outcome])}")
```

and got results:
```
('0',): Rel error = 6.995624265810122e-05
('1',): Rel error = 6.995624265810122e-05
```
which seems pretty decent?

@coreyostrove will be interested in this.