### PR TITLE
Fiducial Selection Bugfix

### DIFF
--- a/pygsti/algorithms/fiducialselection.py
+++ b/pygsti/algorithms/fiducialselection.py
@@ -712,8 +712,8 @@ def create_meas_cache(model, available_meas_fid_list, circuit_cache=None):
     if circuit_cache is not None:
         for povm in model.povms.values():
             for E in povm.values():
-                if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
-                new_povm_effect_key_pair= (povm.to_vector().tobytes(), E.to_vector().tobytes())
+                #if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
+                new_povm_effect_key_pair= (povm.to_vector().tobytes(), E.to_dense().tobytes())
                 keypairlist.append(new_povm_effect_key_pair)
                 for measFid in available_meas_fid_list:
                     meas_cache[(new_povm_effect_key_pair[0],new_povm_effect_key_pair[1],measFid.str)] = _np.dot(E.to_dense(), circuit_cache[measFid.str])    
@@ -721,8 +721,8 @@ def create_meas_cache(model, available_meas_fid_list, circuit_cache=None):
     else:
         for povm in model.povms.values():
             for E in povm.values():
-                if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
-                new_povm_effect_key_pair= (povm.to_vector().tobytes(), E.to_vector().tobytes())
+                #if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
+                new_povm_effect_key_pair= (povm.to_vector().tobytes(), E.to_dense().tobytes())
                 keypairlist.append(new_povm_effect_key_pair)
                 for measFid in available_meas_fid_list:
                     meas_cache[(new_povm_effect_key_pair[0],new_povm_effect_key_pair[1],measFid.str)] = _np.dot(E.to_dense(), model.sim.product(measFid))
@@ -832,9 +832,9 @@ def create_meas_mxs(model, meas_fid_list, meas_cache=None):
                 #Actually, this is slowing things down a good amount, let's just print a
                 #descriptive error message if the key is missing 
                 try:
-                    outputMat[:, i] = meas_cache[0][(povm_key, E_key,measFid.str)] 
+                    outputMat[:, i] = meas_cache[0][(povm_key, E_key, measFid.str)] 
                 except KeyError as err:
-                    print('A (POVM, Effect, Circuit) pair is missing from the cache, all such pairs should be available is using the caching option.')
+                    print('A (POVM, Effect, Circuit) pair is missing from the cache, all such pairs should be available if using the caching option.')
                     raise err
                     #outputMat[:, i] = _np.dot(E.to_dense(), model.sim.product(measFid))
             outputMatList.append(outputMat)
@@ -842,7 +842,7 @@ def create_meas_mxs(model, meas_fid_list, meas_cache=None):
     else:
         for povm in model.povms.values():
             for E in povm.values():
-                if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
+                #if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
                 outputMat = _np.zeros([dimE, numFid], float)
                 for i, measFid in enumerate(meas_fid_list):
                     outputMat[:, i] = _np.dot(E.to_dense(), model.sim.product(measFid))

--- a/pygsti/algorithms/fiducialselection.py
+++ b/pygsti/algorithms/fiducialselection.py
@@ -712,7 +712,6 @@ def create_meas_cache(model, available_meas_fid_list, circuit_cache=None):
     if circuit_cache is not None:
         for povm in model.povms.values():
             for E in povm.values():
-                #if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
                 new_povm_effect_key_pair= (povm.to_vector().tobytes(), E.to_dense().tobytes())
                 keypairlist.append(new_povm_effect_key_pair)
                 for measFid in available_meas_fid_list:
@@ -721,7 +720,6 @@ def create_meas_cache(model, available_meas_fid_list, circuit_cache=None):
     else:
         for povm in model.povms.values():
             for E in povm.values():
-                #if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
                 new_povm_effect_key_pair= (povm.to_vector().tobytes(), E.to_dense().tobytes())
                 keypairlist.append(new_povm_effect_key_pair)
                 for measFid in available_meas_fid_list:
@@ -777,7 +775,6 @@ def create_prep_mxs(model, prep_fid_list, prep_cache=None):
                 except KeyError as err:
                     print('A (Rho, Circuit) pair is missing from the cache, all such pairs should be available is using the caching option.')
                     raise err                
-                    #outputMat[:, i] = _np.dot(model.sim.product(prepFid), rho.to_dense())
             outputMatList.append(outputMat)
     
     else:
@@ -836,13 +833,11 @@ def create_meas_mxs(model, meas_fid_list, meas_cache=None):
                 except KeyError as err:
                     print('A (POVM, Effect, Circuit) pair is missing from the cache, all such pairs should be available if using the caching option.')
                     raise err
-                    #outputMat[:, i] = _np.dot(E.to_dense(), model.sim.product(measFid))
             outputMatList.append(outputMat)
     
     else:
         for povm in model.povms.values():
             for E in povm.values():
-                #if isinstance(E, _ComplementPOVMEffect): continue  # complement is dependent on others
                 outputMat = _np.zeros([dimE, numFid], float)
                 for i, measFid in enumerate(meas_fid_list):
                     outputMat[:, i] = _np.dot(E.to_dense(), model.sim.product(measFid))
@@ -1774,10 +1769,6 @@ def _find_fiducials_greedy(model, fids_list, prep_or_meas, op_penalty=0.0,
             else: 
                 for fiducial in fids_list:
                     #calculate the score matrix
-                    #if prep_or_meas == 'prep':
-                    #    fidArrayList = create_prep_mxs(model, [fiducial], fid_cache)
-                    #elif prep_or_meas == 'meas':
-                    #    fidArrayList = create_meas_mxs(model, [fiducial], fid_cache)
                     current_score_mx= fiducial_compact_EVD_cache[fiducial]
                     current_score_gramian= fiducial_compact_EVD_cache[fiducial]@fiducial_compact_EVD_cache[fiducial].T
                     current_inv_trace = _np.trace(_np.linalg.pinv(current_score_gramian, hermitian=True))


### PR DESCRIPTION
This fixes a rather old bug in the fiducial selection code that I was only recently motivated to track down. This bug related to incorrectly skipping complement POVM effects when determining the rank of the Gramian for the measurement fiducials. This looks to be the reason why fiducial selection would never find the MIC fiducial set for measurements when you wanted it to which is an issue a number of folks have noticed previously. This should incidentally result in slightly smaller experiment designs in many circumstances.

Note: The old behavior wasn't wrong per se, so there is no reason to worry about the correctness of older measurement fiducial sets, they were just a bit overcomplete.