### PR TITLE
Resolve round-trip serializability issues with ModelMember labels and Circuit line labels

### DIFF
--- a/pygsti/algorithms/core.py
+++ b/pygsti/algorithms/core.py
@@ -468,10 +468,10 @@ def _construct_a(effect_fiducials, model):
         #A[k,:] = st[0,:] # E_k == kth row of A
         for i in range(dim):  # propagate each basis initial state
             basis_st[i] = 1.0
-            model.preps['rho_LGST_tmp'] = basis_st
-            probs = model.probabilities(_circuits.Circuit(('rho_LGST_tmp',), line_labels=estr.line_labels) + estr)
+            model.preps['rho_lgst_tmp'] = basis_st
+            probs = model.probabilities(_circuits.Circuit(('rho_lgst_tmp',), line_labels=estr.line_labels) + estr)
             A[eoff:eoff + povmLen, i] = [probs[(ol,)] for ol in model.povms[povmLbl]]  # CHECK will this work?
-            del model.preps['rho_LGST_tmp']
+            del model.preps['rho_lgst_tmp']
             basis_st[i] = 0.0
 
         eoff += povmLen
@@ -497,16 +497,16 @@ def _construct_b(prep_fiducials, model):
         basis_E = _np.zeros((dim, 1), 'd')
         basis_E[i] = 1.0
         basis_Es.append(basis_E)
-    model.povms['M_LGST_tmp_povm'] = _povm.UnconstrainedPOVM(
+    model.povms['M_lgst_tmp_povm'] = _povm.UnconstrainedPOVM(
         [("E%d" % i, E) for i, E in enumerate(basis_Es)], evotype='default')
 
     for k, rhostr in enumerate(prep_fiducials):
         #Build fiducial | rho_k > := Circuit(prepSpec[0:-1]) | rhoVec[ prepSpec[-1] ] >
         # B[:,k] = st[:,0] # rho_k == kth column of B
-        probs = model.probabilities(rhostr + _circuits.Circuit(('M_LGST_tmp_povm',), line_labels=rhostr.line_labels))
+        probs = model.probabilities(rhostr + _circuits.Circuit(('M_lgst_tmp_povm',), line_labels=rhostr.line_labels))
         B[:, k] = [probs[("E%d" % i,)] for i in range(dim)]  # CHECK will this work?
 
-    del model.povms['M_LGST_tmp_povm']
+    del model.povms['M_lgst_tmp_povm']
     model.povms.default_param = old_default_param
 
     return B

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -189,6 +189,7 @@ def _op_seq_to_str(seq, line_labels, occurrence_id, compilable_layer_indices):
                          for i, layer_el in enumerate(processed_seq)]
         return ''.join(str_processed) + _op_seq_str_suffix(line_labels, occurrence_id)
 
+
 def _sort_layer_labels(label_list: list[ConcreteLabel]) -> tuple[_Label]:
     """
     For every layer of the label list ensure that the gates mentioned within the
@@ -206,23 +207,16 @@ def _sort_layer_labels(label_list: list[ConcreteLabel]) -> tuple[_Label]:
     return tuple(sorted_labels_list)
 
 
-def to_label(x):
-    """
-    Helper function for converting `x` to a single Label object
-
-    Parameters
-    ----------
-    x : various
-        An object to (attempt to) convert into a :class:`Label`.
-
-    Returns
-    -------
-    Label
-    """
-    if isinstance(x, _Label): return x
-    # # do this manually when desired, as it "boxes" a circuit being inserted
-    #elif isinstance(x,Circuit): return x.to_circuit_label()
-    else: return _Label(x)
+def validate_line_labels(linelabels):
+    from pygsti.circuits.circuitparser import parse_label
+    for line_lbl in linelabels:
+        if line_lbl == '*': continue
+        test_str = f'Gi:{str(line_lbl)}'
+        parsed = str(parse_label(test_str))  # can trigger a ValueError.
+        if parsed != test_str:
+            msg = "Line label '{line_lbl}' could not round-trip through the parse_label function."
+            raise ValueError(msg)
+    return
 
 
 class Circuit(object):
@@ -446,7 +440,7 @@ class Circuit(object):
         if expand_subcircuits == "default":
             expand_subcircuits = Circuit.default_expand_subcircuits
         if expand_subcircuits and layer_labels is not None:
-            layer_labels_objs = tuple(_itertools.chain(*[x.expand_subcircuits() for x in map(to_label, layer_labels)]))
+            layer_labels_objs = tuple(_itertools.chain(*[x.expand_subcircuits() for x in map(_Label, layer_labels)]))
 
         #Parse stringrep if needed
         if stringrep is not None and (layer_labels is None or check):
@@ -454,13 +448,13 @@ class Circuit(object):
             cparser.lookup = None  # lookup - functionality removed as it wasn't used
             chk, chk_labels, chk_occurrence, chk_compilable_inds = cparser.parse(stringrep)  # tuple of Labels
             if expand_subcircuits and chk is not None:
-                chk = tuple(_itertools.chain(*[x.expand_subcircuits() for x in map(to_label, chk)]))
+                chk = tuple(_itertools.chain(*[x.expand_subcircuits() for x in map(_Label, chk)]))
 
             if layer_labels is None:
                 layer_labels = chk
             else:  # check == True
                 if layer_labels_objs is None:
-                    layer_labels_objs = tuple(map(to_label, layer_labels))
+                    layer_labels_objs = tuple(map(_Label, layer_labels))
                 expect_len = len(chk)
                 actual_len = len(layer_labels_objs)
                 if expect_len != actual_len:
@@ -516,7 +510,7 @@ class Circuit(object):
         # Set self._line_labels
         if line_labels == 'auto':
             if layer_labels_objs is None:
-                layer_labels_objs = tuple(map(to_label, layer_labels))
+                layer_labels_objs = tuple(map(_Label, layer_labels))
             explicit_lbls = _accumulate_explicit_sslbls(layer_labels_objs)
             if len(explicit_lbls) == 0:
                 if num_lines is not None:
@@ -546,16 +540,17 @@ class Circuit(object):
         if check:
             if explicit_lbls is None:
                 if layer_labels_objs is None:
-                    layer_labels_objs = tuple(map(to_label, layer_labels))
+                    layer_labels_objs = tuple(map(_Label, layer_labels))
                 explicit_lbls = _accumulate_explicit_sslbls(layer_labels_objs)
             if not set(explicit_lbls).issubset(my_line_labels):
                 raise ValueError("line labels must contain at least %s" % str(explicit_lbls))
+            validate_line_labels(my_line_labels)
 
         #Set compute self._labels, which is either a nested list of simple labels (non-static case)
         #  or a tuple of Label objects (static case)
         if not editable:
             if layer_labels_objs is None:
-                layer_labels_objs = map(to_label, layer_labels)
+                layer_labels_objs = map(_Label, layer_labels)
             labels = _sort_layer_labels(layer_labels_objs)
             layer_labels_objs = labels
         else:
@@ -574,6 +569,7 @@ class Circuit(object):
         #Set *all* class attributes (separated so can call bare_init separately for fast internal creation)
         self._bare_init(labels, my_line_labels, editable, name, stringrep,
                         occurrence, compilable_layer_indices_tup)
+        return
 
     @staticmethod
     def _fastinit(labels, line_labels, editable, name='', stringrep=None, occurrence=None,
@@ -1425,7 +1421,7 @@ class Circuit(object):
         if int_layers:
             if isinstance(lbls, Circuit):  # special case: "box" a circuit assigned to a single layer
                 lbls = lbls.to_label()     # converts Circuit => CircuitLabel
-            lbls = to_label(lbls)
+            lbls = _Label(lbls)
             lbls_sslbls = None if (lbls.sslbls is None) else set(lbls.sslbls)
         else:
             if isinstance(lbls, Circuit):
@@ -1436,7 +1432,7 @@ class Circuit(object):
             assert(isinstance(lbls, (tuple, list))), \
                 ("When assigning to a layer range (even w/len=1) `lbls` "
                  "must be  a *list or tuple* of label-like items")
-            lbls = tuple(map(to_label, lbls))
+            lbls = tuple(map(_Label, lbls))
             lbls_sslbls = None if any([l.sslbls is None for l in lbls]) \
                 else set(_itertools.chain(*[l.sslbls for l in lbls]))
 
@@ -1673,7 +1669,7 @@ class Circuit(object):
         assert(not self._static), "Cannot edit a read-only circuit!"
         if isinstance(lbls, Circuit): lbls = tuple(lbls)
         # lbls is expected to be a list/tuple of Label-like items, one per inserted layer
-        lbls = tuple(map(to_label, lbls))
+        lbls = tuple(map(_Label, lbls))
         numLayersToInsert = len(lbls)
         self.insert_idling_layers_inplace(layer_to_insert_before, numLayersToInsert, lines)  # make space
         self.set_labels(lbls, slice(layer_to_insert_before, layer_to_insert_before + numLayersToInsert), lines)
@@ -2327,7 +2323,7 @@ class Circuit(object):
         assert(not self._static), "Cannot edit a read-only circuit!"
         if self._line_labels is None or self._line_labels == ():
             #Allow insertion of a layer into an empty circuit to update the circuit's line_labels
-            layer_lbl = to_label(circuit_layer)
+            layer_lbl = _Label(circuit_layer)
             self.line_labels = layer_lbl.sslbls if (layer_lbl.sslbls is not None) else ('*',)
 
         self.insert_labels_into_layers_inplace([circuit_layer], j)
@@ -2745,8 +2741,8 @@ class Circuit(object):
         -------
         Circuit
         """
-        old_layer = to_label(old_layer)
-        new_layer = to_label(new_layer)
+        old_layer = _Label(old_layer)
+        new_layer = _Label(new_layer)
         if not self._static:
             #Could to this in both cases, but is slow for large static circuits
             cpy = self.copy(editable=False)  # convert our layers to Labels
@@ -3101,7 +3097,7 @@ class Circuit(object):
         assert(not self._static),"Cannot edit a read-only circuit!"
 
         if idle_layer_labels:
-            assert(all([to_label(x).sslbls is None for x in idle_layer_labels])), "Idle layer labels must be *global*"
+            assert(all([_Label(x).sslbls is None for x in idle_layer_labels])), "Idle layer labels must be *global*"
 
         if self._static:
             layers = [x for x in self._labels if x not in idle_layer_labels] if idle_layer_labels else self._labels

--- a/pygsti/circuits/circuitparser/fastcircuitparser.pyx
+++ b/pygsti/circuits/circuitparser/fastcircuitparser.pyx
@@ -259,19 +259,35 @@ cdef get_next_simple_lbl(unicode s, INT start, INT end, bool integerize_sslbls, 
     sslbls = []
     while i < end and s[i] == u':':
         i += 1
-        last = i; is_int = True
+        last = i
+        is_int = True
         while i < end:
             c = s[i]
             if u'0' <= c <= u'9':
                 i += 1
-            elif u'a' <= c <= u'z' or c == u'_' or c == u'Q':
-                i += 1; is_int = False
+            elif u'a' <= c <= u'z' or c == u'_':
+                # Labels can contain any combination of lowercase letters and underscores.
+                i += 1
+                is_int = False
+            elif c in (u'G', u'M', u'I', u'S'):
+                # These reserved characters (all uppercase letters) indicate that we've already
+                # seen everything there is to see for the most recent/current label.
+                break
+            elif last == i and c in (u'Q', u'T', u'L'):
+                # Labels can start with reserved uppercase letters Q, T, and L, per the 
+                # StateSpace documentation.
+                i += 1
+                is_int = False
+            elif last == i and u'A' <= c <= u'Z':
+                msg = f"Invalid target label: {s[last:i + 1]!r}. Labels can't start with uppercase letters other than Q, T, and L."
+                raise ValueError(msg)
             else:
                 break
         if integerize_sslbls and is_int:
-            sslbls.append(int(s[last:i])); last = i
+            sslbls.append(int(s[last:i]))
         else:
-            sslbls.append(sys.intern(s[last:i])); last = i
+            sslbls.append(sys.intern(s[last:i]))
+        last = i
 
     if i < end and s[i] == u'!':
         i += 1

--- a/pygsti/circuits/circuitparser/slowcircuitparser.py
+++ b/pygsti/circuits/circuitparser/slowcircuitparser.py
@@ -9,6 +9,7 @@
 #***************************************************************************************************
 
 from pygsti.baseobjs import label as _lbl
+import sys
 
 
 def _to_int_or_strip(x):
@@ -194,23 +195,37 @@ def _get_next_simple_lbl(s, start, end, integerize_sslbls, segment):
         args.append(arg); last = i
 
     sslbls = []
-    while i < end and s[i] == ':':
+    while i < end and s[i] == u':':
         i += 1
         last = i
+        is_int = True
         while i < end:
             c = s[i]
-            if 'a' <= c <= 'z' or '0' <= c <= '9' or c == '_' or c == 'Q':
+            if u'0' <= c <= u'9':
                 i += 1
+            elif u'a' <= c <= u'z' or c == u'_':
+                # Labels can contain any combination of lowercase letters and underscores.
+                i += 1
+                is_int = False
+            elif c in (u'G', u'M', u'I', u'S'):
+                # These reserved characters (all uppercase letters) indicate that we've already
+                # seen everything there is to see for the most recent/current label.
+                break
+            elif last == i and c in (u'Q', u'T', u'L'):
+                # Labels can start with reserved uppercase letters Q, T, and L, per the 
+                # StateSpace documentation.
+                i += 1
+                is_int = False
+            elif last == i and u'A' <= c <= u'Z':
+                msg = f"Invalid target label: {s[last:i + 1]!r}. Labels can't start with uppercase letters other than Q, T, and L."
+                raise ValueError(msg)
             else:
                 break
-        if integerize_sslbls:
-            try:
-                val = int(s[last:i])
-            except:
-                val = s[last:i]
-            sslbls.append(val); last = i
+        if integerize_sslbls and is_int:
+            sslbls.append(int(s[last:i]))
         else:
-            sslbls.append(s[last:i]); last = i
+            sslbls.append(sys.intern(s[last:i]))
+        last = i
 
     if i < end and s[i] == '!':
         i += 1

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -130,7 +130,8 @@ class ExplicitOpModel(_mdl.OpModel):
         #assert(default_param in ('full','TP','CPTP','H+S','S','static',
         #                         'H+S terms','clifford','H+S clifford terms'))
         def flagfn(typ): return {'auto_embed': True, 'match_parent_statespace': True,
-                                 'match_parent_evotype': True, 'cast_to_type': typ}
+                                 'match_parent_evotype': True, 'cast_to_type': typ,
+                                 'validate_keys': True}
 
         if default_prep_type == "auto":
             default_prep_type = _state.state_type_from_op_type(default_gate_type)
@@ -143,7 +144,9 @@ class ExplicitOpModel(_mdl.OpModel):
         self.povms = _OrderedMemberDict(self, default_povm_type, povm_prefix, flagfn("povm"))
         self.operations = _OrderedMemberDict(self, default_gate_type, gate_prefix, flagfn("operation"))
         self.instruments = _OrderedMemberDict(self, default_instrument_type, instrument_prefix, flagfn("instrument"))
-        self.factories = _OrderedMemberDict(self, default_gate_type, gate_prefix, flagfn("factory"))
+        self.factories = _OrderedMemberDict(self, default_gate_type, gate_prefix,
+                                            {'auto_embed': True, 'match_parent_statespace': True,
+                                             'match_parent_evotype': True, 'cast_to_type': "factory"})
         self.effects_prefix = effect_prefix
         self._default_gauge_group = None
 

--- a/pygsti/models/memberdict.py
+++ b/pygsti/models/memberdict.py
@@ -140,7 +140,8 @@ class OrderedMemberDict(_PrefixOrderedDict, _mm.ModelChild):
         self.flags = {'auto_embed': flags.get('auto_embed', False),
                       'match_parent_statespace': flags.get('match_parent_statespace', False),
                       'match_parent_evotype': flags.get('match_parent_evotype', False),
-                      'cast_to_type': flags.get('cast_to_type', None)
+                      'cast_to_type': flags.get('cast_to_type', None),
+                      'validate_keys': flags.get('validate_keys', False)
                       }
         _PrefixOrderedDict.__init__(self, prefix, items)
         _mm.ModelChild.__init__(self, parent)  # set's self.parent
@@ -272,6 +273,17 @@ class OrderedMemberDict(_PrefixOrderedDict, _mm.ModelChild):
         return obj
 
     def __setitem__(self, key, value):
+        if self.flags.get('validate_keys', False):
+            from pygsti.circuits.circuitparser import parse_label as _parse_label
+            key_as_lbl = _Label(key) # handles if `key` is a str, or castable to a LabelTup, or already a Label.
+            round_trip = _parse_label(str(key_as_lbl))
+            if str(key_as_lbl) != str(round_trip):
+                raise ValueError(
+                    f"Model-member key {key!r} does not round-trip through "
+                    f"parse_label (parsed form is "
+                    f"{round_trip!r}). Pick a name whose string "
+                    f"form is preserved by parse_label."
+                )
         if not isinstance(key, _Label): key = _Label(key)
         value = self._auto_embed(key, value)  # automatically create an embedded gate if needed
         self._check_state_space(value)

--- a/pygsti/models/qutrit.py
+++ b/pygsti/models/qutrit.py
@@ -282,16 +282,16 @@ def create_qutrit_model(error_scale, x_angle=_np.pi / 2, y_angle=_np.pi / 2,
     E1final = change_basis(_np.reshape(E1, (9, 1)), "std", basis)
     E2final = change_basis(_np.reshape(E2, (9, 1)), "std", basis)
 
-    state_space = _statespace.ExplicitStateSpace(['QT'], [3])
+    state_space = _statespace.ExplicitStateSpace(['T0'], [3])
     qutritMDL = _ExplicitOpModel(state_space, _Basis.cast(basis, 9), evotype=evotype)
     qutritMDL.preps['rho0'] = _TPState(rho0final, evotype=evotype)
     qutritMDL.povms['Mdefault'] = _TPPOVM([('0bright', E0final),
                                            ('1bright', E1final),
                                            ('2bright', E2final)], evotype=evotype)
-    qutritMDL.operations['Gi', 'QT'] = _FullTPOp(arrType(gateISOfinal), basis, evotype, state_space)
-    qutritMDL.operations['Gx', 'QT'] = _FullTPOp(arrType(gateXSOfinal), basis, evotype, state_space)
-    qutritMDL.operations['Gy', 'QT'] = _FullTPOp(arrType(gateYSOfinal), basis, evotype, state_space)
-    qutritMDL.operations['Gm', 'QT'] = _FullTPOp(arrType(gateMSOfinal), basis, evotype, state_space)
+    qutritMDL.operations['Gi', 'T0'] = _FullTPOp(arrType(gateISOfinal), basis, evotype, state_space)
+    qutritMDL.operations['Gx', 'T0'] = _FullTPOp(arrType(gateXSOfinal), basis, evotype, state_space)
+    qutritMDL.operations['Gy', 'T0'] = _FullTPOp(arrType(gateYSOfinal), basis, evotype, state_space)
+    qutritMDL.operations['Gm', 'T0'] = _FullTPOp(arrType(gateMSOfinal), basis, evotype, state_space)
     qutritMDL.default_gauge_group = _TPGaugeGroup(state_space, qutritMDL.basis, evotype)
 
     return qutritMDL

--- a/test/test_packages/objects/test_instruments.py
+++ b/test/test_packages/objects/test_instruments.py
@@ -23,9 +23,10 @@ class InstrumentTestCase(BaseTestCase):
         self.povm_ident = self.target_model.povms['Mdefault']['0'] + self.target_model.povms['Mdefault']['1']
 
         self.mdl_target_wTP = self.target_model.copy()
-        self.mdl_target_wTP.instruments['IzTP'] = pygsti.modelmembers.instruments.TPInstrument({'plus': Gmz_plus, 'minus': Gmz_minus})
+        self.mdl_target_wTP.instruments['Iztp'] = pygsti.modelmembers.instruments.TPInstrument({'plus': Gmz_plus, 'minus': Gmz_minus})
 
         super(InstrumentTestCase, self).setUp()
+
 
     def testFutureFunctionality(self):
         #Test instrument construction with elements whose gpindices are already initialized.
@@ -66,7 +67,7 @@ class InstrumentTestCase(BaseTestCase):
 
         self.assertAlmostEqual(mdl.frobeniusdist(self.mdl_target_wTP),0.0)
 
-        for lbl in ('Iz','IzTP'):
+        for lbl in ('Iz','Iztp'):
             v = mdl.to_vector()
             gates = mdl.instruments[lbl].simplify_operations(prefix="ABC")
             for igate in gates.values():

--- a/test/test_packages/reportb/test_workspace.py
+++ b/test/test_packages/reportb/test_workspace.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pygsti.protocols.estimate
 from pygsti.extras import drift
-from pygsti.modelpacks.legacy import stdQT_XYIMS
+from pygsti.modelpacks import smq1Q_XY
 from ..report.reportBaseCase import ReportBaseCase
 from ..testutils import compare_files, temp_files
 from pygsti.baseobjs import Label
@@ -107,7 +107,7 @@ class TestWorkspace(ReportBaseCase):
         gsCPTP = self.tgt.depolarize(0.01,0.01); gsCPTP.set_all_parameterizations("CPTPLND")
         gsGM = self.mdl.depolarize(0.01,0.01); gsGM.basis = pygsti.baseobjs.Basis.cast("gm", 4)
         gsSTD = self.mdl.depolarize(0.01,0.01); gsSTD.basis = pygsti.baseobjs.Basis.cast("std", 4)
-        gsQT = stdQT_XYIMS.target_model().depolarize(0.01,0.01)
+        gsQT = smq1Q_XY.target_model().depolarize(0.01,0.01)
 
         #Construct confidence regions
         def make_cr(mdl):
@@ -158,7 +158,7 @@ class TestWorkspace(ReportBaseCase):
         tbls.append( w.ErrgenTable(self.mdl, self.tgt, cr, display_as="numbers", gen_type="logG-logT") )
         tbls.append( w.ErrgenTable(gsGM, self.tgt, cr, display_as="numbers", gen_type="logGTi") )
         #tbls.append( w.ErrgenTable(gsSTD, self.tgt, cr, display_as="numbers", gen_type="logGTi") )  # first el of basis must be I!!!
-        tbls.append( w.ErrgenTable(gsQT, stdQT_XYIMS.target_model(), cr, display_as="numbers", gen_type="logGTi") )
+        tbls.append( w.ErrgenTable(gsQT, smq1Q_XY.target_model(), cr, display_as="numbers", gen_type="logGTi") )
         with self.assertRaises(ValueError):
             w.ErrgenTable(self.mdl, self.tgt, cr, display=('foobar',))
         with self.assertRaises(AssertionError):

--- a/test/unit/algorithms/test_core.py
+++ b/test/unit/algorithms/test_core.py
@@ -173,16 +173,16 @@ class CoreMC2GSTTester(CoreStdData, BaseCase):
         
         aliased_list = [
             Circuit([
-                (x if x != Label(('Gxpi2',0)) else Label("GA1")) for x in mdl
+                (x if x != Label(('Gxpi2',0)) else Label("Ga1")) for x in mdl
             ], line_labels = (0,)) for mdl in self.lsgstStrings[0]
         ]
-        aliases = {Label('GA1'): Circuit([Label('Gxpi2',0)], line_labels= (0,))}
+        aliases = {Label('Ga1'): Circuit([Label('Gxpi2',0)], line_labels= (0,))}
         aliased_list = CircuitList(aliased_list, aliases)
 
         print(list(aliased_list))
 
         aliased_model = self.mdl_clgst.copy()
-        aliased_model.operations['GA1'] = self.mdl_clgst.operations['Gxpi2',0]
+        aliased_model.operations['Ga1'] = self.mdl_clgst.operations['Gxpi2',0]
         aliased_model.operations.pop(('Gxpi2',0))
 
         mdl_lsgst = core.run_gst_fit_simple(self.ds, aliased_model, aliased_list,
@@ -319,14 +319,14 @@ class CoreMLGSTTester(CoreStdData, BaseCase):
     def test_do_mlgst_alias_model(self):
         aliased_list = [
             Circuit([
-                (x if x != Label('Gxpi2',0) else Label("GA1")) for x in mdl
+                (x if x != Label('Gxpi2',0) else Label("Ga1")) for x in mdl
             ], line_labels=(0,)) for mdl in self.lsgstStrings[0]
         ]
-        aliases = {Label('GA1'): Circuit([Label('Gxpi2',0)], line_labels=(0,))}
+        aliases = {Label('Ga1'): Circuit([Label('Gxpi2',0)], line_labels=(0,))}
         aliased_list = CircuitList(aliased_list, aliases)
 
         aliased_model = self.mdl_clgst.copy()
-        aliased_model.operations['GA1'] = self.mdl_clgst.operations['Gxpi2',0]
+        aliased_model.operations['Ga1'] = self.mdl_clgst.operations['Gxpi2',0]
         aliased_model.operations.pop(('Gxpi2',0))
 
         mdl_lsgst = core.run_gst_fit_simple(self.ds, aliased_model, aliased_list,

--- a/test/unit/construction/test_qutrit.py
+++ b/test/unit/construction/test_qutrit.py
@@ -11,7 +11,7 @@ class QutritConstructionTester(BaseCase):
     def test_noisy_qutrit(self):
         mdl_sim = qutrit.create_qutrit_model(error_scale=0.1, similarity=True, seed=1234, basis='qt')
         mdl_ideal = qutrit.create_qutrit_model(error_scale=0.1, similarity=True, seed=1234, basis='qt')
-        self.assertArraysAlmostEqual(mdl_sim['Gi', 'QT'], mdl_ideal['Gi', 'QT'])
+        self.assertArraysAlmostEqual(mdl_sim['Gi', 'T0'], mdl_ideal['Gi', 'T0'])
 
         #just test building a gate in the qutrit basis
         # Can't do this b/c need a 'T*' triplet space designator for "triplet space" and it doesn't seem

--- a/test/unit/objects/smqfixtures.py
+++ b/test/unit/objects/smqfixtures.py
@@ -8,7 +8,7 @@ from ..util import Namespace
 ns = Namespace()
 ns.model = smq.target_model('full TP')
 ns.max_max_length = 2
-ns.aliases = {Label(('GA1', 0)): Circuit([('Gxpi2', 0)])}
+ns.aliases = {Label(('Ga1', 0)): Circuit([('Gxpi2', 0)])}
 
 
 @ns.memo
@@ -42,14 +42,14 @@ def perfect_dataset(self):
 
 @ns.memo
 def alias_circuits(self):
-    alias_list = [c.replace_layer(Label(("Gxpi2", 0)), Label(("GA1", 0))) for c in self.circuits]
+    alias_list = [c.replace_layer(Label(("Gxpi2", 0)), Label(("Ga1", 0))) for c in self.circuits]
     return CircuitList(alias_list, self.aliases)
 
 
 @ns.memo
 def alias_model(self):
     aliased_model = self.model.copy()
-    aliased_model.operations[('GA1', 0)] = self.model.operations[('Gxpi2', 0)]
+    aliased_model.operations[('Ga1', 0)] = self.model.operations[('Gxpi2', 0)]
     aliased_model.operations.pop(('Gxpi2', 0))
     return aliased_model
 
@@ -57,6 +57,6 @@ def alias_model(self):
 @ns.memo
 def alias_datagen_model(self):
     aliased_model = self.datagen_model.copy()
-    aliased_model.operations[('GA1', 0)] = self.datagen_model.operations[('Gxpi2', 0)]
+    aliased_model.operations[('Ga1', 0)] = self.datagen_model.operations[('Gxpi2', 0)]
     aliased_model.operations.pop(('Gxpi2', 0))
     return aliased_model

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -3,6 +3,7 @@ import pickle
 import unittest
 import numpy as np
 import warnings
+import pytest
 
 from pygsti.circuits import circuit
 from pygsti.baseobjs import Label, CircuitLabel
@@ -84,6 +85,11 @@ class CircuitTester(BaseCase):
         c = circuit.Circuit(layer_labels=labels, line_labels=['Q0', 'Q1'], editable=True)
         cnew = circuit.Circuit(c)
         self.assertEqual(cnew, c)
+
+    def test_construct_malformed_input(self):
+        with pytest.raises(ValueError):
+            c = circuit.Circuit([("Gxpi2", "A0")])
+        return
 
     def test_create_circuitlabel(self):
         # test automatic creation of "power" subcircuits when needed

--- a/test/unit/objects/test_labeldicts.py
+++ b/test/unit/objects/test_labeldicts.py
@@ -1,6 +1,7 @@
 import pickle
 
 import pygsti.baseobjs.outcomelabeldict as ld
+from pygsti.baseobjs.label import Label
 from pygsti.models.memberdict import OrderedMemberDict
 from pygsti.models.modelconstruction import create_explicit_model_from_expressions
 from pygsti.models import ExplicitOpModel
@@ -46,3 +47,37 @@ class LabelDictTester(BaseCase):
         d = ld.OutcomeLabelDict([(('0',), 90), (('1',), 10)])
         d_copy = d.copy()
         self.assertEqual(d, d_copy)
+
+    def test_validate_keys_round_trip(self):
+        # Build a real ExplicitOpModel so we have valid ModelMember values to assign.
+        # The four primary member dicts (preps, povms, operations, instruments)
+        # have validate_keys=True; factories does not.
+        model = create_explicit_model_from_expressions(
+            [('Q0',)], ['Gi', 'Gx', 'Gy'],
+            ["I(Q0)", "X(pi/2,Q0)", "Y(pi/2,Q0)"]
+        )
+        # Grab a real Instrument-compatible member by constructing a tiny
+        # ExplicitOpModel-style instrument from existing ops via the
+        # public Instrument class.
+        from pygsti.modelmembers import instruments as _inst
+        op_gi = model.operations[Label('Gi')]
+        instr_value = _inst.Instrument([('outcome', op_gi.copy())])
+
+        # 1) Round-tripping str key -> success
+        model.instruments[Label('Iz')] = instr_value
+        # 2) Non-round-tripping str key -> ValueError
+        with self.assertRaises(ValueError):
+            model.instruments['IzTP'] = instr_value
+        # 3) Label constructed from non-round-tripping string -> ValueError
+        with self.assertRaises(ValueError):
+            model.instruments[Label('IzTP')] = instr_value
+        # 4) Label constructed from round-tripping string -> success
+        model.instruments[Label('Iz2')] = instr_value
+
+        # 5) Opt-in nature: when validate_keys is False (default),
+        # the same assignments succeed on a bare OrderedMemberDict.
+        d = OrderedMemberDict(None, "full", "I", {'cast_to_type': None})
+        # Use a ModelMember directly to bypass cast logic.
+        d[Label('IzTP')] = op_gi.copy()
+        d['I_zTP'] = op_gi.copy()
+        return

--- a/test/unit/objects/test_model.py
+++ b/test/unit/objects/test_model.py
@@ -266,7 +266,7 @@ class GeneralMethodBase(object):
             self.model['Non-existent-key'] = np.zeros((4, 4), 'd')  # can't set things not in the model
 
     def test_raise_on_set_bad_prep_key(self):
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             self.model.preps['foobar'] = [1.0 / np.sqrt(2), 0, 0, 0]  # bad key prefix
 
     def test_raise_on_get_bad_povm_key(self):


### PR DESCRIPTION
This PR resolves issue #495, which was originally opened to address bugs of the form
```python
from pygsti.circuit import Circuit
c = Circuit([("Gxpi2", "A0")]) # This is fine
c.str # This is also fine
Circuit(c.str) # Errors with ValueError: invalid literal for int() with base 10: ''
```
The resolution is to have the constructor invocation above raise an error. The error is triggered whenever a Circuit object's line_labels field can't be round-tripped through pygsti.circuits.circuitparser.parse_label.

This PR also modifies the two implementations of parse_label (fast and slow) to allow labels where ...
 * the first character is a lowercase letter, or one of the letters Q, T, L, or a digit, or an underscore.
 * all remaining characters are lowercase letters, or numbers, or underscores.

The ability to start line labels with T or L is new. I chose those because they're mentioned in the StateSpace documentation.

Finally, this PR updates OrderedMemberDict to have a flag where it can check for round-trip-ability of a key provided to its `__setitem__` function. That flag is set to True for four members of ExplicitOpModel: preps, povms, instruments, and operations. This makes it impossible to set a ModelMember label that can't be round-trip serialized. In the process I found some code that used invalid labels (linear GST and one instrument test) and changed the labels to be valid.