### PR TITLE
Fix dictionary comprehension for gate unitary renaming in QuditProcessorSpec

### DIFF
--- a/pygsti/processors/processorspec.py
+++ b/pygsti/processors/processorspec.py
@@ -535,9 +535,9 @@ class QuditProcessorSpec(ProcessorSpec):
             return new_gate_name if (nm == existing_gate_name) else nm
 
         self.gate_names = tuple([rename(nm) for nm in self.gate_names])
-        self.nonstd_gate_unitaries = {rename(k): v for k, v in self.nonstd_gate_unitaries}
-        self.gate_unitaries = {rename(k): v for k, v in self.gate_unitaries}
-        self.availability = {rename(k): v for k, v in self.availability}
+        self.nonstd_gate_unitaries = {rename(k): v for k, v in self.nonstd_gate_unitaries.items()}
+        self.gate_unitaries = {rename(k): v for k, v in self.gate_unitaries.items()}
+        self.availability = {rename(k): v for k, v in self.availability.items()}
 
     def resolved_availability(self, gate_name, tuple_or_function="auto"):
         """


### PR DESCRIPTION
Any usage of `rename_gate_inplace` breaks since `items()` was missing in the dict comprehensions