### PR TITLE
Expire Dense Interfaces

### DIFF
--- a/pygsti/algorithms/contract.py
+++ b/pygsti/algorithms/contract.py
@@ -19,6 +19,7 @@ from pygsti import optimize as _opt
 from pygsti import tools as _tools
 from pygsti.modelmembers import operations as _op
 from pygsti.modelmembers import povms as _povm
+from pygsti.modelmembers import states as _state
 
 
 def contract(model, to_what, dataset=None, maxiter=1000000, tol=0.01, use_direct_cp=True, method="Nelder-Mead",
@@ -192,7 +193,7 @@ def _contract_to_cp_direct(model, verbosity, tp_also=False, maxiter=100000, tol=
     printer.log(("--- Contract to %s (direct) ---" % ("CPTP" if tp_also else "CP")), 1)
 
     for (opLabel, gate) in model.operations.items():
-        new_op = gate.copy()
+        new_op = gate.to_dense()
         if(tp_also):
             for k in range(new_op.shape[1]): new_op[0, k] = 1.0 if k == 0 else 0.0
 
@@ -294,7 +295,7 @@ def _contract_to_cp_direct(model, verbosity, tp_also=False, maxiter=100000, tol=
         #else: print "contract_to_cp_direct success in %d iterations" % it  #DEBUG
 
         printer.log("Direct CP contraction of %s gate gives frobenius diff of %g" %
-                    (opLabel, _tools.frobeniusdist(mdl.operations[opLabel], gate)), 2)
+                    (opLabel, _tools.frobeniusdist(mdl.operations[opLabel].to_dense(), gate)), 2)
 
     #mdl.log("Choi-Truncate to %s" % ("CPTP" if tp_also else "CP"), { 'maxiter': maxiter } )
     distance = mdl.frobeniusdist(model)
@@ -302,8 +303,10 @@ def _contract_to_cp_direct(model, verbosity, tp_also=False, maxiter=100000, tol=
 
     if tp_also:  # TP also constrains prep vectors
         op_dim = mdl.dim
-        for rhoVec in list(mdl.preps.values()):
-            rhoVec[0, 0] = 1.0 / op_dim**0.25
+        for lbl, rhoVec in mdl.preps.items():
+            new_rho_vec = rhoVec.to_dense()
+            new_rho_vec[0, 0] = 1.0 / op_dim**0.25
+            mdl.preps[lbl] = _state.TPState(new_rho_vec)
 
     mdl._need_to_rebuild = True
     return distance, mdl
@@ -315,13 +318,18 @@ def _contract_to_tp(model, verbosity):
     #printer.log('', 2)
     printer.log("--- Contract to TP ---", 1)
     mdl = model.copy()
-    for gate in list(mdl.operations.values()):
-        gate[0, 0] = 1.0
-        for k in range(1, gate.shape[1]): gate[0, k] = 0.0
+    for lbl, gate in mdl.operations.items():
+        new_gate_mx = gate.to_dense()
+        new_gate_mx[0, 0] = 1.0
+        for k in range(1, gate.shape[1]): 
+            new_gate_mx[0, k] = 0.0
+        mdl.operations[lbl] = _op.FullTPOp(new_gate_mx)
 
     op_dim = mdl.dim
-    for rhoVec in list(mdl.preps.values()):
-        rhoVec[0, 0] = 1.0 / op_dim**0.25
+    for lbl, rhoVec in mdl.preps.items():
+        new_rho_vec = rhoVec.to_dense()
+        new_rho_vec[0, 0] = 1.0 / op_dim**0.25
+        mdl.preps[lbl] = _state.TPState(new_rho_vec)
 
     mdl._need_to_rebuild = True
     distance = mdl.frobeniusdist(model)
@@ -363,7 +371,7 @@ def _contract_to_valid_spam(model, verbosity=0):
 
     # rhoVec must be positive semidefinite and trace = 1
     for prepLabel, rhoVec in mdl.preps.items():
-        vec = rhoVec.copy()
+        vec = rhoVec.to_dense()
 
         #Ensure trace == 1.0 (maybe later have this be optional)
         firstElTarget = 1.0 / firstElTrace  # TODO: make this function more robust
@@ -376,7 +384,7 @@ def _contract_to_valid_spam(model, verbosity=0):
             for povmLbl in list(mdl.povms.keys()):
                 scaled_effects = []
                 for ELabel, EVec in mdl.povms[povmLbl].items():
-                    scaled_effects.append((ELabel, EVec / r))
+                    scaled_effects.append((ELabel, EVec.to_dense() / r))
                 # Note: always creates an unconstrained POVM
                 mdl.povms[povmLbl] = _povm.UnconstrainedPOVM(scaled_effects, mdl.evotype, mdl.state_space)
 
@@ -390,7 +398,7 @@ def _contract_to_valid_spam(model, verbosity=0):
             vec /= 1.00001; vec[0, 0] = idEl
             lowEval = min([ev.real for ev in _np.linalg.eigvals(_tools.ppvec_to_stdmx(vec))])
 
-        diff += _np.linalg.norm(model.preps[prepLabel] - vec)
+        diff += _np.linalg.norm(model.preps[prepLabel].to_dense() - vec)
         mdl.preps[prepLabel] = vec
 
     # EVec must have eigenvals between 0 and 1 <==> positive semidefinite and trace <= 1
@@ -399,6 +407,7 @@ def _contract_to_valid_spam(model, verbosity=0):
         for ELabel, EVec in mdl.povms[povmLbl].items():
             #if isinstance(EVec, _povm.ComplementPOVMEffect):
             #    continue #don't contract complement vectors
+            EVec = EVec.to_dense()
             evals, evecs = _np.linalg.eig(_tools.ppvec_to_stdmx(EVec))
             if(min(evals) < 0.0 or max(evals) > 1.0):
                 if all([ev > 1.0 for ev in evals]):
@@ -423,12 +432,12 @@ def _contract_to_valid_spam(model, verbosity=0):
     printer.log("--- Contract to valid SPAM ---", 1)
     printer.log(("Sum of norm(deltaE) and norm(deltaRho) = %g" % diff), 1)
     for (prepLabel, rhoVec) in model.preps.items():
-        printer.log("  %s: %s ==> %s " % (prepLabel, str(_np.transpose(rhoVec)),
-                                          str(_np.transpose(mdl.preps[prepLabel]))), 2)
+        printer.log("  %s: %s ==> %s " % (prepLabel, str(_np.transpose(rhoVec.to_dense())),
+                                          str(_np.transpose(mdl.preps[prepLabel].to_dense()))), 2)
     for povmLbl, povm in model.povms.items():
         printer.log(("  %s (POVM)" % povmLbl), 2)
         for ELabel, EVec in povm.items():
-            printer.log("  %s: %s ==> %s " % (ELabel, str(_np.transpose(EVec)),
-                                              str(_np.transpose(mdl.povms[povmLbl][ELabel]))), 2)
+            printer.log("  %s: %s ==> %s " % (ELabel, str(_np.transpose(EVec.to_dense())),
+                                              str(_np.transpose(mdl.povms[povmLbl][ELabel].to_dense()))), 2)
 
     return mdl  # return contracted model

--- a/pygsti/extras/rpe/rpeconstruction.py
+++ b/pygsti/extras/rpe/rpeconstruction.py
@@ -95,9 +95,9 @@ def create_parameterized_rpe_model(alpha_true, epsilon_true, aux_rot, spam_depol
             effect_labels=ELabels, effect_expressions=EExpressions)
 
         outputModel.operations[loose_axis_gate_label] = \
-            _np.dot(_np.dot(_np.linalg.inv(modelAux1.operations[auxiliary_axis_gate_label]),
-                            outputModel.operations[loose_axis_gate_label]),
-                    modelAux1.operations[auxiliary_axis_gate_label])
+            _np.linalg.inv(modelAux1.operations[auxiliary_axis_gate_label].to_dense())@\
+            outputModel.operations[loose_axis_gate_label].to_dense()@\
+            modelAux1.operations[auxiliary_axis_gate_label].to_dense()
 
     outputModel = outputModel.depolarize(op_noise=gate_depol,
                                          spam_noise=spam_depol)

--- a/pygsti/extras/rpe/rpetools.py
+++ b/pygsti/extras/rpe/rpetools.py
@@ -257,7 +257,7 @@ def extract_alpha(model, rpeconfig_inst):
         The value of alpha for the input model.
     """
     op_label = rpeconfig_inst.fixed_axis_gate_label
-    decomp = _decompose_gate_matrix(model.operations[op_label])
+    decomp = _decompose_gate_matrix(model.operations[op_label].to_dense())
     alphaVal = decomp['pi rotations'] * _np.pi
     return alphaVal
 
@@ -284,7 +284,7 @@ def extract_epsilon(model, rpeconfig_inst):
         The value of epsilon for the input model.
     """
     op_label = rpeconfig_inst.loose_axis_gate_label
-    decomp = _decompose_gate_matrix(model.operations[op_label])
+    decomp = _decompose_gate_matrix(model.operations[op_label].to_dense())
 
     epsilonVal = decomp['pi rotations'] * _np.pi
     return epsilonVal
@@ -313,10 +313,10 @@ def extract_theta(model, rpeconfig_inst):
         The value of theta for the input model.
     """
     op_label = rpeconfig_inst.loose_axis_gate_label
-    decomp = _decompose_gate_matrix(model.operations[op_label])
+    decomp = _decompose_gate_matrix(model.operations[op_label].to_dense())
     target_axis = rpeconfig_inst.loose_axis_target
 
-    decomp = _decompose_gate_matrix(model.operations[op_label])
+    decomp = _decompose_gate_matrix(model.operations[op_label].to_dense())
     thetaVal = _np.real_if_close([_np.arccos(
         _np.dot(decomp['axis of rotation'], target_axis))])[0]
     if thetaVal > _np.pi / 2:

--- a/pygsti/modelmembers/instruments/instrument.py
+++ b/pygsti/modelmembers/instruments/instrument.py
@@ -226,7 +226,7 @@ class Instrument(_mm.ModelMember, _collections.OrderedDict):
         -------
         int
         """
-        return sum([g.size for g in self.values()])
+        return sum([g._ptr.size for g in self.values()])
 
     @property
     def num_params(self):

--- a/pygsti/modelmembers/instruments/tpinstrumentop.py
+++ b/pygsti/modelmembers/instruments/tpinstrumentop.py
@@ -122,13 +122,13 @@ class TPInstrumentOp(_DenseOperator):
         nEls = self.num_instrument_elements
         self._ptr.flags.writeable = True
         if self.index < nEls - 1:
-            self._ptr[:, :] = _np.asarray(self.relevant_param_ops[1]  # i.e. param_ops[self.index + 1]
-                                          + self.relevant_param_ops[0])  # i.e. param_ops[0]
+            self._ptr[:, :] = _np.asarray(self.relevant_param_ops[1].to_dense()  # i.e. param_ops[self.index + 1]
+                                          + self.relevant_param_ops[0].to_dense())  # i.e. param_ops[0]
         else:
             assert(self.index == nEls - 1), \
                 "Invalid index %d > %d" % (self.index, nEls - 1)
-            self._ptr[:, :] = _np.asarray(-sum(self.relevant_param_ops)  # all instrument param_ops == relevant
-                                          - (nEls - 3) * self.relevant_param_ops[0])
+            self._ptr[:, :] = _np.asarray(-sum([op.to_dense() for op in self.relevant_param_ops])  # all instrument param_ops == relevant
+                                          - (nEls - 3) * self.relevant_param_ops[0].to_dense())
 
         assert(self._ptr.shape == (self.dim, self.dim))
         self._ptr.flags.writeable = False

--- a/pygsti/modelmembers/operations/__init__.py
+++ b/pygsti/modelmembers/operations/__init__.py
@@ -15,7 +15,7 @@ import warnings as _warnings
 
 from .composederrorgen import ComposedErrorgen
 from .composedop import ComposedOp
-from .denseop import DenseOperator, DenseOperatorInterface
+from .denseop import DenseOperator
 from .depolarizeop import DepolarizeOp
 from .eigpdenseop import EigenvalueParamDenseOp
 from .embeddederrorgen import EmbeddedErrorgen

--- a/pygsti/modelmembers/operations/denseop.py
+++ b/pygsti/modelmembers/operations/denseop.py
@@ -225,6 +225,44 @@ class DenseOperator(_KrausOperatorInterface, _LinearOperator):
         """
         return self._rep.to_dense(on_space)  # both types of possible reps implement 'to_dense'
 
+    def to_array(self):
+        """
+        Return the array used to identify this operation within its range of possible values.
+
+        For instance, if the operation is a unitary operation, this returns a
+        unitary matrix regardless of the evolution type.  The related :meth:`to_dense`
+        method, in contrast, returns the dense representation of the operation, which
+        varies by evolution type.
+
+        Note: for efficiency, this doesn't copy the underlying data, so
+        the caller should copy this data before modifying it.
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        return _np.asarray(self._ptr)
+        # *must* be a numpy array for Cython arg conversion
+
+    def to_sparse(self, on_space='minimal'):
+        """
+        Return the operation as a sparse matrix.
+
+        Parameters
+        ----------
+        on_space : {'minimal', 'Hilbert', 'HilbertSchmidt'}
+            The space that the returned dense operation acts upon.  For unitary matrices and bra/ket vectors,
+            use `'Hilbert'`.  For superoperator matrices and super-bra/super-ket vectors use `'HilbertSchmidt'`.
+            `'minimal'` means that `'Hilbert'` is used if possible given this operator's evolution type, and
+            otherwise `'HilbertSchmidt'` is used.
+
+        Returns
+        -------
+        scipy.sparse.csr_matrix
+        """
+        return _sps.csr_matrix(self.to_dense(on_space))
+
+
     def to_memoized_dict(self, mmg_memo):
         """Create a serializable dict with references to other objects in the memo.
 
@@ -469,6 +507,43 @@ class DenseUnitaryOperator(_KrausOperatorInterface, _LinearOperator):
         if self._reptype == 'superop' and on_space == 'Hilbert':
             return self._unitary
         return self._rep.to_dense(on_space)  # both types of possible reps implement 'to_dense'
+
+    def to_array(self):
+        """
+        Return the array used to identify this operation within its range of possible values.
+
+        For instance, if the operation is a unitary operation, this returns a
+        unitary matrix regardless of the evolution type.  The related :meth:`to_dense`
+        method, in contrast, returns the dense representation of the operation, which
+        varies by evolution type.
+
+        Note: for efficiency, this doesn't copy the underlying data, so
+        the caller should copy this data before modifying it.
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        return _np.asarray(self._ptr)
+        # *must* be a numpy array for Cython arg conversion
+
+    def to_sparse(self, on_space='minimal'):
+        """
+        Return the operation as a sparse matrix.
+
+        Parameters
+        ----------
+        on_space : {'minimal', 'Hilbert', 'HilbertSchmidt'}
+            The space that the returned dense operation acts upon.  For unitary matrices and bra/ket vectors,
+            use `'Hilbert'`.  For superoperator matrices and super-bra/super-ket vectors use `'HilbertSchmidt'`.
+            `'minimal'` means that `'Hilbert'` is used if possible given this operator's evolution type, and
+            otherwise `'HilbertSchmidt'` is used.
+
+        Returns
+        -------
+        scipy.sparse.csr_matrix
+        """
+        return _sps.csr_matrix(self.to_dense(on_space))
 
     def to_memoized_dict(self, mmg_memo):
         """Create a serializable dict with references to other objects in the memo.

--- a/pygsti/modelmembers/operations/denseop.py
+++ b/pygsti/modelmembers/operations/denseop.py
@@ -126,157 +126,15 @@ def check_deriv_wrt_params(operation, deriv_to_check=None, wrt_filter=None, eps=
                          " norm diff = %g" %
                          _np.linalg.norm(fd_deriv - deriv_to_check))  # pragma: no cover
 
-
-class DenseOperatorInterface(object):
+def __str__(self):
+    s = "%s with shape %s\n" % (self.__class__.__name__, str(self._ptr.shape))
+    s += _mt.mx_to_string(self._ptr, width=4, prec=2)
+    return s
+class DenseOperator(_KrausOperatorInterface, _LinearOperator):
     """
-    Adds a numpy-array-mimicing interface onto an operation object.
-    """
-
-    def __init__(self):
-        pass
-
-    @property
-    def _ptr(self):
-        raise NotImplementedError("Derived classes must implement the _ptr property!")
-
-    def _ptr_has_changed(self):
-        """ Derived classes should override this function to handle rep updates
-            when the `_ptr` property is changed. """
-        pass
-
-    def to_array(self):
-        """
-        Return the array used to identify this operation within its range of possible values.
-
-        For instance, if the operation is a unitary operation, this returns a
-        unitary matrix regardless of the evolution type.  The related :meth:`to_dense`
-        method, in contrast, returns the dense representation of the operation, which
-        varies by evolution type.
-
-        Note: for efficiency, this doesn't copy the underlying data, so
-        the caller should copy this data before modifying it.
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        return _np.asarray(self._ptr)
-        # *must* be a numpy array for Cython arg conversion
-
-    def to_sparse(self, on_space='minimal'):
-        """
-        Return the operation as a sparse matrix.
-
-        Parameters
-        ----------
-        on_space : {'minimal', 'Hilbert', 'HilbertSchmidt'}
-            The space that the returned dense operation acts upon.  For unitary matrices and bra/ket vectors,
-            use `'Hilbert'`.  For superoperator matrices and super-bra/super-ket vectors use `'HilbertSchmidt'`.
-            `'minimal'` means that `'Hilbert'` is used if possible given this operator's evolution type, and
-            otherwise `'HilbertSchmidt'` is used.
-
-        Returns
-        -------
-        scipy.sparse.csr_matrix
-        """
-        return _sps.csr_matrix(self.to_dense(on_space))
-
-    def __copy__(self):
-        # We need to implement __copy__ because we defer all non-existing
-        # attributes to self.base (a numpy array) which *has* a __copy__
-        # implementation that we don't want to use, as it results in just a
-        # copy of the numpy array.
-        cls = self.__class__
-        cpy = cls.__new__(cls)
-        cpy.__dict__.update(self.__dict__)
-        return cpy
-
-    def __deepcopy__(self, memo):
-        # We need to implement __deepcopy__ because we defer all non-existing
-        # attributes to self.base (a numpy array) which *has* a __deepcopy__
-        # implementation that we don't want to use, as it results in just a
-        # copy of the numpy array.
-        cls = self.__class__
-        cpy = cls.__new__(cls)
-        memo[id(self)] = cpy
-        for k, v in self.__dict__.items():
-            setattr(cpy, k, _copy.deepcopy(v, memo))
-        return cpy
-
-    #Access to underlying ndarray
-    def __getitem__(self, key):
-        self.dirty = True
-        return self._ptr.__getitem__(key)
-
-    def __getslice__(self, i, j):
-        self.dirty = True
-        return self.__getitem__(slice(i, j))  # Called for A[:]
-
-    def __setitem__(self, key, val):
-        self.dirty = True
-        ret = self._ptr.__setitem__(key, val)
-        self._ptr_has_changed()
-        return ret
-
-    def __getattr__(self, attr):
-        #use __dict__ so no chance for recursive __getattr__
-        #ret = getattr(self.__dict__['_rep'].base, attr)
-        ret = getattr(self._ptr, attr)
-        self.dirty = True
-        return ret
-
-    def __str__(self):
-        s = "%s with shape %s\n" % (self.__class__.__name__, str(self._ptr.shape))
-        s += _mt.mx_to_string(self._ptr, width=4, prec=2)
-        return s
-
-    #Mimic array behavior
-    def __pos__(self): return self._ptr
-    def __neg__(self): return -self._ptr
-    def __abs__(self): return abs(self._ptr)
-    def __add__(self, x): return self._ptr + x
-    def __radd__(self, x): return x + self._ptr
-    def __sub__(self, x): return self._ptr - x
-    def __rsub__(self, x): return x - self._ptr
-    def __mul__(self, x): return self._ptr * x
-    def __rmul__(self, x): return x * self._ptr
-    def __truediv__(self, x): return self._ptr / x
-    def __rtruediv__(self, x): return x / self._ptr
-    def __floordiv__(self, x): return self._ptr // x
-    def __rfloordiv__(self, x): return x // self._ptr
-    def __pow__(self, x): return self._ptr ** x
-    def __eq__(self, x): return _np.array_equal(self._ptr, x)
-    def __len__(self): return len(self._ptr)
-    def __int__(self): return int(self._ptr)
-    def __long__(self): return int(self._ptr)
-    def __float__(self): return float(self._ptr)
-    def __complex__(self): return complex(self._ptr)
-
-
-class DenseOperator(DenseOperatorInterface, _KrausOperatorInterface, _LinearOperator):
-    """
-    TODO: update docstring
     An operator that behaves like a dense super-operator matrix.
 
     This class is the common base class for more specific dense operators.
-
-    Parameters
-    ----------
-    mx : numpy.ndarray
-        The operation as a dense process matrix.
-
-    basis : Basis or {'pp','gm','std'} or None
-        The basis used to construct the Hilbert-Schmidt space representation
-        of this state as a super-operator.  If None, certain functionality,
-        such as access to Kraus operators, will be unavailable.
-
-    evotype : Evotype or str
-        The evolution type.  The special value `"default"` is equivalent
-        to specifying the value of `pygsti.evotypes.Evotype.default_evotype`.
-
-    state_space : StateSpace, optional
-        The state space for this operation.  If `None` a default state space
-        with the appropriate number of qubits is used.
 
     Attributes
     ----------
@@ -310,6 +168,25 @@ class DenseOperator(DenseOperatorInterface, _KrausOperatorInterface, _LinearOper
         return cls(superop, basis, evotype, state_space)
 
     def __init__(self, mx, basis, evotype, state_space=None):
+        """
+        Parameters
+        ----------
+        mx : numpy.ndarray
+            The operation as a dense process matrix.
+
+        basis : Basis or {'pp','gm','std'} or None
+            The basis used to construct the Hilbert-Schmidt space representation
+            of this state as a super-operator.  If None, certain functionality,
+            such as access to Kraus operators, will be unavailable.
+
+        evotype : Evotype or str
+            The evolution type.  The special value `"default"` is equivalent
+            to specifying the value of `pygsti.evotypes.Evotype.default_evotype`.
+
+        state_space : StateSpace, optional
+            The state space for this operation.  If `None` a default state space
+            with the appropriate number of qubits is used.
+        """
         mx = _LinearOperator.convert_to_matrix(mx)
         state_space = _statespace.default_space_for_dim(mx.shape[0]) if (state_space is None) \
             else _statespace.StateSpace.cast(state_space)
@@ -317,7 +194,6 @@ class DenseOperator(DenseOperatorInterface, _KrausOperatorInterface, _LinearOper
         self._basis = _Basis.cast(basis, state_space.dim) if (basis is not None) else None  # for Hilbert-Schmidt space
         rep = evotype.create_dense_superop_rep(mx, self._basis, state_space)
         _LinearOperator.__init__(self, rep, evotype)
-        DenseOperatorInterface.__init__(self)
 
     @property
     def _ptr(self):
@@ -450,30 +326,16 @@ class DenseOperator(DenseOperatorInterface, _KrausOperatorInterface, _LinearOper
         superop = _bt.change_basis(std_superop, 'std', self._basis)
         self.set_dense(superop)  # this may fail if derived class doesn't allow it
 
+    def __str__(self):
+        s = "%s with shape %s\n" % (self.__class__.__name__, str(self._ptr.shape))
+        s += _mt.mx_to_string(self._ptr, width=4, prec=2)
+        return s
 
-class DenseUnitaryOperator(DenseOperatorInterface, _KrausOperatorInterface, _LinearOperator):
+class DenseUnitaryOperator(_KrausOperatorInterface, _LinearOperator):
     """
-    TODO: update docstring
     An operator that behaves like a dense (unitary) operator matrix.
 
     This class is the common base class for more specific dense operators.
-
-    Parameters
-    ----------
-    mx : numpy.ndarray
-        The operation as a dense process matrix.
-
-    basis : Basis or {'pp','gm','std'}, optional
-        The basis used to construct the Hilbert-Schmidt space representation
-        of this state as a super-operator.
-
-    evotype : Evotype or str
-        The evolution type.  The special value `"default"` is equivalent
-        to specifying the value of `pygsti.evotypes.Evotype.default_evotype`.
-
-    state_space : StateSpace, optional
-        The state space for this operation.  If `None` a default state space
-        with the appropriate number of qubits is used.
 
     Attributes
     ----------
@@ -524,11 +386,29 @@ class DenseUnitaryOperator(DenseOperatorInterface, _KrausOperatorInterface, _Lin
 
         self._basis = basis
         _LinearOperator.__init__(self, rep, evotype)
-        DenseOperatorInterface.__init__(self)
         return self
 
     def __init__(self, mx, basis, evotype, state_space):
-        """ Initialize a new LinearOperator """
+        """ 
+        Initialize a new DenseUnitaryOperator
+        
+        Parameters
+        ----------
+        mx : numpy.ndarray
+            The operation as a dense process matrix.
+
+        basis : Basis or {'pp','gm','std'}, optional
+            The basis used to construct the Hilbert-Schmidt space representation
+            of this state as a super-operator.
+
+        evotype : Evotype or str
+            The evolution type.  The special value `"default"` is equivalent
+            to specifying the value of `pygsti.evotypes.Evotype.default_evotype`.
+
+        state_space : StateSpace, optional
+            The state space for this operation.  If `None` a default state space
+            with the appropriate number of qubits is used.    
+        """
         mx = _LinearOperator.convert_to_matrix(mx)
         state_space = _statespace.default_space_for_udim(mx.shape[0]) if (state_space is None) \
             else _statespace.StateSpace.cast(state_space)
@@ -554,7 +434,6 @@ class DenseUnitaryOperator(DenseOperatorInterface, _KrausOperatorInterface, _Lin
         self._basis = basis
 
         _LinearOperator.__init__(self, rep, evotype)
-        DenseOperatorInterface.__init__(self)
 
     @property
     def _ptr(self):
@@ -654,3 +533,7 @@ class DenseUnitaryOperator(DenseOperatorInterface, _KrausOperatorInterface, _Lin
         assert(len(kraus_operators) == 1), "Length of `kraus_operators` must == 1 for a unitary channel!"
         self.set_dense(kraus_operators[0])
 
+    def __str__(self):
+        s = "%s with shape %s\n" % (self.__class__.__name__, str(self._ptr.shape))
+        s += _mt.mx_to_string(self._ptr, width=4, prec=2)
+        return s

--- a/pygsti/modelmembers/operations/fullarbitraryop.py
+++ b/pygsti/modelmembers/operations/fullarbitraryop.py
@@ -82,7 +82,7 @@ class FullArbitraryOp(_DenseOperator):
         int
             the number of independent parameters.
         """
-        return self.size
+        return self._ptr.size
 
     def to_vector(self):
         """

--- a/pygsti/modelmembers/operations/linearop.py
+++ b/pygsti/modelmembers/operations/linearop.py
@@ -671,7 +671,7 @@ class LinearOperator(_modelmember.ModelMember):
             Array of derivatives with shape (dimension^2, num_params)
         """
         if self.num_params == 0:
-            derivMx = _np.zeros((self.size, 0), 'd')
+            derivMx = _np.zeros((self._ptr.size, 0), 'd')
             if wrt_filter is None:
                 return derivMx
             else:

--- a/pygsti/modelmembers/povms/conjugatedeffect.py
+++ b/pygsti/modelmembers/povms/conjugatedeffect.py
@@ -17,117 +17,12 @@ from pygsti.modelmembers.povms.effect import POVMEffect as _POVMEffect
 from pygsti.modelmembers import term as _term
 from pygsti.tools import matrixtools as _mt
 
-
-class DenseEffectInterface(object):
+class ConjugatedStatePOVMEffect(_POVMEffect):
     """
-    Adds a numpy-array-mimicing interface onto a POVM effect object.
-    """
-    # Note: this class may not really be necessary, and maybe methods should just be
-    # placed within ConjugatedStatePOVMEffect?
-
-    @property
-    def _ptr(self):
-        raise NotImplementedError("Derived classes must implement the _ptr property!")
-
-    def _ptr_has_changed(self):
-        """ Derived classes should override this function to handle rep updates
-            when the `_ptr` property is changed. """
-        pass
-
-    @property
-    def columnvec(self):
-        """
-        Direct access the the underlying data as column vector, i.e, a (dim,1)-shaped array.
-        """
-        bv = self._ptr.view()
-        bv.shape = (bv.size, 1)  # 'base' is by convention a (N,1)-shaped array
-        return bv
-
-    def __copy__(self):
-        # We need to implement __copy__ because we defer all non-existing
-        # attributes to self.columnvec (a numpy array) which *has* a __copy__
-        # implementation that we don't want to use, as it results in just a
-        # copy of the numpy array.
-        cls = self.__class__
-        cpy = cls.__new__(cls)
-        cpy.__dict__.update(self.__dict__)
-        return cpy
-
-    def __deepcopy__(self, memo):
-        # We need to implement __deepcopy__ because we defer all non-existing
-        # attributes to self.columnvec (a numpy array) which *has* a __deepcopy__
-        # implementation that we don't want to use, as it results in just a
-        # copy of the numpy array.
-        cls = self.__class__
-        cpy = cls.__new__(cls)
-        memo[id(self)] = cpy
-        for k, v in self.__dict__.items():
-            setattr(cpy, k, _copy.deepcopy(v, memo))
-        return cpy
-
-    #Access to underlying array
-    def __getitem__(self, key):
-        if not isinstance(key, (int, _np.int64)):  # don't set dirty flag if returning a single element
-            self.dirty = True
-        return self.columnvec.__getitem__(key)
-
-    def __getslice__(self, i, j):
-        self.dirty = True
-        return self.__getitem__(slice(i, j))  # Called for A[:]
-
-    def __setitem__(self, key, val):
-        self.dirty = True
-        ret = self.columnvec.__setitem__(key, val)
-        self._ptr_has_changed()
-        return ret
-
-    def __getattr__(self, attr):
-        #use __dict__ so no chance for recursive __getattr__
-        if '_rep' in self.__dict__:  # sometimes in loading __getattr__ gets called before the instance is loaded
-            ret = getattr(self.columnvec, attr)
-        else:
-            raise AttributeError("No attribute:", attr)
-        self.dirty = True
-        return ret
-
-    #Mimic array
-    def __pos__(self): return self.columnvec
-    def __neg__(self): return -self.columnvec
-    def __abs__(self): return abs(self.columnvec)
-    def __add__(self, x): return self.columnvec + x
-    def __radd__(self, x): return x + self.columnvec
-    def __sub__(self, x): return self.columnvec - x
-    def __rsub__(self, x): return x - self.columnvec
-    def __mul__(self, x): return self.columnvec * x
-    def __rmul__(self, x): return x * self.columnvec
-    def __truediv__(self, x): return self.columnvec / x
-    def __rtruediv__(self, x): return x / self.columnvec
-    def __floordiv__(self, x): return self.columnvec // x
-    def __rfloordiv__(self, x): return x // self.columnvec
-    def __pow__(self, x): return self.columnvec ** x
-    def __eq__(self, x): return self.columnvec == x
-    def __len__(self): return len(self.columnvec)
-    def __int__(self): return int(self.columnvec)
-    def __long__(self): return int(self.columnvec)
-    def __float__(self): return float(self.columnvec)
-    def __complex__(self): return complex(self.columnvec)
-
-
-class ConjugatedStatePOVMEffect(DenseEffectInterface, _POVMEffect):
-    """
-    TODO: update docstring
-    A POVM effect vector that behaves like a numpy array.
-
     This class is the common base class for parameterizations of an effect vector
-    that have a dense representation and can be accessed like a numpy array.
+    that have a dense representation.
 
-    Parameters
-    ----------
-    vec : numpy.ndarray
-        The POVM effect vector as a dense numpy array.
 
-    evotype : {"statevec", "densitymx"}
-        The evolution type.
 
     Attributes
     ----------
@@ -140,6 +35,20 @@ class ConjugatedStatePOVMEffect(DenseEffectInterface, _POVMEffect):
     """
 
     def __init__(self, state, called_from_reduce=False):
+        """
+        Parameters
+        ----------
+        vec : numpy.ndarray
+            The POVM effect vector as a dense numpy array.
+
+        evotype : {"statevec", "densitymx"}
+            The evolution type.
+        
+        called_from_reduce : bool, optional (default False)
+            Special flag used when pickling. Users should not need to
+            interact with this flag directly.
+        """
+
         self.state = state
         evotype = state._evotype
         rep = evotype.create_conjugatedstate_effect_rep(state._rep)

--- a/pygsti/modelmembers/states/densestate.py
+++ b/pygsti/modelmembers/states/densestate.py
@@ -23,136 +23,12 @@ from pygsti.tools import matrixtools as _mt
 from pygsti.tools import optools as _ot
 
 
-class DenseStateInterface(object):
+class DenseState(_State):
     """
-    Adds a numpy-array-mimicing interface onto a state object.
-    """
-
-    def __init__(self):
-        pass
-
-    @property
-    def _ptr(self):
-        raise NotImplementedError("Derived classes must implement the _ptr property!")
-
-    def _ptr_has_changed(self):
-        """ Derived classes should override this function to handle rep updates
-            when the `_ptr` property is changed. """
-        pass
-
-    def to_array(self):
-        """
-        Return the array used to identify this state within its range of possible values.
-
-        For instance, if the state is a pure state, this returns a complex pure-state
-        vector regardless of the evolution type.  The related :meth:`to_dense`
-        method, in contrast, returns the dense representation of the state, which
-        varies by evolution type.
-
-        Returns
-        -------
-        numpy.ndarray
-        """
-        return self._ptr  # *must* be a numpy array for Cython arg conversion
-
-    @property
-    def columnvec(self):
-        """
-        Direct access the the underlying data as column vector, i.e, a (dim,1)-shaped array.
-        """
-        bv = self._ptr.view()
-        bv.shape = (bv.size, 1)  # 'base' is by convention a (N,1)-shaped array
-        return bv
-
-    def __copy__(self):
-        # We need to implement __copy__ because we defer all non-existing
-        # attributes to self.columnvec (a numpy array) which *has* a __copy__
-        # implementation that we don't want to use, as it results in just a
-        # copy of the numpy array.
-        cls = self.__class__
-        cpy = cls.__new__(cls)
-        cpy.__dict__.update(self.__dict__)
-        return cpy
-
-    def __deepcopy__(self, memo):
-        # We need to implement __deepcopy__ because we defer all non-existing
-        # attributes to self.columnvec (a numpy array) which *has* a __deepcopy__
-        # implementation that we don't want to use, as it results in just a
-        # copy of the numpy array.
-        cls = self.__class__
-        cpy = cls.__new__(cls)
-        memo[id(self)] = cpy
-        for k, v in self.__dict__.items():
-            setattr(cpy, k, _copy.deepcopy(v, memo))
-        return cpy
-
-    #Access to underlying array
-    def __getitem__(self, key):
-        self.dirty = True
-        return self.columnvec.__getitem__(key)
-
-    def __getslice__(self, i, j):
-        self.dirty = True
-        return self.__getitem__(slice(i, j))  # Called for A[:]
-
-    def __setitem__(self, key, val):
-        self.dirty = True
-        ret = self.columnvec.__setitem__(key, val)
-        self._ptr_has_changed()
-        return ret
-
-    def __getattr__(self, attr):
-        #use __dict__ so no chance for recursive __getattr__
-        if '_rep' in self.__dict__:  # sometimes in loading __getattr__ gets called before the instance is loaded
-            ret = getattr(self.columnvec, attr)
-        else:
-            raise AttributeError("No attribute:", attr)
-        self.dirty = True
-        return ret
-
-    #Mimic array
-    def __pos__(self): return self.columnvec
-    def __neg__(self): return -self.columnvec
-    def __abs__(self): return abs(self.columnvec)
-    def __add__(self, x): return self.columnvec + x
-    def __radd__(self, x): return x + self.columnvec
-    def __sub__(self, x): return self.columnvec - x
-    def __rsub__(self, x): return x - self.columnvec
-    def __mul__(self, x): return self.columnvec * x
-    def __rmul__(self, x): return x * self.columnvec
-    def __truediv__(self, x): return self.columnvec / x
-    def __rtruediv__(self, x): return x / self.columnvec
-    def __floordiv__(self, x): return self.columnvec // x
-    def __rfloordiv__(self, x): return x // self.columnvec
-    def __pow__(self, x): return self.columnvec ** x
-    def __eq__(self, x): return self.columnvec == x
-    def __len__(self): return len(self.columnvec)
-    def __int__(self): return int(self.columnvec)
-    def __long__(self): return int(self.columnvec)
-    def __float__(self): return float(self.columnvec)
-    def __complex__(self): return complex(self.columnvec)
-
-    def __str__(self):
-        s = "%s with dimension %d\n" % (self.__class__.__name__, self.dim)
-        s += _mt.mx_to_string(self.to_dense(on_space='minimal'), width=4, prec=2)
-        return s
-
-
-class DenseState(DenseStateInterface, _State):
-    """
-    TODO: update docstring
-    A state preparation vector that is interfaced/behaves as a dense super-ket (a numpy array).
+    A state preparation vector that is parameterized as a dense super-ket.
 
     This class is the common base class for parameterizations of a state vector
-    that have a dense representation and can be accessed like a numpy array.
-
-    Parameters
-    ----------
-    vec : numpy.ndarray
-        The SPAM vector as a dense numpy array.
-
-    evotype : {"statevec", "densitymx"}
-        The evolution type.
+    that have a dense representation.
 
     Attributes
     ----------
@@ -165,6 +41,21 @@ class DenseState(DenseStateInterface, _State):
     """
 
     def __init__(self, vec, basis, evotype, state_space):
+        """
+        Parameters
+        ----------
+        vec : numpy.ndarray
+            The SPAM vector as a dense numpy array.
+
+        evotype : {"statevec", "densitymx"}
+            The evolution type.
+        
+        state_space : `StateSpace`, optional (default None)
+            The state space for this state.  If `None` a default state space
+            with the appropriate number of qubits is used.
+        """
+        
+        
         vec = _State._to_vector(vec)
         if state_space is None:
             state_space = _statespace.default_space_for_dim(vec.shape[0])
@@ -175,8 +66,6 @@ class DenseState(DenseStateInterface, _State):
         rep = evotype.create_dense_state_rep(vec, self._basis, state_space)
 
         _State.__init__(self, rep, evotype)
-        DenseStateInterface.__init__(self)
-        #assert(self._ptr.flags['C_CONTIGUOUS'] and self._ptr.flags['OWNDATA'])  # not true for TPState
 
     @property
     def _ptr(self):
@@ -254,8 +143,12 @@ class DenseState(DenseStateInterface, _State):
         
         return self._ptr.shape == other._ptr.shape  # similar (up to params) if have same data shape
 
+    def __str__(self):
+        s = "%s with dimension %d\n" % (self.__class__.__name__, self.dim)
+        s += _mt.mx_to_string(self.to_dense(on_space='minimal'), width=4, prec=2)
+        return s
 
-class DensePureState(DenseStateInterface, _State):
+class DensePureState(_State):
     """
     TODO: docstring - a state that is interfaced as a dense ket
     """
@@ -286,7 +179,6 @@ class DensePureState(DenseStateInterface, _State):
             self._purevec = purevec; self._basis = basis
 
         _State.__init__(self, rep, evotype)
-        DenseStateInterface.__init__(self)
 
     @property
     def _ptr(self):
@@ -368,3 +260,8 @@ class DensePureState(DenseStateInterface, _State):
         the same local structure, i.e., not considering parameter values or submembers 
         """
         return self._ptr.shape == other._ptr.shape  # similar (up to params) if have same data shape
+
+    def __str__(self):
+        s = "%s with dimension %d\n" % (self.__class__.__name__, self.dim)
+        s += _mt.mx_to_string(self.to_dense(on_space='minimal'), width=4, prec=2)
+        return s

--- a/pygsti/modelmembers/states/fullstate.py
+++ b/pygsti/modelmembers/states/fullstate.py
@@ -76,7 +76,7 @@ class FullState(_DenseState):
         int
             the number of independent parameters.
         """
-        return self.size
+        return self._ptr.size
 
     def to_vector(self):
         """

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -801,14 +801,15 @@ class ExplicitOpModel(_mdl.OpModel):
         """
         penalty = 0.0
         for operationMx in list(self.operations.values()):
-            penalty += abs(operationMx[0, 0] - 1.0)**2
-            for k in range(1, operationMx.shape[1]):
-                penalty += abs(operationMx[0, k])**2
+            mx = operationMx.to_dense()
+            penalty += abs(mx[0, 0] - 1.0)**2
+            for k in range(1, mx.shape[1]):
+                penalty += abs(mx[0, k])**2
 
         op_dim = self.state_space.dim
         firstEl = 1.0 / op_dim**0.25
         for rhoVec in list(self.preps.values()):
-            penalty += abs(rhoVec[0, 0] - firstEl)**2
+            penalty += abs(rhoVec.to_dense()[0] - firstEl)**2
 
         return _np.sqrt(penalty)
 
@@ -1343,8 +1344,8 @@ class ExplicitOpModel(_mdl.OpModel):
         kicked_gs = self.copy()
         rndm = _np.random.RandomState(seed)
         for opLabel, gate in self.operations.items():
-            delta = absmag * 2.0 * (rndm.random_sample(gate.shape) - 0.5) + bias
-            kicked_gs.operations[opLabel] = _op.FullArbitraryOp(kicked_gs.operations[opLabel] + delta)
+            delta = absmag * 2.0 * (rndm.random_sample(gate.to_dense().shape) - 0.5) + bias
+            kicked_gs.operations[opLabel] = _op.FullArbitraryOp(kicked_gs.operations[opLabel].to_dense() + delta)
 
         #Note: does not alter intruments!
         return kicked_gs

--- a/pygsti/objectivefns/objectivefns.py
+++ b/pygsti/objectivefns/objectivefns.py
@@ -5771,7 +5771,7 @@ def _cptp_penalty(mdl, prefactor, op_basis):
         a (real) 1D array of length len(mdl.operations).
     """
     return prefactor * _np.sqrt(_np.array([_tools.tracenorm(
-        _tools.fast_jamiolkowski_iso_std(gate, op_basis)
+        _tools.fast_jamiolkowski_iso_std(gate.to_dense(), op_basis)
     ) for gate in mdl.operations.values()], 'd'))
 
 
@@ -5840,7 +5840,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
 
         #get sgn(chi-matrix) == d(|chi|_Tr)/dchi in std basis
         # so sgnchi == d(|chi_std|_Tr)/dchi_std
-        chi = _tools.fast_jamiolkowski_iso_std(gate, op_basis)
+        chi = _tools.fast_jamiolkowski_iso_std(gate.to_dense(), op_basis)
         assert(_np.linalg.norm(chi - chi.T.conjugate()) < 1e-4), \
             "chi should be Hermitian!"
 
@@ -5915,7 +5915,7 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_bas
 
         #get sgn(denMx) == d(|denMx|_Tr)/d(denMx) in std basis
         # dmDim = denMx.shape[0]
-        denmx = _tools.vec_to_stdmx(prepvec, op_basis)
+        denmx = _tools.vec_to_stdmx(prepvec.to_dense(), op_basis)
         assert(_np.linalg.norm(denmx - denmx.T.conjugate()) < 1e-4), \
             "denMx should be Hermitian!"
 
@@ -5950,7 +5950,7 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_bas
             nparams = effectvec.num_params
 
             #get sgn(EMx) == d(|EMx|_Tr)/d(EMx) in std basis
-            emx = _tools.vec_to_stdmx(effectvec, op_basis)
+            emx = _tools.vec_to_stdmx(effectvec.to_dense(), op_basis)
             # dmDim = EMx.shape[0]
             assert(_np.linalg.norm(emx - emx.T.conjugate()) < 1e-4), \
                 "EMx should be Hermitian!"

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -375,7 +375,7 @@ def magnitudes_of_negative_choi_eigenvalues(model):
     """
     ret = []
     for (_, gate) in model.operations.items():
-        J = jamiolkowski_iso(gate, model.basis, choi_mx_basis=model.basis.create_simple_equivalent('std'))
+        J = jamiolkowski_iso(gate.to_dense(on_space='HilbertSchmidt'), model.basis, choi_mx_basis=model.basis.create_simple_equivalent('std'))
         evals = _np.linalg.eigvals(J)  # could use eigvalsh, but wary of this since eigh can be wrong...
         for ev in evals:
             ret.append(-ev.real if ev.real < 0 else 0.0)

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -2225,8 +2225,8 @@ def project_model(model, target_model,
         gsDict[p].set_all_parameterizations("full")
         NpDict[p] = 0
 
-    errgens = [error_generator(model.operations[gl],
-                               target_model.operations[gl],
+    errgens = [error_generator(model.operations[gl].to_dense(),
+                               target_model.operations[gl].to_dense(),
                                target_model.basis, gen_type, logG_weight)
                for gl in opLabels]
 
@@ -2256,7 +2256,7 @@ def project_model(model, target_model,
             lnd_error_gen = _np.tensordot(HBlk.block_data, HGens, (0, 0)) + \
                 _np.tensordot(otherBlk.block_data, otherGens, ((0, 1), (0, 1)))
 
-        targetOp = target_model.operations[gl]
+        targetOp = target_model.operations[gl].to_dense()
 
         if 'H' in projectiontypes:
             gsDict['H'].operations[gl] = operation_from_error_generator(

--- a/scripts/api_names.yaml
+++ b/scripts/api_names.yaml
@@ -1556,8 +1556,6 @@ objects:
       prs_as_polys: prs_as_polynomials
       test_map: null
   operation.py:
-    BasedDenseOperatorInterface:
-      __name__: null
     CliffordOp:
       __name__: null
     ComposedDenseOp:
@@ -1606,11 +1604,6 @@ objects:
     DenseOperator:
       __name__: null
       base: null
-    DenseOperatorInterface:
-      __name__: null
-      deriv_wrt_params: null
-      todense: to_dense
-      tosparse: to_sparse
     DepolarizeOp:
       __name__: null
       copy: null

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -106,8 +106,8 @@ class ModelConstructionTester(BaseCase):
         gateset2b = mc.create_explicit_model_from_expressions([('Q0',)], ['Gi', 'Gx', 'Gy'],
                                                               ["I(Q0)", "X(pi/2,Q0)", "Y(pi/2,Q0)"],
                                                               effect_labels=['1', '0'])
-        self.assertArraysAlmostEqual(model.effects['0'], gateset2b.effects['1'])
-        self.assertArraysAlmostEqual(model.effects['1'], gateset2b.effects['0'])
+        self.assertArraysAlmostEqual(model.effects['0'].to_dense(), gateset2b.effects['1'].to_dense())
+        self.assertArraysAlmostEqual(model.effects['1'].to_dense(), gateset2b.effects['0'].to_dense())
 
         # This is slightly confusing. Single qubit rotations are always stored in "pp" basis internally
         # UPDATE: now this isn't even allowed, as the 'densitymx' type represents states as *real* vectors.
@@ -667,21 +667,21 @@ class GateConstructionBase(object):
         leakA_ans = np.array([[0., 1., 0.],
                               [1., 0., 0.],
                               [0., 0., 1.]], 'd')
-        self.assertArraysAlmostEqual(self.leakA, leakA_ans)
+        self.assertArraysAlmostEqual(self.leakA.to_dense(), leakA_ans)
 
     def _test_rotXa(self):
         rotXa_ans = np.array([[1., 0., 0., 0.],
                               [0., 1., 0., 0.],
                               [0., 0., 0, -1.],
                               [0., 0., 1., 0]], 'd')
-        self.assertArraysAlmostEqual(self.rotXa, rotXa_ans)
+        self.assertArraysAlmostEqual(self.rotXa.to_dense(), rotXa_ans)
 
     def _test_rotX2(self):
         rotX2_ans = np.array([[1., 0., 0., 0.],
                               [0., 1., 0., 0.],
                               [0., 0., -1., 0.],
                               [0., 0., 0., -1.]], 'd')
-        self.assertArraysAlmostEqual(self.rotX2, rotX2_ans)
+        self.assertArraysAlmostEqual(self.rotX2.to_dense(), rotX2_ans)
 
     def _test_rotLeak(self):
         rotLeak_ans = np.array([[0.5, 0., 0., -0.5, 0.70710678],
@@ -689,7 +689,7 @@ class GateConstructionBase(object):
                                 [0., 0., 0., 0., 0.],
                                 [0.5, 0., 0., -0.5, -0.70710678],
                                 [0.70710678, 0., 0., 0.70710678, 0.]], 'd')
-        self.assertArraysAlmostEqual(self.rotLeak, rotLeak_ans)
+        self.assertArraysAlmostEqual(self.rotLeak.to_dense(), rotLeak_ans)
 
     def _test_leakB(self):
         leakB_ans = np.array([[0.5, 0., 0., -0.5, 0.70710678],
@@ -697,7 +697,7 @@ class GateConstructionBase(object):
                               [0., 0., 0., 0., 0.],
                               [-0.5, 0., 0., 0.5, 0.70710678],
                               [0.70710678, 0., 0., 0.70710678, 0.]], 'd')
-        self.assertArraysAlmostEqual(self.leakB, leakB_ans)
+        self.assertArraysAlmostEqual(self.leakB.to_dense(), leakB_ans)
 
     def _test_rotXb(self):
         rotXb_ans = np.array([[1., 0., 0., 0., 0., 0.],
@@ -706,7 +706,7 @@ class GateConstructionBase(object):
                               [0., 0., 0., -1., 0., 0.],
                               [0., 0., 0., 0., 1., 0.],
                               [0., 0., 0., 0., 0., 1.]], 'd')
-        self.assertArraysAlmostEqual(self.rotXb, rotXb_ans)
+        self.assertArraysAlmostEqual(self.rotXb.to_dense(), rotXb_ans)
 
     def _test_CnotA(self):
         CnotA_ans = np.array([[1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -725,7 +725,7 @@ class GateConstructionBase(object):
                               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0, 0, 0],
                               [0, 0, 1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                               [0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-        self.assertArraysAlmostEqual(self.CnotA, CnotA_ans)
+        self.assertArraysAlmostEqual(self.CnotA.to_dense(), CnotA_ans)
 
     def _test_CnotB(self):
         CnotB_ans = np.array([[1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -745,7 +745,7 @@ class GateConstructionBase(object):
                               [0, 0, 1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                               [0, 0, 0, 1.0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                               [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0]])
-        self.assertArraysAlmostEqual(self.CnotB, CnotB_ans)
+        self.assertArraysAlmostEqual(self.CnotB.to_dense(), CnotB_ans)
 
     def test_raises_on_bad_basis(self):
         with self.assertRaises(AssertionError):

--- a/test/unit/construction/test_qutrit.py
+++ b/test/unit/construction/test_qutrit.py
@@ -11,7 +11,7 @@ class QutritConstructionTester(BaseCase):
     def test_noisy_qutrit(self):
         mdl_sim = qutrit.create_qutrit_model(error_scale=0.1, similarity=True, seed=1234, basis='qt')
         mdl_ideal = qutrit.create_qutrit_model(error_scale=0.1, similarity=True, seed=1234, basis='qt')
-        self.assertArraysAlmostEqual(mdl_sim['Gi', 'QT'], mdl_ideal['Gi', 'QT'])
+        self.assertArraysAlmostEqual(mdl_sim['Gi', 'QT'].to_dense(), mdl_ideal['Gi', 'QT'].to_dense())
 
         #just test building a gate in the qutrit basis
         # Can't do this b/c need a 'T*' triplet space designator for "triplet space" and it doesn't seem

--- a/test/unit/extras/interpygate/test_construction.py
+++ b/test/unit/extras/interpygate/test_construction.py
@@ -119,7 +119,7 @@ class InterpygateConstructionTester(BaseCase):
                                 interpolator_and_args='linear')
         op = opfactory_linear.create_op([0,np.pi/4])
         op.from_vector([1])
-        self.assertArraysAlmostEqual(op, self.static_target)
+        self.assertArraysAlmostEqual(op.to_dense(), self.static_target)
 
         if USE_CSAPS: 
             opfactory_spline = interp.InterpolatedOpFactory.create_by_interpolating_physical_process(
@@ -128,7 +128,7 @@ class InterpygateConstructionTester(BaseCase):
                                     interpolator_and_args='spline')
             op = opfactory_spline.create_op([0,np.pi/4])
             op.from_vector([1])
-            self.assertArraysAlmostEqual(op, self.static_target)
+            self.assertArraysAlmostEqual(op.to_dense(), self.static_target)
 
         interpolator_and_args = (_linND, {'rescale': True})
         opfactory_custom = opfactory_spline = interp.InterpolatedOpFactory.create_by_interpolating_physical_process(
@@ -137,7 +137,7 @@ class InterpygateConstructionTester(BaseCase):
                                 interpolator_and_args=interpolator_and_args)
         op = opfactory_custom.create_op([0,np.pi/4])
         op.from_vector([1])
-        self.assertArraysAlmostEqual(op, self.static_target)
+        self.assertArraysAlmostEqual(op.to_dense(), self.static_target)
 
 
 

--- a/test/unit/extras/rb/test_theory.py
+++ b/test/unit/extras/rb/test_theory.py
@@ -55,7 +55,7 @@ class RBTheoryZrotModelTester(GaugeTransformBase, BaseCase):
         Zrot_channel = ot.unitary_to_pauligate(Zrot_unitary)
 
         for key in cls.target_model.operations.keys():
-            cls.mdl.operations[key] = np.dot(Zrot_channel, cls.target_model.operations[key])
+            cls.mdl.operations[key] = np.dot(Zrot_channel, cls.target_model.operations[key].to_dense())
 
 
 class RBTheoryWeightedInfidelityTester(GaugeTransformBase, InfidelityBase, BaseCase):
@@ -72,17 +72,17 @@ class RBTheoryWeightedInfidelityTester(GaugeTransformBase, InfidelityBase, BaseC
         depmap_X = np.array([[1., 0., 0., 0.], [0., lx, 0., 0.], [0., 0., lx, 0.], [0, 0., 0., lx]])
         ly = 1. - depol_strength_Y
         depmap_Y = np.array([[1., 0., 0., 0.], [0., ly, 0., 0.], [0., 0., ly, 0.], [0, 0., 0., ly]])
-        cls.mdl.operations['Gx'] = np.dot(depmap_X, cls.target_model.operations['Gx'])
-        cls.mdl.operations['Gy'] = np.dot(depmap_Y, cls.target_model.operations['Gy'])
+        cls.mdl.operations['Gx'] = np.dot(depmap_X, cls.target_model.operations['Gx'].to_dense())
+        cls.mdl.operations['Gy'] = np.dot(depmap_Y, cls.target_model.operations['Gy'].to_dense())
 
         Gx_weight = 1
         Gy_weight = 2
         cls.weights = {'Gx': Gx_weight, 'Gy': Gy_weight}
-        GxAGI = ot.average_gate_infidelity(cls.mdl.operations['Gx'], cls.target_model.operations['Gx'])
-        GyAGI = ot.average_gate_infidelity(cls.mdl.operations['Gy'], cls.target_model.operations['Gy'])
+        GxAGI = ot.average_gate_infidelity(cls.mdl.operations['Gx'].to_dense(), cls.target_model.operations['Gx'].to_dense())
+        GyAGI = ot.average_gate_infidelity(cls.mdl.operations['Gy'].to_dense(), cls.target_model.operations['Gy'].to_dense())
         cls.expected_AGI = (Gx_weight * GxAGI + Gy_weight * GyAGI) / (Gx_weight + Gy_weight)
-        GxAEI = ot.entanglement_infidelity(cls.mdl.operations['Gx'], cls.target_model.operations['Gx'])
-        GyAEI = ot.entanglement_infidelity(cls.mdl.operations['Gy'], cls.target_model.operations['Gy'])
+        GxAEI = ot.entanglement_infidelity(cls.mdl.operations['Gx'].to_dense(), cls.target_model.operations['Gx'].to_dense())
+        GyAEI = ot.entanglement_infidelity(cls.mdl.operations['Gy'].to_dense(), cls.target_model.operations['Gy'].to_dense())
         cls.expected_EI = (Gx_weight * GxAEI + Gy_weight * GyAEI) / (Gx_weight + Gy_weight)
 
 

--- a/test/unit/modelmembers/test_modelmembergraph.py
+++ b/test/unit/modelmembers/test_modelmembergraph.py
@@ -21,14 +21,16 @@ class TestModelMemberGraph(BaseCase):
 
         # Change parameter, similar but not equivalent
         ex_mdl3 = ex_mdl1.copy()
-        ex_mdl3.operations['Gxpi2', 0][0, 0] = 0.0
+        op_mx = ex_mdl3.operations['Gxpi2', 0].to_dense()
+        op_mx[0,0]= 0.0
+        ex_mdl3.operations['Gxpi2', 0].set_dense(op_mx)
         ex_mmg3 = ex_mdl3.create_modelmember_graph()
         self.assertTrue(ex_mmg3.is_similar(ex_mmg1))
         self.assertFalse(ex_mmg3.is_equivalent(ex_mmg1))
 
         # Change parameterization, not similar or equivalent
         ex_mdl4 = ex_mdl1.copy()
-        ex_mdl4.operations['Gxpi2', 0] = _op.StaticArbitraryOp(ex_mdl4.operations['Gxpi2', 0])
+        ex_mdl4.operations['Gxpi2', 0] = _op.StaticArbitraryOp(ex_mdl4.operations['Gxpi2', 0].to_dense())
         ex_mmg4 = ex_mdl4.create_modelmember_graph()
         self.assertFalse(ex_mmg4.is_similar(ex_mmg1))
         self.assertFalse(ex_mmg4.is_equivalent(ex_mmg1))

--- a/test/unit/modelmembers/test_spamvec.py
+++ b/test/unit/modelmembers/test_spamvec.py
@@ -91,61 +91,16 @@ class DenseStateBase(StateBase):
         self.vec.from_vector(v)
         deriv = self.vec.deriv_wrt_params()
         # TODO assert correctness
-    
-    def test_element_accessors(self):
-        a = self.vec[:]
-        b = self.vec[0]
-        #with self.assertRaises(ValueError):
-        #    self.vec.shape = (2,2) #something that would affect the shape??
-
-        self.vec_as_str = str(self.vec)
-        a1 = self.vec[:]  # invoke getslice method
-        # TODO assert correctness
 
     def test_copy(self):
         vec_copy = self.vec.copy()
         self.assertArraysAlmostEqual(vec_copy.to_dense(), self.vec.to_dense())
         self.assertEqual(type(vec_copy), type(self.vec))
 
-    def test_arithmetic(self):
-        result = self.vec + self.vec
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec + (-self.vec)
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec - self.vec
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec - abs(self.vec)
-        self.assertEqual(type(result), np.ndarray)
-        result = 2 * self.vec
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec * 2
-        self.assertEqual(type(result), np.ndarray)
-        result = 2 / self.vec
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec / 2
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec // 2
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec**2
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec.transpose()
-        self.assertEqual(type(result), np.ndarray)
-
-        V = np.ones((4, 1), 'd')
-
-        result = self.vec + V
-        self.assertEqual(type(result), np.ndarray)
-        result = self.vec - V
-        self.assertEqual(type(result), np.ndarray)
-        result = V + self.vec
-        self.assertEqual(type(result), np.ndarray)
-        result = V - self.vec
-        self.assertEqual(type(result), np.ndarray)
-
-
+   
 class MutableDenseStateBase(DenseStateBase):
     def test_set_value(self):
-        v = np.asarray(self.vec)
+        v = np.asarray(self.vec.to_dense())
         self.vec.set_dense(v)
         # TODO assert correctness
 
@@ -162,7 +117,7 @@ class MutableDenseStateBase(DenseStateBase):
 
 class ImmutableDenseStateBase(DenseStateBase):
     def test_raises_on_set_value(self):
-        v = np.asarray(self.vec)
+        v = np.asarray(self.vec.to_dense())
         with self.assertRaises(ValueError):
             self.vec.set_dense(v)
 

--- a/test/unit/objects/test_explicitmodel.py
+++ b/test/unit/objects/test_explicitmodel.py
@@ -51,14 +51,14 @@ class ExplicitOpModelToolTester(BaseCase):
 
     def test_rotate_1q(self):
         sslbls = ExplicitStateSpace("Q0")
-        rotXPi = create_operation("X(pi,Q0)", sslbls, "pp")
-        rotXPiOv2 = create_operation("X(pi/2,Q0)", sslbls, "pp")
-        rotYPiOv2 = create_operation("Y(pi/2,Q0)", sslbls, "pp")
+        rotXPi = create_operation("X(pi,Q0)", sslbls, "pp").to_dense()
+        rotXPiOv2 = create_operation("X(pi/2,Q0)", sslbls, "pp").to_dense()
+        rotYPiOv2 = create_operation("Y(pi/2,Q0)", sslbls, "pp").to_dense()
         gateset_rot = self.model.rotate((np.pi / 2, 0, 0))  # rotate all gates by pi/2 about X axis
-        self.assertArraysAlmostEqual(gateset_rot['Gi'], rotXPiOv2)
-        self.assertArraysAlmostEqual(gateset_rot['Gx'], rotXPi)
-        self.assertArraysAlmostEqual(gateset_rot['Gx'], np.dot(rotXPiOv2, rotXPiOv2))
-        self.assertArraysAlmostEqual(gateset_rot['Gy'], np.dot(rotXPiOv2, rotYPiOv2))
+        self.assertArraysAlmostEqual(gateset_rot['Gi'].to_dense(), rotXPiOv2)
+        self.assertArraysAlmostEqual(gateset_rot['Gx'].to_dense(), rotXPi)
+        self.assertArraysAlmostEqual(gateset_rot['Gx'].to_dense(), np.dot(rotXPiOv2, rotXPiOv2))
+        self.assertArraysAlmostEqual(gateset_rot['Gy'].to_dense(), np.dot(rotXPiOv2, rotYPiOv2))
 
     def test_rotate_2q(self):
         gateset_2q_rot = self.gateset_2q.rotate(rotate=list(np.zeros(15, 'd')))
@@ -81,9 +81,9 @@ class ExplicitOpModelToolTester(BaseCase):
                            [0, 0, 0.9, 0],
                            [0, -0.9, 0, 0]], 'd')
         gateset_dep = self.model.depolarize(op_noise=0.1)
-        self.assertArraysAlmostEqual(gateset_dep['Gi'], Gi_dep)
-        self.assertArraysAlmostEqual(gateset_dep['Gx'], Gx_dep)
-        self.assertArraysAlmostEqual(gateset_dep['Gy'], Gy_dep)
+        self.assertArraysAlmostEqual(gateset_dep['Gi'].to_dense(), Gi_dep)
+        self.assertArraysAlmostEqual(gateset_dep['Gx'].to_dense(), Gx_dep)
+        self.assertArraysAlmostEqual(gateset_dep['Gy'].to_dense(), Gy_dep)
 
     def test_depolarize_with_spam_noise(self):
         gateset_spam = self.model.depolarize(spam_noise=0.1)

--- a/test/unit/objects/test_instrument.py
+++ b/test/unit/objects/test_instrument.py
@@ -51,12 +51,13 @@ class InstrumentInstanceBase(object):
         self.n_elements = 32
 
         self.model = std.target_model()
-        E = self.model.povms['Mdefault']['0']
-        Erem = self.model.povms['Mdefault']['1']
+        E = self.model.povms['Mdefault']['0'].to_dense()
+        E = E.reshape((len(E),1))
+        Erem = self.model.povms['Mdefault']['1'].to_dense()
+        Erem = Erem.reshape((len(Erem),1))
         self.Gmz_plus = np.dot(E, E.T)
         self.Gmz_minus = np.dot(Erem, Erem.T)
         # XXX is this used?
-        self.povm_ident = self.model.povms['Mdefault']['0'] + self.model.povms['Mdefault']['1']
         self.instrument = self.constructor({'plus': self.Gmz_plus, 'minus': self.Gmz_minus})
         self.model.instruments['Iz'] = self.instrument
         super(InstrumentInstanceBase, self).setUp()

--- a/test/unit/tools/fixtures.py
+++ b/test/unit/tools/fixtures.py
@@ -69,6 +69,7 @@ def mdl_lsgst(self):
         resource_alloc={'mem_limit': self.CM + 1024**3},
         verbosity=0
     )
+    print(models[-1])
     return models[-1]
 
 

--- a/test/unit/tools/test_edesigntools.py
+++ b/test/unit/tools/test_edesigntools.py
@@ -125,8 +125,10 @@ class FisherInformationTester(BaseCase):
         #E0 = target_model.effects['0']
         #E1 = target_model.effects['1']
         # Alternate indexing that uses POVM label explicitly
-        E0 = self.target_model['Mdefault']['0']  # 'Mdefault' = POVM label, '0' = effect label
-        E1 = self.target_model['Mdefault']['1']
+        E0 = self.target_model['Mdefault']['0'].to_dense()
+        E0 = E0.reshape(len(E0),1)  # 'Mdefault' = POVM label, '0' = effect label
+        E1 = self.target_model['Mdefault']['1'].to_dense()
+        E1 = E1.reshape(len(E1),1)
         Gmz_plus = _np.dot(E0,E0.T) #note effect vectors are stored as column vectors
         Gmz_minus = _np.dot(E1,E1.T)
         self.target_model_inst[('Iz',0)] = TPInstrument({'p0': Gmz_plus, 'p1': Gmz_minus})

--- a/test/unit/tools/test_jamiolkowski.py
+++ b/test/unit/tools/test_jamiolkowski.py
@@ -31,13 +31,14 @@ class JamiolkowskiBasisTester(BaseCase):
 
         #Build a test gate   -- old # X(pi,Qhappy)*LX(pi,0,2)
         self.testGate = create_operation("LX(pi,0,2)", self.sslbls, self.stdSmall)
-        self.testGateGM_mx = bt.change_basis(self.testGate, self.stdSmall, self.gmSmall)
-        self.expTestGate_mx = bt.flexible_change_basis(self.testGate, self.stdSmall, self.std)
+        self.testGatemx = self.testGate.to_dense()
+        self.testGateGM_mx = bt.change_basis(self.testGatemx, self.stdSmall, self.gmSmall)
+        self.expTestGate_mx = bt.flexible_change_basis(self.testGatemx, self.stdSmall, self.std)
         self.expTestGateGM_mx = bt.change_basis(self.expTestGate_mx, self.std, self.gm)
 
     def checkBasis(self, cmb):
         #Op with Jamio map on gate in std and gm bases
-        Jmx1 = j.jamiolkowski_iso(self.testGate, op_mx_basis=self.stdSmall,
+        Jmx1 = j.jamiolkowski_iso(self.testGatemx, op_mx_basis=self.stdSmall,
                                   choi_mx_basis=cmb)
         Jmx2 = j.jamiolkowski_iso(self.testGateGM_mx, op_mx_basis=self.gmSmall,
                                   choi_mx_basis=cmb)
@@ -64,7 +65,7 @@ class JamiolkowskiBasisTester(BaseCase):
         #Reverse transform without specifying stateSpaceDims, then contraction, should yield same result
         revExpTestGate_mx = j.jamiolkowski_iso_inv(Jmx1, choi_mx_basis=cmb, op_mx_basis=self.std)
         self.assertArraysAlmostEqual(bt.resize_std_mx(revExpTestGate_mx, 'contract', self.std, self.stdSmall),
-                                     self.testGate)
+                                     self.testGatemx)
 
     def test_std_basis(self):
         #mx_dim = sum([ int(np.sqrt(d)) for d in ])


### PR DESCRIPTION
This PR removes the `DenseOperatorInterface`, `DenseStateInterface` and `DenseEffectInterface` classes. These classes enabled interfacing with certain densely parameterized model members as if they we numpy arrays. These classes were official deprecated with the release of 0.9.13 and as an issue is being tracked by #447. Following discussions it was decided that due to some pernicious bugs introduced by these classes, as well as the suboptimality of having a bifurcated API, the best course of action was to simplify the codebase and remove these.

As a side-effect of these changes issue #397 should be resolved.

Simply removing these classes obviously breaks a lot of code and backwards compatibility, so included here are a number of patches which at a minimum transition the main pyGSTi codebase away from the old API. We had originally targeted full removal in 0.9.14, but now that I've seen just how much of the code needed patching I suggest we push the full removal to 0.9.15. This will allow us to merge in this PR shortly after 0.9.14 is released, and as such will maximize the amount of time we can beta test these changes on develop making it much more likely we'll suss out any stragglers before wider release. 