### PR TITLE
Circuit to OpenQASM conversion breaks when using ECR gates

### DIFF
--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -730,6 +730,7 @@ def standard_gatenames_openqasm_conversions(version='u3'):
         std_gatenames_to_qasm['Gc23'] = ['u3(0, 0, 4.71238898038469)']  # [0, 0, 3] * pi/2 (this is Gzmpi2 / Gpdag)
 
         std_gatenames_to_qasm['Gecr'] = ['ecr']
+        std_gatenames_to_qasm['Gecres'] = ['ecr']
 
         std_gatenames_to_argmap = {}
         std_gatenames_to_argmap['Gzr'] = lambda gatearg: ['u3(0, 0, ' + str(gatearg[0]) + ')']
@@ -785,6 +786,7 @@ def standard_gatenames_openqasm_conversions(version='u3'):
         std_gatenames_to_qasm['Gtdag'] = ['rz(5.497787143782138)']
 
         std_gatenames_to_qasm['Gecr'] = ['ecr']
+        std_gatenames_to_qasm['Gecres'] = ['ecr']
 
         std_gatenames_to_argmap = {}
         std_gatenames_to_argmap['Gzr'] = lambda gatearg: ['rz(' + str(gatearg[0]) + ')']


### PR DESCRIPTION
Fixes #608

Added `"Gecres"` conversion to `"ecr"`.
Since `"Gecres"` is the key associated with the ECR unitary and is most likely used in existing processor specs, this seemed like the fix least likely to break existing code.