### PR TITLE
Fix cataloged bugs in the Circuit class

### DIFF
--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2500,12 +2500,17 @@ class Circuit(object):
         assert(not self._static), "Cannot edit a read-only circuit!"
         #assert(self.identity == circuit.identity), "The identity labels must be the same!"
 
-        if circuit.num_layers > 0 and len(self._line_labels) > 0 \
-           and _sslbls_of_nested_lists_of_simple_labels(self._labels) is None:
+        # Implicit (None) state-space labels are interpreted as acting on *all* of a circuit's
+        # lines, so a gate with implicit sslbls cannot sit in a layer that the insertion below
+        # writes to (the first circuit.num_layers layers): it would straddle the new lines.
+        # Layers beyond the insertion region are unaffected (e.g. a trailing global idle).
+        if circuit.num_layers > 0 and len(circuit._line_labels) > 0 and len(self._line_labels) > 0 \
+           and _sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None:
             raise ValueError("Cannot tensor: this circuit contains gates with implicit (None) state-space "
-                             "labels, which are interpreted as acting on *all* of the circuit's lines and "
-                             "so cannot coexist with the new lines being added.  Give these gates explicit "
-                             "state-space labels (e.g. 'Gx:0' rather than 'Gx') before tensoring.")
+                             "labels in the layers being tensored, which are interpreted as acting on *all* "
+                             "of the circuit's lines and so cannot coexist with the new lines being added.  "
+                             "Give these gates explicit state-space labels (e.g. 'Gx:0' rather than 'Gx') "
+                             "before tensoring.")
 
         #Construct new line labels (of final circuit)
         overlap = set(self._line_labels).intersection(circuit._line_labels)

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -1337,6 +1337,7 @@ class Circuit(object):
                                         not self._static)  # zero-area region
 
         ret = []
+        observed_sslbls = set()  # the sslbls of all labels kept when strict=False (unused when strict=True)
         if self._static:
             def get_sslbls(lbl): return lbl.sslbls
         else:
@@ -1354,12 +1355,19 @@ class Circuit(object):
                 else:
                     sslbls = set(sslbls)
                 if (strict and sslbls.issubset(lines)) or \
-                   (not strict and len(sslbls.intersection(lines)) >= 0):
+                   (not strict and sslbls.intersection(lines)):
                     ret_layer.append(l)
+                    if not strict:
+                        observed_sslbls.update(sslbls)
             ret.append(_Label(ret_layer) if len(ret_layer) != 1 else ret_layer[0])  # Labels b/c we use _fastinit
 
         if nonint_layers:
-            if not strict: lines = "auto"  # since we may have included lbls on other lines
+            if not strict:
+                # Included labels may straddle the boundary of the requested lines,
+                # so the result can act on more lines than requested -- extend the
+                # line labels to cover them (in this circuit's line-label order).
+                extra_lines = observed_sslbls - set(lines)
+                lines = tuple(lines) + tuple(ll for ll in self._line_labels if ll in extra_lines)
             # don't worry about string rep for now...
 
             return Circuit._fastinit(tuple(ret) if self._static else ret,

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -1365,7 +1365,9 @@ class Circuit(object):
                 # so the result can act on more lines than requested -- extend the
                 # line labels to cover them (in this circuit's line-label order).
                 extra_lines = observed_sslbls - set(lines)
-                lines = tuple(lines) + tuple(ll for ll in self._line_labels if ll in extra_lines)
+                # (filter, not a genexpr: a genexpr would close over extra_lines and put a
+                #  MAKE_CELL prologue on every call, measurably slowing the int fast path)
+                lines = tuple(lines) + tuple(filter(extra_lines.__contains__, self._line_labels))
             # don't worry about string rep for now...
 
             return Circuit._fastinit(tuple(ret) if self._static else ret,

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2932,7 +2932,16 @@ class Circuit(object):
             if isinstance(mapper, dict) else mapper(gatename)
 
         def map_names(obj):  # obj is either a simple label or a list
-            if isinstance(obj, _Label):
+            if isinstance(obj, _CircuitLabel):
+                # CircuitLabel.IS_SIMPLE is True, but rebuilding it through the
+                # simple-label branch below would silently discard its subcircuit.
+                # Map only the label's own (box) name; the component labels inside
+                # the subcircuit are not renamed (matching the dict-mapper behavior
+                # of leaving non-matching CircuitLabels untouched).
+                new_name = mapper_func(obj.name)
+                newobj = _CircuitLabel(new_name, obj.components, obj.sslbls, obj.reps, obj.time) \
+                    if (new_name is not None and new_name != obj.name) else obj
+            elif isinstance(obj, _Label):
                 if obj.IS_SIMPLE:  # *simple* label
                     new_name = mapper_func(obj.name)
                     newobj = _Label(new_name, obj.sslbls) \
@@ -2968,7 +2977,12 @@ class Circuit(object):
         self._line_labels = tuple((mapper_func(l) for l in self._line_labels))
 
         def map_sslbls(obj):  # obj is either a simple label or a list
-            if isinstance(obj, _Label):
+            if isinstance(obj, _CircuitLabel):
+                # CircuitLabel.IS_SIMPLE is True, but rebuilding it through the
+                # branch below would silently discard its subcircuit; delegate to
+                # the Label-level method, which maps the subcircuit's sslbls too.
+                newobj = obj.map_state_space_labels(mapper_func)
+            elif isinstance(obj, _Label):
                 new_sslbls = [mapper_func(l) for l in obj.sslbls] \
                     if (obj.sslbls is not None) else None
                 newobj = _Label(obj.name, new_sslbls)

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2494,6 +2494,13 @@ class Circuit(object):
         assert(not self._static), "Cannot edit a read-only circuit!"
         #assert(self.identity == circuit.identity), "The identity labels must be the same!"
 
+        if circuit.num_layers > 0 and len(self._line_labels) > 0 \
+           and _sslbls_of_nested_lists_of_simple_labels(self._labels) is None:
+            raise ValueError("Cannot tensor: this circuit contains gates with implicit (None) state-space "
+                             "labels, which are interpreted as acting on *all* of the circuit's lines and "
+                             "so cannot coexist with the new lines being added.  Give these gates explicit "
+                             "state-space labels (e.g. 'Gx:0' rather than 'Gx') before tensoring.")
+
         #Construct new line labels (of final circuit)
         overlap = set(self._line_labels).intersection(circuit._line_labels)
         if len(overlap) > 0:
@@ -2514,7 +2521,7 @@ class Circuit(object):
             if len(extra) > 0:
                 raise ValueError("`line_order` had nonpresent line labels %s." % str(extra))
 
-            new_line_labels = line_order
+            new_line_labels = tuple(line_order)
         else:
             new_line_labels = self._line_labels + circuit._line_labels
 

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -215,7 +215,7 @@ def validate_line_labels(linelabels):
         test_str = f'Gi:{str(line_lbl)}'
         parsed = str(parse_label(test_str))  # can trigger a ValueError.
         if parsed != test_str:
-            msg = "Line label '{line_lbl}' could not round-trip through the parse_label function."
+            msg = f"Line label '{line_lbl}' could not round-trip through the parse_label function."
             raise ValueError(msg)
     return
 
@@ -1204,7 +1204,7 @@ class Circuit(object):
         """ Pre-process the key argument used by many methods """
         if isinstance(key, tuple):
             if len(key) != 2:
-                return IndexError("Index must be of the form <layerIndex>,<lineIndex>")
+                raise IndexError("Index must be of the form <layerIndex>,<lineIndex>")
             else:
                 return key[0], key[1]
         else:
@@ -1332,9 +1332,7 @@ class Circuit(object):
             if self._static:
                 return Circuit._fastinit((), tuple(lines), False)  # zero-area region
             else:
-                return Circuit._fastinit(() if self._static else [],
-                                        tuple(lines) if self._static else lines,
-                                        not self._static)  # zero-area region
+                return Circuit._fastinit([], lines, True)  # zero-area region
 
         ret = []
         observed_sslbls = set()  # the sslbls of all labels kept when strict=False (unused when strict=True)
@@ -2633,7 +2631,7 @@ class Circuit(object):
             _warnings.warn(f'Casting `old_gatename` of type {type(old_gatename)} to the string "{str(old_gatename)}".')
             old_gatename = str(old_gatename)
         if not isinstance(new_gatename, str):
-            _warnings.warn(f'Casting `old_gatename` of type {type(new_gatename)} to the string "{str(new_gatename)}".')
+            _warnings.warn(f'Casting `new_gatename` of type {type(new_gatename)} to the string "{str(new_gatename)}".')
             new_gatename = str(new_gatename)
         
         if ':' in old_gatename or ':' in new_gatename:
@@ -3117,12 +3115,7 @@ class Circuit(object):
         if idle_layer_labels:
             assert(all([_Label(x).sslbls is None for x in idle_layer_labels])), "Idle layer labels must be *global*"
 
-        if self._static:
-            layers = [x for x in self._labels if x not in idle_layer_labels] if idle_layer_labels else self._labels
-            all_sslbls = None if any([layer.sslbls is None for layer in layers]) \
-                else set([sslbl for layer in layers for sslbl in layer.sslbls])
-        else:
-            all_sslbls = _sslbls_of_nested_lists_of_simple_labels(self._labels, idle_layer_labels)  # None or a set
+        all_sslbls = _sslbls_of_nested_lists_of_simple_labels(self._labels, idle_layer_labels)  # None or a set
 
         if all_sslbls is None:
             return  # no lines are idling
@@ -3832,68 +3825,6 @@ class Circuit(object):
         print("--- LABEL INFO for %s (%d layers) ---" % (self.str, self.num_layers))
         for j in range(0, self.num_layers):
             plbl(self[j], "self[%d]" % j)
-
-    def _write_q_circuit_tex(self, filename):  # TODO
-        """
-        Writes a LaTeX file for rendering this circuit nicely.
-
-        Creates a file containing LaTex that will display this circuit using the
-        Qcircuit.tex LaTex import (compiling the LaTex requires that you have the
-        Qcircuit.tex file).
-
-        Parameters
-        ----------
-        filename : str
-            The file to write the LaTex into. Should end with '.tex'
-
-        Returns
-        -------
-        None
-        """
-        raise NotImplementedError("TODO: need to upgrade this method")
-        n = self.num_lines
-        d = self.num_layers
-
-        f = open(filename, 'w')
-        f.write("\\documentclass{article}\n")
-        f.write("\\usepackage{mathtools}\n")
-        f.write("\\usepackage{xcolor}\n")
-        f.write("\\usepackage[paperwidth=" + str(5. + d * 0.3)
-                + "in, paperheight=" + str(2 + n * 0.2) + "in,margin=0.5in]{geometry}")
-        f.write("\\input{Qcircuit}\n")
-        f.write("\\begin{document}\n")
-        f.write("\\begin{equation*}\n")
-        f.write("\\Qcircuit @C=1.0em @R=0.5em {\n")
-
-        for q in range(0, n):
-            qstring = '&'
-            # The quantum wire for qubit q
-            circuit_for_q = self.line_items[q]
-            for gate in circuit_for_q:
-                gate_qubits = gate.qubits if (gate.qubits is not None) else self._line_labels
-                nqubits = len(gate_qubits)
-                if gate.name == self.identity:
-                    qstring += r' \qw &'
-                elif gate.name in ('CNOT', 'Gcnot') and nqubits == 2:
-                    if gate_qubits[0] == q:
-                        qstring += r' \ctrl{' + str(gate_qubits[1] - q) + '} &'
-                    else:
-                        qstring += r' \targ &'
-                elif gate.name in ('CPHASE', 'Gcphase') and nqubits == 2:
-                    if gate_qubits[0] == q:
-                        qstring += r' \ctrl{' + str(gate_qubits[1] - q) + '} &'
-                    else:
-                        qstring += r' \control \qw &'
-
-                else:
-                    qstring += r' \gate{' + str(gate.name) + '} &'
-
-            qstring += r' \qw & \\' + '\\ \n'
-            f.write(qstring)
-
-        f.write("}\\end{equation*}\n")
-        f.write("\\end{document}")
-        f.close()
 
     def convert_to_stim_tableau_layers(self, gate_name_conversions: Optional[dict[str, stim.Tableau]] = None,
                                        num_qubits: Optional[int] = None,

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -1159,7 +1159,9 @@ class Circuit(object):
 
         Updates the circuit inplace.
         """
-        self._labels = _sort_layer_labels(self._labels)
+        assert(not self._static), "Cannot edit a read-only circuit!"
+        self._labels = [_label_to_nested_lists_of_simple_labels(lbl)
+                        for lbl in _sort_layer_labels(self._labels)]
 
     def clear(self):
         """
@@ -5047,7 +5049,7 @@ class Circuit(object):
         """
         if not self._static:
             self._static = True
-            self.sort_layer_labels_inplace()
+            self._labels = _sort_layer_labels(self._labels)
         self._hashable_tup = self.tup
         self._hash = hash(self._hashable_tup)
         self._str = None

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2909,7 +2909,7 @@ class Circuit(object):
 
         # If the mapper is a dict, turn it into a function
         def mapper_func(gatename): return mapper.get(gatename, None) \
-            if isinstance(mapper, dict) else mapper
+            if isinstance(mapper, dict) else mapper(gatename)
 
         def map_names(obj):  # obj is either a simple label or a list
             if isinstance(obj, _Label):
@@ -2943,7 +2943,7 @@ class Circuit(object):
 
         # If the mapper is a dict, turn it into a function
         def mapper_func(line_label): return mapper[line_label] \
-            if isinstance(mapper, dict) else mapper
+            if isinstance(mapper, dict) else mapper(line_label)
 
         self._line_labels = tuple((mapper_func(l) for l in self._line_labels))
 

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -919,3 +919,39 @@ class CompressedCircuitTester(BaseCase):
     def test_raise_on_construct_from_non_circuit(self):
         with self.assertRaises(ValueError):
             circuit.CompressedCircuit(('Gx',))  # can only create from Circuits
+
+
+class CircuitBugfixRegressionTester(BaseCase):
+    """Regression tests for the batch of circuit.py bug fixes (issues #756, #760, #762, #763, #764)."""
+
+    def test_map_names_inplace_with_callable(self):
+        # regression test for issue #763
+        c = circuit.Circuit("Gx:0Gy:1@(0,1)", editable=True)
+        c.map_names_inplace(lambda name: name + '2')
+        c.done_editing()
+        self.assertEqual(c, circuit.Circuit("Gx2:0Gy2:1@(0,1)"))
+
+    def test_map_names_inplace_with_dict(self):
+        # regression test for issue #763 (dict path must keep working; missing
+        # keys mean "keep the old name")
+        c = circuit.Circuit("Gx:0Gy:1@(0,1)", editable=True)
+        c.map_names_inplace({'Gx': 'Gz'})
+        c.done_editing()
+        self.assertEqual(c, circuit.Circuit("Gz:0Gy:1@(0,1)"))
+
+    def test_map_state_space_labels_inplace_with_callable(self):
+        # regression test for issue #763
+        c = circuit.Circuit("Gx:0Gy:1@(0,1)", editable=True)
+        c.map_state_space_labels_inplace(lambda ll: ll + 10)
+        c.done_editing()
+        self.assertEqual(c.line_labels, (10, 11))
+        self.assertEqual(c, circuit.Circuit("Gx:10Gy:11@(10,11)"))
+
+    def test_map_state_space_labels_with_callable_matches_inplace(self):
+        # the non-inplace variant already handled callables; pin that the two agree
+        c = circuit.Circuit("Gx:0Gy:1@(0,1)")
+        mapped = c.map_state_space_labels(lambda ll: ll + 10)
+        c2 = c.copy(editable=True)
+        c2.map_state_space_labels_inplace(lambda ll: ll + 10)
+        c2.done_editing()
+        self.assertEqual(mapped, c2)

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -982,3 +982,56 @@ class CircuitBugfixRegressionTester(BaseCase):
         canonical = circuit.Circuit([[('Gx', 0), ('Gy', 1)]], line_labels=(0, 1))
         self.assertEqual(c, canonical)
         self.assertEqual(hash(c), hash(canonical))
+
+    def test_tensor_circuit_with_list_line_order(self):
+        # regression test for issue #762: a list line_order was stored
+        # un-tupled, crashing later in done_editing
+        c = circuit.Circuit("Gx:0@(0)", editable=True)
+        c.tensor_circuit_inplace(circuit.Circuit("Gy:1@(1)"), line_order=[1, 0])
+        c.done_editing()
+        self.assertEqual(c.line_labels, (1, 0))
+        self.assertEqual(c[0, 0], Label('Gx', 0))
+        self.assertEqual(c[0, 1], Label('Gy', 1))
+
+    def test_tensor_circuit_with_tuple_line_order(self):
+        c = circuit.Circuit("Gx:0@(0)", editable=True)
+        c.tensor_circuit_inplace(circuit.Circuit("Gy:1@(1)"), line_order=(1, 0))
+        c.done_editing()
+        self.assertEqual(c.line_labels, (1, 0))
+
+    def test_tensor_circuit_noninplace(self):
+        t = circuit.Circuit("Gx:0@(0)").tensor_circuit(circuit.Circuit("Gy:1@(1)"))
+        self.assertEqual(t, circuit.Circuit("[Gx:0Gy:1]@(0,1)"))
+
+    def test_tensor_circuit_implicit_sslbls_host_raises(self):
+        # regression test for issue #762: previously failed deep inside
+        # _clear_labels with "Cannot operate on a block that is straddled by Gx!"
+        c = circuit.Circuit("Gx@(0)", editable=True)
+        with self.assertRaises(ValueError) as cm:
+            c.tensor_circuit_inplace(circuit.Circuit("Gy:1@(1)"))
+        self.assertIn("implicit", str(cm.exception))
+
+    def test_tensor_circuit_implicit_sslbls_insertee_ok(self):
+        # pin for issue #762: an implicit-sslbls *insertee* is explicified
+        # onto its own lines during insertion and must keep working
+        # (SimultaneousExperimentDesign relies on this)
+        t = circuit.Circuit("Gx:0@(0)").tensor_circuit(circuit.Circuit("Gy@(1)"))
+        self.assertEqual(t, circuit.Circuit("[Gx:0Gy:1]@(0,1)"))
+
+    def test_tensor_circuit_implicit_sslbls_host_with_empty_insertee_ok(self):
+        # pin for issue #762: tensoring idle lines (a depth-0 circuit) onto a
+        # host with implicit-sslbls gates worked before the new guard and must
+        # continue to work
+        c = circuit.Circuit("Gx@(0)", editable=True)
+        c.tensor_circuit_inplace(circuit.Circuit((), line_labels=(1,)))
+        c.done_editing()
+        self.assertEqual(c.line_labels, (0, 1))
+
+    def test_tensor_circuit_with_empty_layers_ok(self):
+        # pin for issue #762: empty (idle) layers contain no implicit-sslbls
+        # gates and must not trip the new guard
+        c = circuit.Circuit([('Gx', 0), (), ('Gy', 0)], line_labels=(0,), editable=True)
+        c.tensor_circuit_inplace(circuit.Circuit("Gz:1@(1)"))
+        c.done_editing()
+        self.assertEqual(c.line_labels, (0, 1))
+        self.assertEqual(c.depth, 3)

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -1035,3 +1035,41 @@ class CircuitBugfixRegressionTester(BaseCase):
         c.done_editing()
         self.assertEqual(c.line_labels, (0, 1))
         self.assertEqual(c.depth, 3)
+
+    def test_extract_labels_nonstrict_filters_and_line_labels(self):
+        # regression test for issue #756: the non-strict membership test was
+        # always true (so no filtering happened) and the result's line labels
+        # were tuple('auto') == ('a', 'u', 't', 'o')
+        c = circuit.Circuit("[Gx:0Gy:1][Gz:1]@(0,1)")
+        sub = c.extract_labels(layers=slice(0, 2), lines=(1,), strict=False)
+        self.assertEqual(sub.line_labels, (1,))
+        self.assertEqual(sub[0], Label('Gy', 1))
+        self.assertEqual(sub[1], Label('Gz', 1))
+
+    def test_extract_labels_nonstrict_includes_straddlers(self):
+        # issue #756: labels straddling the requested-lines boundary are kept
+        # (per the docstring) and the result's line labels grow to cover them;
+        # layers with no intersecting labels come back empty
+        c = circuit.Circuit("[Gcnot:0:1][Gz:1]@(0,1,2)")
+        sub = c.extract_labels(layers=slice(0, 2), lines=(0,), strict=False)
+        self.assertEqual(sub.line_labels, (0, 1))
+        self.assertEqual(sub[0], Label('Gcnot', (0, 1)))
+        self.assertEqual(sub[1], Label(()))
+
+    def test_extract_labels_nonstrict_editable_matches_static(self):
+        # issue #756: the editable and static code paths must agree
+        text = "[Gx:0Gy:1][Gz:1]@(0,1)"
+        sub_static = circuit.Circuit(text).extract_labels(layers=slice(0, 2), lines=(1,), strict=False)
+        sub_editable = circuit.Circuit(text, editable=True).extract_labels(layers=slice(0, 2), lines=(1,), strict=False)
+        sub_editable.done_editing()
+        self.assertEqual(sub_static, sub_editable)
+        self.assertEqual(sub_static, circuit.Circuit("Gy:1Gz:1@(1)"))
+
+    def test_extract_labels_strict_behavior_unchanged(self):
+        # context pin for issue #756: strict extraction (the default, used by
+        # __getitem__) drops straddling labels and keeps the requested lines
+        c = circuit.Circuit("[Gcnot:0:1][Gz:1]@(0,1)")
+        sub = c.extract_labels(layers=slice(0, 2), lines=(1,))
+        self.assertEqual(sub.line_labels, (1,))
+        self.assertEqual(sub[0], Label(()))
+        self.assertEqual(sub[1], Label('Gz', 1))

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -932,8 +932,8 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c, circuit.Circuit("Gx2:0Gy2:1@(0,1)"))
 
     def test_map_names_inplace_with_dict(self):
-        # regression test for issue #763 (dict path must keep working; missing
-        # keys mean "keep the old name")
+        # context pin for issue #763: the dict path was never broken and must
+        # keep working; missing keys mean "keep the old name"
         c = circuit.Circuit("Gx:0Gy:1@(0,1)", editable=True)
         c.map_names_inplace({'Gx': 'Gz'})
         c.done_editing()
@@ -995,7 +995,6 @@ class CircuitBugfixRegressionTester(BaseCase):
         # regression test for issue #760: sorting must preserve the editable
         # representation so that subsequent in-place edits still work
         c = circuit.Circuit([[('Gy', 1), ('Gx', 0)]], line_labels=(0, 1), editable=True)
-        self.assertEqual(c[0], Label((('Gy', 1), ('Gx', 0))))
         c.sort_layer_labels_inplace()
         self.assertEqual(c[0], Label((('Gx', 0), ('Gy', 1))))
         c.insert_labels_into_layers_inplace([Label('Gz', 0)], 1)
@@ -1022,12 +1021,14 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c[0, 1], Label('Gy', 1))
 
     def test_tensor_circuit_with_tuple_line_order(self):
+        # context pin for issue #762: tuple line_order always worked
         c = circuit.Circuit("Gx:0@(0)", editable=True)
         c.tensor_circuit_inplace(circuit.Circuit("Gy:1@(1)"), line_order=(1, 0))
         c.done_editing()
         self.assertEqual(c.line_labels, (1, 0))
 
     def test_tensor_circuit_noninplace(self):
+        # context pin: first direct test of the copy-returning tensor_circuit
         t = circuit.Circuit("Gx:0@(0)").tensor_circuit(circuit.Circuit("Gy:1@(1)"))
         self.assertEqual(t, circuit.Circuit("[Gx:0Gy:1]@(0,1)"))
 
@@ -1104,6 +1105,15 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(sub_static, sub_editable)
         self.assertEqual(sub_static, circuit.Circuit("Gy:1Gz:1@(1)"))
 
+    def test_extract_labels_nonstrict_implicit_sslbls_covers_all_lines(self):
+        # pin for issue #756: an implicit (None-sslbls) label acts on every
+        # line, so non-strict extraction through any line keeps it and the
+        # result covers all of the parent's lines
+        c = circuit.Circuit([('Gx', 0), 'Gi'], line_labels=(0, 1))
+        sub = c.extract_labels(layers=slice(0, 2), lines=(0,), strict=False)
+        self.assertEqual(sub.line_labels, (0, 1))
+        self.assertEqual(sub, c)
+
     def test_extract_labels_strict_behavior_unchanged(self):
         # context pin for issue #756: strict extraction (the default, used by
         # __getitem__) drops straddling labels and keeps the requested lines
@@ -1114,11 +1124,13 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(sub[1], Label('Gz', 1))
 
     def test_extract_labels_zero_area(self):
-        # pin for issue #764: the zero-area path on editable circuits
+        # pin for issue #764: the zero-area path on editable circuits returns
+        # an *editable* result (the in-place edit below would raise otherwise)
         c = circuit.Circuit("Gx:0Gy:0@(0,1)", editable=True)
         sub = c.extract_labels(layers=(), lines=(0,))
+        sub.insert_labels_into_layers_inplace([Label('Gz', 0)], 0)
         sub.done_editing()
-        self.assertEqual(sub, circuit.Circuit((), line_labels=(0,)))
+        self.assertEqual(sub, circuit.Circuit("Gz:0@(0)"))
 
     def test_malformed_index_raises_index_error(self):
         # regression test for issue #764: _proc_key_arg *returned* the

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -955,3 +955,30 @@ class CircuitBugfixRegressionTester(BaseCase):
         c2.map_state_space_labels_inplace(lambda ll: ll + 10)
         c2.done_editing()
         self.assertEqual(mapped, c2)
+
+    def test_sort_layer_labels_inplace_raises_on_static(self):
+        # regression test for issue #760: previously this silently rewrote
+        # _labels while leaving the cached hash/tup/str stale
+        s = circuit.Circuit("Gx:0Gy:1@(0,1)")
+        with self.assertRaises(AssertionError):
+            s.sort_layer_labels_inplace()
+
+    def test_sort_layer_labels_inplace_on_editable(self):
+        # regression test for issue #760: sorting must preserve the editable
+        # representation so that subsequent in-place edits still work
+        c = circuit.Circuit([[('Gy', 1), ('Gx', 0)]], line_labels=(0, 1), editable=True)
+        self.assertEqual(c[0], Label((('Gy', 1), ('Gx', 0))))
+        c.sort_layer_labels_inplace()
+        self.assertEqual(c[0], Label((('Gx', 0), ('Gy', 1))))
+        c.insert_labels_into_layers_inplace([Label('Gz', 0)], 1)
+        c.done_editing()
+        self.assertEqual(c, circuit.Circuit([[('Gx', 0), ('Gy', 1)], [('Gz', 0)]], line_labels=(0, 1)))
+
+    def test_done_editing_still_sorts_layers(self):
+        # pin for issue #760's done_editing change: the editable->static
+        # transition must still canonicalize within-layer label order
+        c = circuit.Circuit([[('Gy', 1), ('Gx', 0)]], line_labels=(0, 1), editable=True)
+        c.done_editing()
+        canonical = circuit.Circuit([[('Gx', 0), ('Gy', 1)]], line_labels=(0, 1))
+        self.assertEqual(c, canonical)
+        self.assertEqual(hash(c), hash(canonical))

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -1073,3 +1073,32 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(sub.line_labels, (1,))
         self.assertEqual(sub[0], Label(()))
         self.assertEqual(sub[1], Label('Gz', 1))
+
+    def test_extract_labels_zero_area(self):
+        # pin for issue #764: the zero-area path on editable circuits
+        c = circuit.Circuit("Gx:0Gy:0@(0,1)", editable=True)
+        sub = c.extract_labels(layers=(), lines=(0,))
+        sub.done_editing()
+        self.assertEqual(sub, circuit.Circuit((), line_labels=(0,)))
+
+    def test_malformed_index_raises_index_error(self):
+        # regression test for issue #764: _proc_key_arg *returned* the
+        # IndexError, surfacing as an unpacking TypeError downstream
+        c = circuit.Circuit("Gx:0Gy:1@(0,1)")
+        with self.assertRaises(IndexError):
+            c[0, 1, 2]
+
+    def test_validate_line_labels_message_names_the_label(self):
+        # regression test for issue #764: the message was a non-f-string, so
+        # users saw the literal text '{line_lbl}'
+        with self.assertRaises(ValueError) as cm:
+            circuit.validate_line_labels(['01'])
+        self.assertIn("'01'", str(cm.exception))
+
+    def test_replace_gatename_inplace_warning_names_new_gatename(self):
+        # regression test for issue #764: the second cast warning blamed
+        # `old_gatename` while casting `new_gatename`
+        c = circuit.Circuit("Gx:0@(0)", editable=True)
+        with self.assertWarns(UserWarning) as cm:
+            c.replace_gatename_inplace('Gx', 123)
+        self.assertIn('new_gatename', str(cm.warning))

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -1019,13 +1019,24 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(t, circuit.Circuit("[Gx:0Gy:1]@(0,1)"))
 
     def test_tensor_circuit_implicit_sslbls_host_with_empty_insertee_ok(self):
-        # pin for issue #762: tensoring idle lines (a depth-0 circuit) onto a
-        # host with implicit-sslbls gates worked before the new guard and must
-        # continue to work
+        # pin for issue #762: adding lines from a depth-0 circuit to a host
+        # with implicit-sslbls gates worked before the new guard and must
+        # continue to work.  (Note the implicit gates then cover the new line
+        # too -- that is what implicit sslbls mean -- so the new line is not
+        # idle; this matches develop's behavior.)
         c = circuit.Circuit("Gx@(0)", editable=True)
         c.tensor_circuit_inplace(circuit.Circuit((), line_labels=(1,)))
         c.done_editing()
         self.assertEqual(c.line_labels, (0, 1))
+
+    def test_tensor_circuit_implicit_idle_beyond_insertee_depth_ok(self):
+        # review follow-up for issue #762: implicit-sslbls labels in layers the
+        # insertion never touches (here a trailing global idle) must not trip
+        # the guard -- develop tensored this successfully
+        c = circuit.Circuit([('Gx', 0), 'Gi'], line_labels=(0,), editable=True)
+        c.tensor_circuit_inplace(circuit.Circuit("Gy:1@(1)"))
+        c.done_editing()
+        self.assertEqual(c, circuit.Circuit([[('Gx', 0), ('Gy', 1)], 'Gi'], line_labels=(0, 1)))
 
     def test_tensor_circuit_with_empty_layers_ok(self):
         # pin for issue #762: empty (idle) layers contain no implicit-sslbls

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -948,13 +948,41 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c, circuit.Circuit("Gx:10Gy:11@(10,11)"))
 
     def test_map_state_space_labels_with_callable_matches_inplace(self):
-        # the non-inplace variant already handled callables; pin that the two agree
+        # issue #763: the non-inplace variant already handled callables; the
+        # fixed inplace variant must agree with it
         c = circuit.Circuit("Gx:0Gy:1@(0,1)")
         mapped = c.map_state_space_labels(lambda ll: ll + 10)
         c2 = c.copy(editable=True)
         c2.map_state_space_labels_inplace(lambda ll: ll + 10)
         c2.done_editing()
         self.assertEqual(mapped, c2)
+
+    def test_map_names_inplace_preserves_circuit_labels(self):
+        # review follow-up for issue #763: CircuitLabel.IS_SIMPLE is True, so
+        # the simple-label rebuild used to silently flatten a CircuitLabel to a
+        # bare Label, discarding its subcircuit
+        cl = CircuitLabel('Gbox', (Label('Gx', 0), Label('Gy', 0)), (0,))
+        c = circuit.Circuit([cl], line_labels=(0,), editable=True, expand_subcircuits=False)
+        c.map_names_inplace(lambda name: name + '2' if name == 'Gbox' else name)
+        self.assertIsInstance(c[0], CircuitLabel)
+        self.assertEqual(c[0].name, 'Gbox2')
+        self.assertEqual(c[0].components, (Label('Gx', 0), Label('Gy', 0)))
+        c2 = circuit.Circuit([cl], line_labels=(0,), editable=True, expand_subcircuits=False)
+        c2.map_names_inplace({'Gbox': 'Gbox2'})
+        self.assertIsInstance(c2[0], CircuitLabel)
+        self.assertEqual(c2[0].name, 'Gbox2')
+
+    def test_map_state_space_labels_inplace_preserves_circuit_labels(self):
+        # review follow-up for issue #763: same flattening hazard as above; the
+        # CircuitLabel's own sslbls and its subcircuit's sslbls both map
+        cl = CircuitLabel('Gbox', (Label('Gx', 0), Label('Gy', 0)), (0,))
+        c = circuit.Circuit([cl], line_labels=(0,), editable=True, expand_subcircuits=False)
+        c.map_state_space_labels_inplace(lambda ll: ll + 10)
+        c.done_editing()
+        self.assertEqual(c.line_labels, (10,))
+        self.assertIsInstance(c[0], CircuitLabel)
+        self.assertEqual(c[0].sslbls, (10,))
+        self.assertEqual(c[0].components, (Label('Gx', 10), Label('Gy', 10)))
 
     def test_sort_layer_labels_inplace_raises_on_static(self):
         # regression test for issue #760: previously this silently rewrote


### PR DESCRIPTION
This PR brought to you by a robot. I reviewed every line before opening it.

## Summary

Five independent bug fixes in `pygsti/circuits/circuit.py`, **one commit per issue** (plus three review-response commits, see below) so the PR can be reviewed bug-by-bug, batched into a single PR to economize on CI time.

Fixes #756, fixes #760, fixes #762, fixes #763, fixes #764.

Every defect was confirmed before fixing (see the linked issues), and every fix ships with regression tests that fail on `develop` without it. No fix touches the circuit identity core: the `tup` wire format, hash values, string grammar, etc..

## The fixes, commit by commit

1. #763: the callable branch returned the mapper function object instead of calling it, so any non-dict mapper hit a Label-validation `AssertionError`. Mirrors the correct branch that the non-inplace `map_state_space_labels` already had. Adds the first direct unit tests for `map_names_inplace` (it had none, dict path included).

2. #760: the only mutator without `assert(not self._static)`; on a static circuit it rewrote `_labels` while leaving the cached `_hashable_tup`/`_hash`/`_str` stale, so `hash(c)` silently disagreed with `c.tup`. It also re-encoded *editable* circuits into the static tuple-of-Labels format, breaking subsequent in-place edits. Now it has the standard guard and preserves the editable nested-list encoding. `done_editing` — its only in-repo caller, which flips `_static` *before* sorting — calls the module-level `_sort_layer_labels` helper directly; its behavior is unchanged (pinned by a new sorting+hash test, and benchmarked identical).

3. #762. This has two parts.
    * tensoring onto a circuit whose gates have implicit (`None`) state-space labels failed deep inside `_clear_labels` with the cryptic *"Cannot operate on a block that is straddled by Gx!"* — now an up-front, actionable `ValueError`. The guard matches develop's failure surface exactly: it only considers implicit labels **in the layers the insertion writes to**, so implicit labels in deeper layers, implicit-sslbls *insertees*, depth-0 or zero-line insertees, and empty idle layers all keep working — each pinned by a test.
    * A list-valued `line_order` (which the signature has always advertised) was stored un-tupled, violating the `_line_labels`-is-a-tuple invariant and crashing much later in `done_editing`. Also adds the first tests ever for the non-inplace `tensor_circuit`.

5. #756: the non-strict membership test `len(sslbls.intersection(lines)) >= 0` was always true (no filtering happened at all), and the result's line labels were assigned the sentinel *string* `'auto'`, which `_bare_init` blindly tuples into `('a', 'u', 't', 'o')`. Now the filter keeps exactly the labels that act on or straddle the requested lines, and the result's line labels are computed for real: the requested lines, extended (in the parent's line-label order) by any extra lines covered by straddling labels. **`strict=False` has zero callers inside pyGSTi and had zero test coverage prior to this PR** — both defects were reachable only through the public API. Bonus: non-strict extraction got ~17% *faster* (it no longer builds oversized layers).

6. #764 misc fixes.
   * `_proc_key_arg` *returned* an `IndexError` instead of raising it (so `c[0,1,2]` surfaced as an unpacking `TypeError`).
   * a non-f-string error message showed users the literal `{line_lbl}`.
   * a cast warning blamed `old_gatename` while casting `new_gatename`.
   * two dead branches (`delete_idling_lines_inplace`'s `if self._static:` after an assert-not-static, constant ternaries in `extract_labels`' zero-area path).
   * `_write_q_circuit_tex` deleted outright — it raised `NotImplementedError` as its first statement and its 43 dead lines referenced attributes that no longer exist (`self.line_items`, `self.identity`). Zero references repo-wide.

## Adversarial self-review (commits 6–8)

Before opening this PR, an adversarial multi-agent review tried to refute each fix. It confirmed four of five outright and caught three real problems, fixed in dedicated commits:

- **Guard too broad** (`bb3f8a08c`): the first version of the 762 guard rejected hosts with implicit labels in layers the insertion never touches (e.g. trailing global idles), which develop tensored successfully. Narrowed to `self._labels[:circuit.num_layers]` and gated on the insertee actually adding lines.

- **CircuitLabel flattening** (`2aff09799`): `CircuitLabel.IS_SIMPLE` is `True`, so the inplace mappers rebuilt CircuitLabels as bare Labels, silently discarding the subcircuit — a path the callable fix made newly reachable (it used to crash). Both mappers now preserve CircuitLabels; the sslbls variant delegates to `CircuitLabel.map_state_space_labels`, which also repairs the pre-existing dict-mapper flattening there.

- **Hot-path nit** (`4fcccd5ed`): a genexpr closing over a local added a `MAKE_CELL` prologue to every `extract_labels` call (~+7% on the `c[i]` fast path that `prefixtable`/`model.py` hit in hot loops). Replaced with closure-free `filter()`; bytecode verified clean.

## Relation to PR #735

Two of these bugs are ones [#735](#735)'s branch currently works around, per the plan that the bug-shaped fixes land on `develop` first and `develop` is then merged back into [#735](#735):

- The [#756](#756) filter fix **matches [#735](#735)'s branch verbatim** (`not strict and sslbls.intersection(lines)`), so no semantic divergence on merge. ([#735](#735) does not fix the `'auto'` line-labels defect; after the merge it inherits this fix.)

- For [#762](#762), this PR makes the implicit-sslbls host case a clear *error*; [#735](#735)'s rewrite later makes it *work* via `Label.concate` — error → works is a clean forward path, no conflict. The `tuple(line_order)` coercion also repairs the same latent un-tupled assignment that [#735](#735)'s rewrite retains (`new_line_labels = line_order`), so merging `develop` into [#735](#735) fixes that branch's copy of the bug for free.

## Testing

26 new unit tests in `test/unit/objects/test_circuit.py::CircuitBugfixRegressionTester`: regression tests verified (in a develop worktree) to **fail on `develop`** for exactly the catalogued reasons, plus explicitly-labeled context pins for neighboring behavior that must *not* change (strict extraction, implicit-sslbls insertees, trailing global idles, empty idle layers, `done_editing` sorting, dict mappers).

```
pytest test/unit/objects/test_circuit.py -q     # 98 passed
pytest test/unit -q                             # full unit suite: green
```

(Environment note: 4 tests fail identically on a clean `develop` checkout in the dev container — 3× `test_gst.py::*::test_write_and_read_to_dir` on a sandbox `PermissionError` and 1× `test_mpi` — i.e. pre-existing environment failures, not branch-caused. CI should be authoritative.)

Indirect-caller paths exercised explicitly: `test_edesigntools.py` / `test_protocols.py`, `test_rb.py` (`map_names_inplace` via MirrorRB), `test_compilers.py` (`map_state_space_labels_inplace`) — all pass.

## Observations out of scope for this PR (no action here)

- `pygsti/extras/crosstalk/core.py:755,898,1039` call the copy-returning `tensor_circuit` and discard the result — silent no-ops since 2020-09 (c47c1c55d), zero test coverage. Worth its own issue.
- `extract_labels` on an *editable* circuit returns layers stored as immutable `Label` objects rather than the editable nested-list encoding (same corruption class as [#760](#760); pre-existing, unchanged by this PR). Candidate for the rewrite or a future issue.
- `insert_circuit_inplace` (circuit.py:2392) is safe under the new `strict=False` semantics only because of its `_is_line_idling` assertion — noted for future maintainers.
