### PR TITLE
PyPI Deployment Fix (v0.9.13.2)

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.2
         env:
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-*
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: ./.github/ci-scripts/before_install.sh
           CIBW_BEFORE_ALL_MACOS: ./.github/ci-scripts/before_install_macos.sh
@@ -43,7 +43,6 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
-    #if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')   # doesn't work -- try using tags: above
     
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +55,9 @@ jobs:
           python-version: '3.10'
 
       - name: Build sdist
-        run: python setup.py sdist
+        run: |
+          pip install build
+          python -m build --sdist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -66,7 +66,7 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    #if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.10'
           
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
           CIBW_BUILD_VERBOSITY: 1

--- a/pygsti/layouts/prefixtable.py
+++ b/pygsti/layouts/prefixtable.py
@@ -12,7 +12,6 @@ Defines the PrefixTable class.
 
 import collections as _collections
 import networkx as _nx
-import matplotlib.pyplot as plt
 from math import ceil
 from pygsti.baseobjs import Label as _Label
 from pygsti.circuits.circuit import SeparatePOVMCircuit as _SeparatePOVMCircuit
@@ -1208,6 +1207,14 @@ def _draw_graph(G, node_label_key='label', edge_label_key='promotion_cost', figu
         An optional size specifier passed into the matplotlib figure
         constructor to set the plot size.
     """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as e:
+        msg = 'The function `_draw_graph` requires the installation of matplotlib.'\
+              +'Please ensure this is properly installed and try again.'
+        print(msg)
+        raise e
+
     plt.figure(figsize=figure_size)
     pos = _nx.nx_agraph.graphviz_layout(G, prog="dot", args="-Granksep=5 -Gnodesep=10")
     labels = _nx.get_node_attributes(G, node_label_key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,7 @@ complete = ['pygsti[multiprocessor,no_mpi]']
 Homepage = 'https://www.pygsti.info'
 Repository = 'https://github.com/sandialabs/pyGSTi'
 Download ='https://github.com/sandialabs/pyGSTi/tarball/master'
+
+[tool.setuptools_scm]
+version_scheme = "only-version"
+local_scheme = "no-local-version"


### PR DESCRIPTION
This PR fixes an issue with the deployment process for release on pypi which had resulted in the source distribution and a handful of wheels being missing from the latest release.

Unrelated, a minor import/dependency issue with matplotlib that was caught in testing the deployment changes.

To avoid name-reuse issues with pypi (my understanding is that once a version number is used it can't be reassigned after the fact even if you delete a release) this will become a new bugfix version 0.9.13.2.