### PR TITLE
Bugfix deterministic fogi

### DIFF
--- a/pygsti/baseobjs/errorgenbasis.py
+++ b/pygsti/baseobjs/errorgenbasis.py
@@ -262,7 +262,7 @@ class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
         #Get the union of the two bases labels.
         union_labels = set(self._labels) | set(other_basis.labels)
         union_state_space = self.state_space.union(other_basis.state_space)
-        return ExplicitElementaryErrorgenBasis(union_state_space, union_labels, self._basis_1q)
+        return ExplicitElementaryErrorgenBasis(union_state_space, sorted(union_labels, key=lambda label: label.__str__()), self._basis_1q)
 
     def intersection(self, other_basis):
         """
@@ -277,7 +277,7 @@ class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
 
         intersection_labels = set(self._labels) & set(other_basis.labels)
         intersection_state_space = self.state_space.intersection(other_basis.state_space)
-        return ExplicitElementaryErrorgenBasis(intersection_state_space, intersection_labels, self._basis_1q)
+        return ExplicitElementaryErrorgenBasis(intersection_state_space, sorted(intersection_labels, key=lambda label: label.__str__()), self._basis_1q)
 
     def difference(self, other_basis):
         """
@@ -295,7 +295,7 @@ class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
         #that relied on the old (kind of incorrect behavior). Revert back to old version temporarily.
         #difference_state_space = self.state_space.difference(other_basis.state_space)
         difference_state_space = self.state_space
-        return ExplicitElementaryErrorgenBasis(difference_state_space, difference_labels, self._basis_1q)
+        return ExplicitElementaryErrorgenBasis(difference_state_space, sorted(difference_labels, key=lambda label: label.__str__()), self._basis_1q)
 
 class CompleteElementaryErrorgenBasis(ElementaryErrorgenBasis):
     """

--- a/pygsti/baseobjs/errorgenbasis.py
+++ b/pygsti/baseobjs/errorgenbasis.py
@@ -231,8 +231,8 @@ class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
 
             sub_labels, sub_indices = zip(*[(lbl, i) for i, lbl in enumerate(self._labels)
                                             if overlaps(lbl[0])])
-            sub_state_space = self.state_space.create_subspace(sub_sslbls)
             sub_sslbls = sorted(sub_sslbls)
+            sub_state_space = self.state_space.create_subspace(sub_sslbls)
         else:
             sub_labels = []
             for lbl in self.labels:

--- a/pygsti/baseobjs/errorgenbasis.py
+++ b/pygsti/baseobjs/errorgenbasis.py
@@ -232,6 +232,7 @@ class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
             sub_labels, sub_indices = zip(*[(lbl, i) for i, lbl in enumerate(self._labels)
                                             if overlaps(lbl[0])])
             sub_state_space = self.state_space.create_subspace(sub_sslbls)
+            sub_sslbls = sorted(sub_sslbls)
         else:
             sub_labels = []
             for lbl in self.labels:


### PR DESCRIPTION
Resolves issue #579

Makes sure that some sets utilized within setup_fogi get sorted before they re utilized, resulting canonical/deterministic FOGI models