### PR TITLE
Bugfix HTML Report Regressions

### DIFF
--- a/pygsti/report/templates/offline/pygsti_dataviz.css
+++ b/pygsti/report/templates/offline/pygsti_dataviz.css
@@ -72,8 +72,8 @@ th .errorbar {
 	}
 
 .dataTable {
-        /* text */
-        font-family: "Computer Modern Serif","times new roman",serif;
+    /* text */
+    font-family: "Computer Modern Serif","times new roman",serif;
 	/*Helvetica, Arial, sans-serif;*/
 
 	/* no space between cells */
@@ -84,9 +84,9 @@ th .errorbar {
 	width: auto;
 	margin: auto;
 	margin-top: 5px;
-	max-width: 100%;
+	max-width: none;
 	overflow: auto; /*hidden; - this hides content sometimes - needed?  */
-        }
+    }
 
 /*.dataTable tr {
     width: 20%;

--- a/pygsti/report/templates/offline/pygsti_plotly_ex.js
+++ b/pygsti/report/templates/offline/pygsti_plotly_ex.js
@@ -119,8 +119,11 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	    else { padding = parseFloat(padding); }
 	    desiredW =	max_width(plots)+2*padding;
             desiredH =	max_height(plots)+2*padding
-            $(td).css("width", desiredW);
+            $(td).css("min-width", desiredW);
             $(td).css("height", desiredH);
+        console.log("desired width: ", desiredW)
+        console.log("desired height: ", desiredH)
+        
 	    if(TDtoCheck === null) TDtoCheck = $(td); //just take the first one
 
 	    if(!initial_autosize) {

--- a/pygsti/report/workspaceplots.py
+++ b/pygsti/report/workspaceplots.py
@@ -1348,6 +1348,14 @@ def _opmatrices_color_boxplot(op_matrices, color_min, color_max, mx_basis_x=None
     row_col_indices = list(_product(range(1,num_rows+1), range(1,num_cols+1)))
     fig = make_subplots(rows=num_rows, cols=num_cols, subplot_titles=subtitles)
 
+    #Need to bump up the height of the subtitles
+    #if the annotation is one of the subtitles we need to bump up
+    #the y value a bit.
+    if subtitles is not None:
+        for annotation in fig.layout.annotations:
+            if annotation['text'] in subtitles:
+                annotation['y']+=0.06
+
     if isinstance(mx_basis_x, str):
         mx_basis_x = _baseobjs.BuiltinBasis(mx_basis_x, op_matrices[0].shape[1])
     if isinstance(mx_basis_y, str):
@@ -1383,7 +1391,11 @@ def _opmatrices_color_boxplot(op_matrices, color_min, color_max, mx_basis_x=None
                                                                 xlabel, ylabel, box_labels, thickLineInterval,
                                                                 colorbar, colormap, prec, scale,
                                                                 eb_matrix, None))
-
+    remapped_annotations = []
+    remapped_shapes = []
+    #add in the existing annotations in fig to start (should at minimum include "Real" and "Imag" headings).
+    remapped_annotations.extend(fig.layout['annotations'])
+    remapped_shapes.extend(fig.layout['shapes'])
     for i, row in enumerate(op_matrix_plots):
         for j, matrix in enumerate(row):
             #add the first trace (data[0]) to figure
@@ -1399,14 +1411,15 @@ def _opmatrices_color_boxplot(op_matrices, color_min, color_max, mx_basis_x=None
             for shape in matrix_shapes:
                 shape['xref'] = f'x{flattened_idx}'
                 shape['yref'] = f'y{flattened_idx}'
-                fig.add_shape(shape)
+                remapped_shapes.append(shape)
             #do this same remapping with the annotations
             matrix_annotations = matrix_dict_layout['annotations']
             for annotation in matrix_annotations:
                 annotation['xref'] = f'x{flattened_idx}'
                 annotation['yref'] = f'y{flattened_idx}'
-                fig.add_annotation(annotation)
-            
+                remapped_annotations.append(annotation)
+    fig.update_layout(annotations=remapped_annotations, shapes=remapped_shapes)
+
     #set the width of the composite figure to be equal to the width of the widest row.
     row_widths = [[] for _ in range(num_rows)]
     for i, row in enumerate(op_matrix_plots):
@@ -1442,13 +1455,7 @@ def _opmatrices_color_boxplot(op_matrices, color_min, color_max, mx_basis_x=None
     )
 
     fig.update_layout(layout)
-    #Need to bump up the height of the subtitles
-    #if the annotation is one of the subtitles we need to bump up
-    #the y value a bit.
-    for annotation in fig.layout.annotations:
-        if annotation['text'] in subtitles:
-            annotation['y']+=0.06
-
+    
     return ReportFigure(fig)
 
 


### PR DESCRIPTION
This PR fixes a pair of regressions introduced with the recent HTML report changes introduced in 0.9.14, which only became apparent in testing 2Q GST report generator. The problems addressed here are:

1. Some of the new figures, particular operation plots like those in the error generator and raw estimates, are now wider. CSS configuration conflicts made it so that the table wasn't able to scale to the needed width for the content within. This led to figures which overlapped rendering 2Q tables mostly unreadable. Tables no longer have a maximum width, and there is a minimum cell width set such that each cell is wide enough for its contents by default.
2. Fixes performance regressions introduced in the operation matrix plotting routines related to inefficient use of plotly figure updates.
