### PR TITLE
Add Clifford Labels to interalgates.py

### DIFF
--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -73,33 +73,31 @@ def internal_gate_unitaries():
     std_unitaries['HP'] = _np.dot(std_unitaries['H'], std_unitaries['P'])
     std_unitaries['PH'] = _np.dot(std_unitaries['P'], std_unitaries['H'])
     std_unitaries['HPH'] = _np.dot(std_unitaries['H'], _np.dot(std_unitaries['P'], std_unitaries['H']))
-    # The 1-qubit Clifford group. The labelling is the same as in the the 1-qubit Clifford group generated
-    # in pygsti.extras.rb.group, with the mapping 'Ci' - > 'Gci'. (we keep with the convention here of not have
-    # hard-coded unitaries starting with a 'G'.)
-    std_unitaries['C0'] = _np.array([[1, 0], [0, 1]], complex)
-    std_unitaries['C1'] = _np.array([[1, -1j], [1, 1j]], complex) / _np.sqrt(2)
-    std_unitaries['C2'] = _np.array([[1, 1], [1j, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['C3'] = _np.array([[0, 1], [1, 0]], complex)
-    std_unitaries['C4'] = _np.array([[-1, -1j], [1, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['C5'] = _np.array([[1, 1], [-1j, 1j]], complex) / _np.sqrt(2)
-    std_unitaries['C6'] = _np.array([[0, -1j], [1j, 0]], complex)
-    std_unitaries['C7'] = _np.array([[1j, 1], [-1j, 1]], complex) / _np.sqrt(2)
-    std_unitaries['C8'] = _np.array([[1j, -1j], [1, 1]], complex) / _np.sqrt(2)
-    std_unitaries['C9'] = _np.array([[1, 0], [0, -1]], complex)
-    std_unitaries['C10'] = _np.array([[1, 1j], [1, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['C11'] = _np.array([[1, -1], [1j, 1j]], complex) / _np.sqrt(2)
-    std_unitaries['C12'] = _np.array([[1, 1], [1, -1]], complex) / _np.sqrt(2)
-    std_unitaries['C13'] = _np.array([[0.5 - 0.5j, 0.5 + 0.5j], [0.5 + 0.5j, 0.5 - 0.5j]], complex)
-    std_unitaries['C14'] = _np.array([[1, 0], [0, 1j]], complex)
-    std_unitaries['C15'] = _np.array([[1, 1], [-1, 1]], complex) / _np.sqrt(2)
-    std_unitaries['C16'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], complex)
-    std_unitaries['C17'] = _np.array([[0, 1], [1j, 0]], complex)
-    std_unitaries['C18'] = _np.array([[1j, -1j], [-1j, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['C19'] = _np.array([[0.5 + 0.5j, -0.5 + 0.5j], [0.5 - 0.5j, -0.5 - 0.5j]], complex)
-    std_unitaries['C20'] = _np.array([[0, -1j], [-1, 0]], complex)
-    std_unitaries['C21'] = _np.array([[1, -1], [1, 1]], complex) / _np.sqrt(2)
-    std_unitaries['C22'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [-0.5 + 0.5j, -0.5 - 0.5j]], complex)
-    std_unitaries['C23'] = _np.array([[1, 0], [0, -1j]], complex)
+    # The 1-qubit Clifford group.
+    std_unitaries['C0'] = _np.array([[1, 0], [0, 1]], complex)                                         # This is Gi
+    std_unitaries['C1'] = _np.array([[1, -1j], [1, 1j]], complex) / _np.sqrt(2)                        # This is H Pdag
+    std_unitaries['C2'] = _np.array([[1, 1], [1j, -1j]], complex) / _np.sqrt(2)                        # This is P H
+    std_unitaries['C3'] = _np.array([[0, 1], [1, 0]], complex)                                         # This is Gxpi (up to phase)
+    std_unitaries['C4'] = _np.array([[-1, -1j], [1, -1j]], complex) / _np.sqrt(2)                      # This is H Pdag X
+    std_unitaries['C5'] = _np.array([[1, 1], [-1j, 1j]], complex) / _np.sqrt(2)                        # This is Pdag H
+    std_unitaries['C6'] = _np.array([[0, -1j], [1j, 0]], complex)                                      # This is Gypi (up to phase)
+    std_unitaries['C7'] = _np.array([[1j, 1], [-1j, 1]], complex) / _np.sqrt(2)                        # This is H P X
+    std_unitaries['C8'] = _np.array([[1j, -1j], [1, 1]], complex) / _np.sqrt(2)                        # This is Pdag X H
+    std_unitaries['C9'] = _np.array([[1, 0], [0, -1]], complex)                                        # This is Gzpi
+    std_unitaries['C10'] = _np.array([[1, 1j], [1, -1j]], complex) / _np.sqrt(2)                       # This is H P
+    std_unitaries['C11'] = _np.array([[1, -1], [1j, 1j]], complex) / _np.sqrt(2)                       # This is P X H
+    std_unitaries['C12'] = _np.array([[1, 1], [1, -1]], complex) / _np.sqrt(2)                         # This is Gh
+    std_unitaries['C13'] = _np.array([[0.5 - 0.5j, 0.5 + 0.5j], [0.5 + 0.5j, 0.5 - 0.5j]], complex)    # This is Gxmpi2 (up to phase)
+    std_unitaries['C14'] = _np.array([[1, 0], [0, 1j]], complex)                                       # This is Gzpi2 / Gp (up to phase)
+    std_unitaries['C15'] = _np.array([[1, 1], [-1, 1]], complex) / _np.sqrt(2)                         # This is Gympi2 (up to phase)
+    std_unitaries['C16'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], complex)    # This is Gxpi2 (up to phase)
+    std_unitaries['C17'] = _np.array([[0, 1], [1j, 0]], complex)                                       # This is P X
+    std_unitaries['C18'] = _np.array([[1j, -1j], [-1j, -1j]], complex) / _np.sqrt(2)                   # This is Y H
+    std_unitaries['C19'] = _np.array([[0.5 + 0.5j, -0.5 + 0.5j], [0.5 - 0.5j, -0.5 - 0.5j]], complex)  # This is Pdag H P
+    std_unitaries['C20'] = _np.array([[0, -1j], [-1, 0]], complex)                                     # This is Pdag X
+    std_unitaries['C21'] = _np.array([[1, -1], [1, 1]], complex) / _np.sqrt(2)                         # This is Gypi2 (up to phase)
+    std_unitaries['C22'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [-0.5 + 0.5j, -0.5 - 0.5j]], complex)  # This is P H Pdag
+    std_unitaries['C23'] = _np.array([[1, 0], [0, -1j]], complex)                                      # This is Gzmpi2 / Gpdag (up to phase)
     # Standard 2-qubit gates.
     std_unitaries['CPHASE'] = _np.array([[1., 0., 0., 0.], [0., 1., 0., 0.], [
                                         0., 0., 1., 0.], [0., 0., 0., -1.]], complex)
@@ -256,34 +254,31 @@ def standard_gatename_unitaries():
     #native gate in some spin qubit systems.
     std_unitaries['Gn'] = _spl.expm(-1j*(_np.pi/4)*((_np.sqrt(3)/2)*sigmax - (.5)*sigmaz))
 
-    # The 1-qubit Clifford group. The labelling is the same as in the the 1-qubit Clifford group generated
-    # in pygsti.extras.rb.group, and also in the internal standard unitary (but with 'Gci' -> 'Ci')
-    std_unitaries['Gc0'] = _np.array([[1, 0], [0, 1]], complex)  # This is Gi
-    std_unitaries['Gc1'] = _np.array([[1, -1j], [1, 1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc2'] = _np.array([[1, 1], [1j, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc3'] = _np.array([[0, 1], [1, 0]], complex)  # This is Gxpi (up to phase)
-    std_unitaries['Gc4'] = _np.array([[-1, -1j], [1, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc5'] = _np.array([[1, 1], [-1j, 1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc6'] = _np.array([[0, -1j], [1j, 0]], complex)  # This is Gypi (up to phase)
-    std_unitaries['Gc7'] = _np.array([[1j, 1], [-1j, 1]], complex) / _np.sqrt(2)
-    std_unitaries['Gc8'] = _np.array([[1j, -1j], [1, 1]], complex) / _np.sqrt(2)
-    std_unitaries['Gc9'] = _np.array([[1, 0], [0, -1]], complex)  # This is Gzpi
-    std_unitaries['Gc10'] = _np.array([[1, 1j], [1, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc11'] = _np.array([[1, -1], [1j, 1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc12'] = _np.array([[1, 1], [1, -1]], complex) / _np.sqrt(2)  # This is Gh
-    std_unitaries['Gc13'] = _np.array([[0.5 - 0.5j, 0.5 + 0.5j], [0.5 + 0.5j, 0.5 - 0.5j]],
-                                      complex)  # This is Gxmpi2 (up to phase)
-    std_unitaries['Gc14'] = _np.array([[1, 0], [0, 1j]], complex)  # THis is Gzpi2 / Gp (up to phase)
-    std_unitaries['Gc15'] = _np.array([[1, 1], [-1, 1]], complex) / _np.sqrt(2)  # This is Gympi2 (up to phase)
-    std_unitaries['Gc16'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]],
-                                      complex)  # This is Gxpi2 (up to phase)
-    std_unitaries['Gc17'] = _np.array([[0, 1], [1j, 0]], complex)
-    std_unitaries['Gc18'] = _np.array([[1j, -1j], [-1j, -1j]], complex) / _np.sqrt(2)
-    std_unitaries['Gc19'] = _np.array([[0.5 + 0.5j, -0.5 + 0.5j], [0.5 - 0.5j, -0.5 - 0.5j]], complex)
-    std_unitaries['Gc20'] = _np.array([[0, -1j], [-1, 0]], complex)
-    std_unitaries['Gc21'] = _np.array([[1, -1], [1, 1]], complex) / _np.sqrt(2)  # This is Gypi2 (up to phase)
-    std_unitaries['Gc22'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [-0.5 + 0.5j, -0.5 - 0.5j]], complex)
-    std_unitaries['Gc23'] = _np.array([[1, 0], [0, -1j]], complex)  # This is Gzmpi2 / Gpdag (up to phase)
+    # The 1-qubit Clifford group.
+    std_unitaries['Gc0'] = _np.array([[1, 0], [0, 1]], complex)                                         # This is Gi
+    std_unitaries['Gc1'] = _np.array([[1, -1j], [1, 1j]], complex) / _np.sqrt(2)                        # This is H Pdag
+    std_unitaries['Gc2'] = _np.array([[1, 1], [1j, -1j]], complex) / _np.sqrt(2)                        # This is P H
+    std_unitaries['Gc3'] = _np.array([[0, 1], [1, 0]], complex)                                         # This is Gxpi (up to phase)
+    std_unitaries['Gc4'] = _np.array([[-1, -1j], [1, -1j]], complex) / _np.sqrt(2)                      # This is H Pdag X
+    std_unitaries['Gc5'] = _np.array([[1, 1], [-1j, 1j]], complex) / _np.sqrt(2)                        # This is Pdag H
+    std_unitaries['Gc6'] = _np.array([[0, -1j], [1j, 0]], complex)                                      # This is Gypi (up to phase)
+    std_unitaries['Gc7'] = _np.array([[1j, 1], [-1j, 1]], complex) / _np.sqrt(2)                        # This is H P X
+    std_unitaries['Gc8'] = _np.array([[1j, -1j], [1, 1]], complex) / _np.sqrt(2)                        # This is Pdag X H
+    std_unitaries['Gc9'] = _np.array([[1, 0], [0, -1]], complex)                                        # This is Gzpi
+    std_unitaries['Gc10'] = _np.array([[1, 1j], [1, -1j]], complex) / _np.sqrt(2)                       # This is H P
+    std_unitaries['Gc11'] = _np.array([[1, -1], [1j, 1j]], complex) / _np.sqrt(2)                       # This is P X H
+    std_unitaries['Gc12'] = _np.array([[1, 1], [1, -1]], complex) / _np.sqrt(2)                         # This is Gh
+    std_unitaries['Gc13'] = _np.array([[0.5 - 0.5j, 0.5 + 0.5j], [0.5 + 0.5j, 0.5 - 0.5j]], complex)    # This is Gxmpi2 (up to phase)
+    std_unitaries['Gc14'] = _np.array([[1, 0], [0, 1j]], complex)                                       # This is Gzpi2 / Gp (up to phase)
+    std_unitaries['Gc15'] = _np.array([[1, 1], [-1, 1]], complex) / _np.sqrt(2)                         # This is Gympi2 (up to phase)
+    std_unitaries['Gc16'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], complex)    # This is Gxpi2 (up to phase)
+    std_unitaries['Gc17'] = _np.array([[0, 1], [1j, 0]], complex)                                       # This is P X
+    std_unitaries['Gc18'] = _np.array([[1j, -1j], [-1j, -1j]], complex) / _np.sqrt(2)                   # This is Y H
+    std_unitaries['Gc19'] = _np.array([[0.5 + 0.5j, -0.5 + 0.5j], [0.5 - 0.5j, -0.5 - 0.5j]], complex)  # This is Pdag H P
+    std_unitaries['Gc20'] = _np.array([[0, -1j], [-1, 0]], complex)                                     # This is Pdag X
+    std_unitaries['Gc21'] = _np.array([[1, -1], [1, 1]], complex) / _np.sqrt(2)                         # This is Gypi2 (up to phase)
+    std_unitaries['Gc22'] = _np.array([[0.5 + 0.5j, 0.5 - 0.5j], [-0.5 + 0.5j, -0.5 - 0.5j]], complex)  # This is P H Pdag
+    std_unitaries['Gc23'] = _np.array([[1, 0], [0, -1j]], complex)                                      # This is Gzmpi2 / Gpdag (up to phase)
     
     # Two-qubit gates
     std_unitaries['Gcphase'] = _np.array([[1., 0., 0., 0.], [0., 1., 0., 0.], [


### PR DESCRIPTION
Added labels for all 24 single-qubit Clifford gates to internalgates.py. The labels show the decomposition of each Clifford gate into the gates {I, X, Y, Z, H, P, Pdag}.