### PR TITLE
Reenable Tests Involving Dataframes

### DIFF
--- a/test/unit/extras/ibmq/test_ibmqexperiment.py
+++ b/test/unit/extras/ibmq/test_ibmqexperiment.py
@@ -136,12 +136,11 @@ class IBMQExperimentTester():
         # Computes the summary statistics for each circuit
         results = stats_generator.run(data)
 
-        #TODO: Turn back on correctness checks when I figure out the pandas 2.3.1 and python 3.12 incompatibilities here.
         # Turns the results into a data frame.
-        #df = results.to_dataframe('ValueName', drop_columns=['ProtocolName','ProtocolType'])
+        df = results.to_dataframe('ValueName', drop_columns=['ProtocolName','ProtocolType'])
 
         # Here's a simple test that everything worked correctly (it's a noise-free simulation)
-        #assert(all(1. == df['success_probabilities']))
+        assert(all(1. == df['success_probabilities']))
 
     #End-to-end integration test for MCM GST.
     def test_e2e_MCM_gst(self):

--- a/test/unit/protocols/test_protocols.py
+++ b/test/unit/protocols/test_protocols.py
@@ -180,7 +180,7 @@ class ExperimentDesignTester(BaseCase):
                 self.assertTrue((root2 / 'edesign' / 'all_circuits_needing_data.txt').exists())
     
     def test_dataframe_conversion(self):
-        self.skipTest('Will turn this back on when we figure out a new incompatibility due to changes in python 3.12 and pandas 2.3.1')
+        #self.skipTest('Will turn this back on when we figure out a new incompatibility due to changes in python 3.12 and pandas 2.3.1')
         # Currently this is just FreeformDesign, but who knows if we add dataframe support to others in the future
         edesigns = self._get_tester_edesigns()
         freeform_design = edesigns[4]


### PR DESCRIPTION
Re-enable unit tests which now should work with #636 fixed.