### PR TITLE
Add version file directive to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,5 +98,6 @@ Repository = 'https://github.com/sandialabs/pyGSTi'
 Download ='https://github.com/sandialabs/pyGSTi/tarball/master'
 
 [tool.setuptools_scm]
+version_file = "pygsti/_version.py"
 version_scheme = "only-version"
 local_scheme = "no-local-version"


### PR DESCRIPTION
This patches a configuration error with the pyproject.toml file that meant the expected _version.py file was not being autogenerated.
