### PR TITLE
Bugfixes for PGG FPR and Germ Selection

### DIFF
--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -19,22 +19,20 @@ import scipy.special as _spspecial
 import scipy.linalg as _sla
 
 from math import ceil
-import time
 
 from pygsti import baseobjs as _baseobjs
 from pygsti import circuits as _circuits
 
 from pygsti.circuits import circuitconstruction as _gsc
 from pygsti.modelmembers.operations import EigenvalueParamDenseOp as _EigenvalueParamDenseOp
-from pygsti.tools import apply_aliases_to_circuits as _apply_aliases_to_circuits
 from pygsti.tools import remove_duplicates as _remove_duplicates
 from pygsti.tools import slicetools as _slct
 from pygsti.tools.legacytools import deprecate as _deprecated_fn
+from pygsti.forwardsims import MatrixForwardSimulator as _MatrixForwardSimulator
 
-from pygsti.algorithms.germselection import construct_update_cache, minamide_style_inverse_trace, compact_EVD, compact_EVD_via_SVD, germ_set_spanning_vectors
+from pygsti.algorithms.germselection import construct_update_cache, minamide_style_inverse_trace, compact_EVD, germ_set_spanning_vectors
 from pygsti.algorithms import scoring as _scoring
 
-from pygsti.tools.matrixtools import print_mx
 
 import warnings
 
@@ -1657,6 +1655,10 @@ def find_sufficient_fiducial_pairs_per_germ_global(target_model, prep_fiducials,
         list of fiducial pairs for a particular germ (indices are into
         `prep_fiducials` and `meas_fiducials`).
     """
+
+    if not isinstance(target_model.sim, _MatrixForwardSimulator):
+        target_model = target_model.copy()
+        target_model.sim = 'matrix'
 
     printer = _baseobjs.VerbosityPrinter.create_printer(verbosity)
 

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1676,7 +1676,7 @@ def find_sufficient_fiducial_pairs_per_germ_global(target_model, prep_fiducials,
             if germ_set_spanning_kwargs is not None:
                 used_kwargs.update(germ_set_spanning_kwargs)
                                        
-            germ_vector_spanning_set = germ_set_spanning_vectors(target_model, germs, 
+            germ_vector_spanning_set, _ = germ_set_spanning_vectors(target_model, germs, 
                                                                  float_type=float_type, 
                                                                  evd_tol = evd_tol,
                                                                  verbosity=verbosity,
@@ -1689,11 +1689,11 @@ def find_sufficient_fiducial_pairs_per_germ_global(target_model, prep_fiducials,
     #if precomputed_jacobians is None then make sure we pass in None for each germ
     #hack this in without branching by constructing a dictionary of Nones.
     if precomputed_jacobians is None:
-        precomputed_jacobians = {germ:None for germ in germ_vector_spanning_set[0].keys()}
+        precomputed_jacobians = {germ:None for germ in germ_vector_spanning_set.keys()}
     
     printer.log("------  Per Germ Global Fiducial Pair Reduction --------")
     with printer.progress_logging(1):
-        for i, (germ, germ_vector_list) in enumerate(germ_vector_spanning_set[0].items()):
+        for i, (germ, germ_vector_list) in enumerate(germ_vector_spanning_set.items()):
             candidate_solution_list, best_score = get_per_germ_fid_pairs_global(prep_fiducials, meas_fiducials, prep_povm_tuples,
                                                                     target_model, germ, germ_vector_list, mem_limit,
                                                                     printer, dof_per_povm, inv_trace_tol, 

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1689,11 +1689,11 @@ def find_sufficient_fiducial_pairs_per_germ_global(target_model, prep_fiducials,
     #if precomputed_jacobians is None then make sure we pass in None for each germ
     #hack this in without branching by constructing a dictionary of Nones.
     if precomputed_jacobians is None:
-        precomputed_jacobians = {germ:None for germ in germ_vector_spanning_set.keys()}
+        precomputed_jacobians = {germ:None for germ in germ_vector_spanning_set[0].keys()}
     
     printer.log("------  Per Germ Global Fiducial Pair Reduction --------")
     with printer.progress_logging(1):
-        for i, (germ, germ_vector_list) in enumerate(germ_vector_spanning_set.items()):
+        for i, (germ, germ_vector_list) in enumerate(germ_vector_spanning_set[0].items()):
             candidate_solution_list, best_score = get_per_germ_fid_pairs_global(prep_fiducials, meas_fiducials, prep_povm_tuples,
                                                                     target_model, germ, germ_vector_list, mem_limit,
                                                                     printer, dof_per_povm, inv_trace_tol, 

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -409,15 +409,17 @@ def find_germs(target_model, randomize=True, randomization_strength=1e-2,
     #force the line labels on each circuit to match the state space labels for the target model.
     #this is suboptimal for many-qubit models, so will probably want to revisit this. #TODO
     finalGermList = []
-    for ckt in germList:
-        if ckt._static:
-            new_ckt = ckt.copy(editable=True)
-            new_ckt.line_labels = target_model.state_space.state_space_labels
-            new_ckt.done_editing()
-            finalGermList.append(new_ckt)
-        else:
-            ckt.line_labels = target_model.state_space.state_space_labels
-            finalGermList.append(ckt)
+    if germList is not None:
+        for ckt in germList:
+            if ckt._static:
+                new_ckt = ckt.copy(editable=True)
+                new_ckt.line_labels = target_model.state_space.state_space_labels
+                new_ckt.done_editing()
+                finalGermList.append(new_ckt)
+            else:
+                ckt.line_labels = target_model.state_space.state_space_labels
+                finalGermList.append(ckt)
+
     return finalGermList
 
 

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -4533,6 +4533,10 @@ def germ_set_spanning_vectors(target_model, germ_list, assume_real=False, float_
         amplificational properties of the reduced vector set. 
     """
     printer = _baseobjs.VerbosityPrinter.create_printer(verbosity)
+
+    if not isinstance(target_model.sim, _MatrixForwardSimulator):
+        target_model = target_model.copy()
+        target_model.sim = 'matrix'
     
     #Add some checks related to the option to switch up data types:
     if not assume_real:

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -4,17 +4,23 @@ import scipy.sparse.linalg as _spsl
 import collections as _collections
 import copy as _copy
 import warnings as _warnings
-
 from pygsti.tools import lindbladtools as _lt
 from pygsti.tools import matrixtools as _mt
 from pygsti.tools import optools as _ot
-from pygsti.tools import fastcalc as _fc
 from pygsti.baseobjs.basis import Basis as _Basis, BuiltinBasis as _BuiltinBasis
 from pygsti.modelmembers import term as _term
 from pygsti.baseobjs.polynomial import Polynomial as _Polynomial
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
-
 from functools import lru_cache
+try:
+    from pygsti.tools import fastcalc as _fc
+    triu_indices = _fc.fast_triu_indices
+except ImportError:
+    msg = 'Could not import cython module `fastcalc`. This may indicate that your cython extensions for pyGSTi failed to.'\
+          +'properly build. Lack of cython extensions can result in significant performance degredation so we recommend trying to rebuild them.'\
+           'Falling back to numpy implementation for triu_indices.'
+    _warnings.warn(msg)
+    triu_indices = _np.triu_indices
 
 IMAG_TOL = 1e-7  # tolerance for imaginary part being considered zero
 
@@ -814,7 +820,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
                 cache_mx = self._cache_mx
 
-                params_upper_indices = _fc.fast_triu_indices(num_bels) 
+                params_upper_indices = triu_indices(num_bels) 
                 params_upper = 1j*params[params_upper_indices]
                 params_lower = (params.T)[params_upper_indices]
 
@@ -837,7 +843,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
             elif self._param_mode == "elements":  # params mx stores block_data (hermitian) directly
                 #params holds block_data real and imaginary parts directly
-                params_upper_indices = _fc.fast_triu_indices(num_bels) 
+                params_upper_indices = triu_indices(num_bels) 
                 params_upper = -1j*params[params_upper_indices]
                 params_lower = (params.T)[params_upper_indices]
 

--- a/test/unit/algorithms/test_germselection.py
+++ b/test/unit/algorithms/test_germselection.py
@@ -147,7 +147,8 @@ class GenerateGermsTester(GermSelectionData, BaseCase):
     def test_generate_germs_with_candidate_germ_counts(self):
         germs = germsel.find_germs(
             self.mdl_target_noisy, randomize=False,
-            candidate_germ_counts={3: 'all upto', 4: 10, 5: 10, 6: 10}
+            candidate_germ_counts={3: 'all upto', 4: 10, 5: 10, 6: 10},
+            candidate_seed=1234
         )
         # TODO assert correctness
 


### PR DESCRIPTION
Three quick bugfixes:

1. Per-germ global FPR requires the matrix forward simulator for some subroutines, but the default forward simulator for models is now map. We now automatically make a copy of the model with the correct forward simulator as needed. Also for pgg FPR, fix to account for change to previously changed return value format when not passing in a precomputed germ spanning vector set. The same fix was also made to the `germ_set_spanning_vectors` function.
2. The change for germ selection line-labels in PR #540 introduced a bug caught by some annoyingly nondeterministic unit test failures. Germ selection returning None is a valid outcome when the initial candidate germ set is not amplificationally complete and we weren't checking for that case when doing the line label conversion. The test that caught this involved making random selections of the candidate set and wasn't seeded which is why it only failed some of the time. It is now seeded.