### PR TITLE
Per seq threshold and miscellaneous QI serialization fixes

### DIFF
--- a/pygsti/modelmembers/instruments/tpinstrument.py
+++ b/pygsti/modelmembers/instruments/tpinstrument.py
@@ -174,7 +174,7 @@ class TPInstrument(_mm.ModelMember, _collections.OrderedDict):
         lbl_member_pairs = [(lbl, serial_memo[subm_serial_id])
                             for lbl, subm_serial_id in zip(mm_dict['member_labels'], mm_dict['submembers'])]
         MT_member = next(filter(lambda pair: pair[1].index == len(lbl_member_pairs) - 1, lbl_member_pairs))
-        param_ops = MT_member.submembers()  # the final (TP) member has all the param_ops as its submembers
+        param_ops = MT_member[-1].submembers()  # the final (TP) member has all the param_ops as its submembers
 
         ret = TPInstrument.__new__(TPInstrument)
         ret.param_ops = param_ops

--- a/pygsti/processors/processorspec.py
+++ b/pygsti/processors/processorspec.py
@@ -309,7 +309,7 @@ class QuditProcessorSpec(ProcessorSpec):
 
         nonstd_preps = {k: _serialize_state(obj) for k, obj in self.nonstd_preps.items()}
         nonstd_povms = {k: _serialize_povm(obj) for k, obj in self.nonstd_povms.items()}
-        nonstd_instruments = {':'.join(k): _serialize_instrument(obj) for k, obj in self.nonstd_instruments.items()}
+        nonstd_instruments = {':'.join(map(str, k)): _serialize_instrument(obj) for k, obj in self.nonstd_instruments.items()}
 
         state.update({'qudit_labels': list(self.qudit_labels),
                       'qudit_udims': list(self.qudit_udims),

--- a/pygsti/report/workspaceplots.py
+++ b/pygsti/report/workspaceplots.py
@@ -2586,7 +2586,7 @@ class ColorBoxPlot(WorkspacePlot):
             else: dataMax = 0
 
             if colormapType == "linlog":
-                colormap = _colormaps.LinlogColormap(0, dataMax, n_boxes,
+                colormap = _colormaps.LinlogColormap(0, dataMax, len(circuits),
                                                      linlg_pcntle, dof_per_box, linlog_color)
             elif colormapType == "manuallinlog":
                 colormap = _colormaps.LinlogColormap.set_manual_transition_point(


### PR DESCRIPTION
Hi Corey,

This should address the remainder of your email. There are three one line fixes:

1) Correcting the threshold calculation for the per sequence detail plot to use the number of circuits not the number of boxes.
2) Addressing a typo that means quantum instruments fail to deserialize correctly. 
3) Fixing a bug where integer qubit labels used with quantum instruments fail to serialize correctly. 