### PR TITLE
Add `tqdm` as a proper dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies=[
     'stim',
     'plotly>=3.8.0',
     'pandas',
-    'networkx'
+    'networkx',
+    'tqdm>=4.42.0'
 ]
 requires-python='>=3.9'
 keywords=[
@@ -59,7 +60,6 @@ html_reports = ['jinja2', 'MarkupSafe']
 ibmq = [
     'qiskit>1',
     'qiskit-ibm-runtime>=0.17.1',
-    'tqdm>=4.42.0',
     'dill'
 ]
 interpygate = ['csaps']


### PR DESCRIPTION
I maintain the https://github.com/conda-forge/pygsti-feedstock/ build for conda-forge. I noticed that `tqdm` is not required for pygsti. Since https://github.com/sandialabs/pyGSTi/commit/57c78536f265afdadccce769fa093891f4118dd6 was merged.