### PR TITLE
Fix DataSet.add_count_list() outcome label misordering

### DIFF
--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -1488,7 +1488,7 @@ class DataSet(_MongoSerializable):
         #unsafe=True OK b/c outcome_label_list contains the keys of an OutcomeLabelDict
 
     def add_count_list(self, circuit, outcome_labels, counts, record_zero_counts=True,
-                       aux=None, update_ol=True, unsafe=False):
+                       aux=None, update_ol=True):
         """
         Add a single circuit's counts to this DataSet
 
@@ -1515,30 +1515,12 @@ class DataSet(_MongoSerializable):
         update_ol : bool, optional
             This argument is for internal use only and should be left as True.
 
-        unsafe : bool, optional
-            `True` means that `outcome_labels` is guaranteed to hold tuple-type
-            outcome labels and never plain strings.  Only set this to `True` if
-            you know what you're doing.
-
         Returns
         -------
         None
         """
-        if self.bStatic: raise ValueError("Cannot add data to a static DataSet object")
-        circuit = self._collisionaction_update_circuit(circuit)
-
-        if self.collisionAction == "aggregate" and circuit in self:
-            iNext = int(max(self[circuit].time)) + 1 \
-                if (len(self[circuit].time) > 0) else 0
-            timeStampList = [iNext] * len(counts)
-            overwriteExisting = False
-        else:
-            timeStampList = [0] * len(counts)
-            overwriteExisting = True
-
-        self.add_raw_series_data(circuit, outcome_labels, timeStampList,
-                                 counts, overwriteExisting, record_zero_counts,
-                                 aux, update_ol, unsafe=unsafe)
+        count_dict = {ol: count for ol, count in zip(outcome_labels, counts)}
+        self.add_count_dict(circuit, count_dict, record_zero_counts, aux, update_ol)
 
     def add_count_arrays(self, circuit, outcome_index_array, count_array,
                          record_zero_counts=True, aux=None):

--- a/pygsti/io/stdinput.py
+++ b/pygsti/io/stdinput.py
@@ -525,7 +525,7 @@ class StdInputParser(object):
                         looking_for = "circuit_line"
                         if ignore_zero_count_lines is False and last_circuit is not None:
                             dataset.add_count_list(last_circuit, [], [], aux=last_commentDict,
-                                                   record_zero_counts=record_zero_counts, update_ol=False, unsafe=True)
+                                                   record_zero_counts=record_zero_counts, update_ol=False)
 
                 if looking_for == "circuit_line":
                     if len(dataline) == 0: continue


### PR DESCRIPTION
This fixes #535 by having `add_count_list` call `add_count_dict`, which handles the outcome label sorting properly. This has the advantage of minimizing code duplication before the `add_raw_series_data` call.

I have not migrated `add_count_arrays` because that uses `add_raw_arrays` instead, but in principle it can also be transition to use `add_count_dict` and therefore centralize all the `collisionAction == "aggregate"` code.