### PR TITLE
Resolve deprecation warning for use of _np.math.log.

### DIFF
--- a/pygsti/circuits/cloudcircuitconstruction.py
+++ b/pygsti/circuits/cloudcircuitconstruction.py
@@ -2164,7 +2164,7 @@ def _get_kcoverage_template_k2(n):
     def invert(bstr):
         return [(0 if x else 1) for x in bstr]
 
-    half = [bitstr(n, k) for k in range(int(_np.ceil(_np.math.log(n, 2))))]
+    half = [bitstr(n, k) for k in range(int(_np.ceil(_np.log2(n))))]
     other_half = [invert(bstr) for bstr in half]
     return half + other_half
 


### PR DESCRIPTION
If you run the tests under test_packages you'll see a deprecation warning of the following form
```
test/test_packages/drivers/test_nqubit.py: 22 warnings
  /Users/rjmurr/Documents/pygsti-general/pyGSTi/pygsti/circuits/cloudcircuitconstruction.py:2167: DeprecationWarning: `np.math` is a deprecated alias for the standard library `math` module (Deprecated Numpy 1.25). Replace usages of `np.math` with `math`
    half = [bitstr(n, k) for k in range(int(_np.ceil(_np.math.log(n, 2))))]
```
This tiny PR resolves this issue by replacing ``_np.math.log(n, 2)`` with ``_np.log2(n)``.