### PR TITLE
Ipython 9.0 Deprecation

### DIFF
--- a/pygsti/report/workspace.py
+++ b/pygsti/report/workspace.py
@@ -62,7 +62,7 @@ def display_ipynb(content):
     -------
     None
     """
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
     display(HTML(content))
 
 


### PR DESCRIPTION
This addresses what looks to be an expired module name alias deprecation in Ipython 9.0 for the `core.display` module.

This issue, and the fix identified here, was kindly reported in #593 by @liuyichao82.