### PR TITLE
Hack For Issue #484

### DIFF
--- a/pygsti/circuits/circuitstructure.py
+++ b/pygsti/circuits/circuitstructure.py
@@ -719,16 +719,6 @@ class PlaquetteGridCircuitStructure(_CircuitList):
                                           if (self.circuit_weights is not None) else None)
                       })
 
-        #state['plaquette_types'] = XXX
-        #state['datacols'] = {
-        #    'Circuit': [circuits]
-        #    'PlaquetteX':
-        #    'PlaquetteY':
-        #    'X':
-        #    'Y':
-        #    'weight':
-        #    # additional circuits have sentinels for Plaquette coords?
-
         return state
 
     @classmethod

--- a/pygsti/circuits/gstcircuits.py
+++ b/pygsti/circuits/gstcircuits.py
@@ -544,7 +544,10 @@ def create_lsgst_circuit_lists(op_label_src, prep_fiducials, meas_fiducials, ger
         unindexed = filter_ds(lgst_list, dscheck, missing_lgst)
         lsgst_structs.append(
             _PlaquetteGridCircuitStructure({}, [], germs, "L", "germ", unindexed, op_label_aliases,
-                                           circuit_weights_dict=None, additional_circuits_location='start', name=None))
+                                           circuit_weights_dict=None, additional_circuits_location='start', name=None)).copy() #HACK
+        #TODO: The copy above is a hack related to a really hard to track bug where the ordering of the
+        #_circuit attribute of the PlaquetteGridCircuitStructure is somehow changing after copying compared
+        #to how it is constructed here.
 
     for i, maxLen in enumerate(max_lengths):
 
@@ -634,7 +637,10 @@ def create_lsgst_circuit_lists(op_label_src, prep_fiducials, meas_fiducials, ger
         lsgst_structs.append(
             _PlaquetteGridCircuitStructure({pkey[base]:plaq for base, plaq in plaquettes.items()},
                                            maxLens, germs, "L", "germ", unindexed, op_label_aliases,
-                                           circuit_weights_dict=None, additional_circuits_location='start', name=None))
+                                           circuit_weights_dict=None, additional_circuits_location='start', name=None).copy()) #HACK
+        #TODO: The copy above is a hack related to a really hard to track bug where the ordering of the
+        #_circuit attribute of the PlaquetteGridCircuitStructure is somehow changing after copying compared
+        #to how it is constructed here.
         tot_circuits += len(lsgst_structs[-1])  # only relevant for non-nested case
 
     if nest:  # then totStrs computation about overcounts -- just take string count of final stage


### PR DESCRIPTION
This is a hacky fix for the issue reported in #484. It was reported there that when serializing and deserializing certain `PlaquetteGridCircuitStructure` objects one wouldn't get exactly identical. Drilling down it was determined that the underlying issue wasn't serialization, but in fact one could reproduce this by taking the `PlaquetteGridCircuitStructure` produced by the function `pygsti.circuits.create_lsgst_circuit_lists` (which is used in the GST experiment design construction workflow internally) and then either copy, or simply instantiate a new `PlaquetteGridCircuitStructure` pulling all of the inputs from the corresponding attributes of the originally produced one and one would get a new instance apparently identical in all ways except for the ordering of the underlying `_circuits` attribute. For the life of me I can't figure out why that is, and there is nothing obvious in the construction logic used in `pygsti.circuits.create_lsgst_circuit_lists` that I can see which would cause this. So, since based on my testing the contents are identical up to the ordering, I've introduced a hacky patch which makes a copy of the `PlaquetteGridCircuitStructure`s in `pygsti.circuits.create_lsgst_circuit_lists` before returning them.