### PR TITLE
Final bugfixes for 0.9.13.1

### DIFF
--- a/pygsti/baseobjs/label.py
+++ b/pygsti/baseobjs/label.py
@@ -13,6 +13,7 @@ Defines the Label class
 import itertools as _itertools
 import numbers as _numbers
 import sys as _sys
+import numpy as _np
 
 
 class Label(object):
@@ -127,7 +128,10 @@ class Label(object):
             time = 0.0  # for non-TupTup labels not setting a time is equivalent to setting it to 0.0
 
         #print(" -> preproc with name=", name, "sslbls=", state_space_labels, "t=", time, "args=", args)
-        if state_space_labels is None or state_space_labels in ((), (None,)):
+        # If numpy object, we have to check size=0 for empty; otherwise, check for empty tuple
+        if state_space_labels is None \
+            or (isinstance(state_space_labels, (_np.ndarray, _np.generic)) and state_space_labels.size == 0) \
+            or (not isinstance(state_space_labels, (_np.ndarray, _np.generic)) and state_space_labels in ((), (None,))):
             if args is not None:
                 return LabelTupWithArgs.init(name, (), time, args)  # just use empty sslbls
             else:

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -1142,7 +1142,7 @@ class ExplicitOpModel(_mdl.OpModel):
 
             randOp = _ot.unitary_to_superop(randUnitary, self.basis)
 
-            mdl_randomized.operations[opLabel] = _op.FullArbitraryOp(_np.dot(randOp, gate))
+            mdl_randomized.operations[opLabel] = _op.FullArbitraryOp(_np.dot(randOp, gate.to_dense("HilbertSchmidt")))
 
         #Note: this function does NOT randomize instruments
 

--- a/pygsti/report/reportables.py
+++ b/pygsti/report/reportables.py
@@ -1780,6 +1780,7 @@ def errorgen_and_projections(errgen, mx_basis):
     ret = {}
     ret['error generator'] = errgen
 
+    mx_basis = _Basis.cast(mx_basis, errgen.shape[0])
     if set(mx_basis.name.split('*')) == set(['pp']):
         #HACK: convert 'pp' => 'PP' here, as that's typically used.  However, other
         # bases just pass through as before and may have different scalings than earlier


### PR DESCRIPTION
This contains the following minor bugfixes for 0.9.13.1:

- Basis casting for #455
- Numpy array size check deprecation fix for #514 
- Explicit use of dense rep of gates in randomize_with_unitary() for #481 