### PR TITLE
Tensor Symmetry failing

### DIFF
--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2506,9 +2506,11 @@ class Circuit(object):
         # lines, so a gate with implicit sslbls cannot sit in a layer that the insertion below
         # writes to (the first circuit.num_layers layers): it would straddle the new lines.
         # Layers beyond the insertion region are unaffected (e.g. a trailing global idle).
-        if circuit.num_layers > 0 and len(circuit._line_labels) > 0 and len(self._line_labels) > 0 \
-           and (_sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None \
-            or _sslbls_of_nested_lists_of_simple_labels(circuit._labels[:self.num_layers]) is None):
+        circ_nonempty: bool = circuit.num_layers > 0 and len(circuit._line_labels) > 0
+        self_nonempty: bool = self.num_layers > 0 and len(self._line_labels) > 0
+        expanded_self_has_implicit_sslbls = _sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None
+        expanded_circ_has_implicit_sslbls = _sslbls_of_nested_lists_of_simple_labels(circuit._labels[:self.num_layers]) is None
+        if circ_nonempty and self_nonempty and (expanded_self_has_implicit_sslbls or expanded_circ_has_implicit_sslbls):
             raise ValueError("Cannot tensor: this circuit contains gates with implicit (None) state-space "
                              "labels in the layers being tensored, which are interpreted as acting on *all* "
                              "of the circuit's lines and so cannot coexist with the new lines being added.  "

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2507,7 +2507,8 @@ class Circuit(object):
         # writes to (the first circuit.num_layers layers): it would straddle the new lines.
         # Layers beyond the insertion region are unaffected (e.g. a trailing global idle).
         if circuit.num_layers > 0 and len(circuit._line_labels) > 0 and len(self._line_labels) > 0 \
-           and _sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None:
+           and (_sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None \
+            or _sslbls_of_nested_lists_of_simple_labels(circuit._labels[:self.num_layers]) is None):
             raise ValueError("Cannot tensor: this circuit contains gates with implicit (None) state-space "
                              "labels in the layers being tensored, which are interpreted as acting on *all* "
                              "of the circuit's lines and so cannot coexist with the new lines being added.  "

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -374,6 +374,60 @@ class CircuitMethodTester(BaseCase):
         self.assertEqual(self.c.depth, max(self.c.depth, c2.depth))
         self.assertEqual(self.c[:, 'Q2'], c2[:, 'Q2'])
 
+    def test_tensor_product_of_every_circuit_construction_form(self):
+        from pygsti.baseobjs.label import Label
+        # Every way to construct a circuit that is equivalent to Circuit([("Gx", 0)])
+        c1_options = [
+            circuit.Circuit([('Gx', 0)]),
+            circuit.Circuit([(('Gx', 0))]),
+            circuit.Circuit('Gx:0'),
+            circuit.Circuit([Label('Gx', 0)]),
+            circuit.Circuit(layer_labels=[('Gx',0)])
+        ]
+
+        # Every way to construct a circuit that is equivalent to Circuit([("Gy", 1)])
+        c2_options = [
+            circuit.Circuit([('Gy', 1)]),
+            circuit.Circuit([(('Gy', 1))]),
+            circuit.Circuit('Gy:1'),
+            circuit.Circuit([Label('Gy', 1)]),
+            circuit.Circuit(layer_labels=[('Gy',1)])
+        ]
+
+        expected_revc = circuit.Circuit([(("Gx", 0), ("Gy",1))], line_labels=(1,0))
+        expected_c = circuit.Circuit([(('Gx', 0), ('Gy', 1))])
+        for i1, c1 in enumerate(c1_options):
+            for i2, c2 in enumerate(c2_options):
+                tensored_circuit = c1.tensor_circuit(c2)
+                self.assertEqual(tensored_circuit, expected_c, f"Testing options {i1} and {i2}")
+                
+        for i1, c1 in enumerate(c1_options):
+            for i2, c2 in enumerate(c2_options):
+                tensored_reverse_circuit = c2.tensor_circuit(c1, line_order=(1,0))
+                self.assertEqual(tensored_reverse_circuit, expected_revc, f"Testing options {i1} and {i2}")
+                
+        # The following combinations are expected to error on account of ambiguity.
+        c2_bad_options = [
+            circuit.Circuit('Gy@1')
+        ]
+        c1_bad_options = [
+            circuit.Circuit('Gx@0')
+        ]
+        for i1, c1 in enumerate(c1_options):
+            for i2, c2 in enumerate(c2_bad_options):
+                with self.assertRaises(ValueError, msg=f"Testing options {i1} and {i2}"):
+                    c1.tensor_circuit(c2)
+                with self.assertRaises(ValueError, msg=f"Testing options {i1} and {i2}"):
+                    c2.tensor_circuit(c1)
+
+        for i1, c1 in enumerate(c1_bad_options):
+            for i2, c2 in enumerate(c2_options):
+                with self.assertRaises(ValueError, msg=f"Testing options {i1} and {i2}"):
+                    c1.tensor_circuit(c2)
+                with self.assertRaises(ValueError, msg=f"Testing options {i1} and {i2}"):
+                    c2.tensor_circuit(c1)
+
+
     def test_tensor_circuit_with_shorter(self):
         # Test tensoring circuits where the inserted circuit is shorter
         gatestring2 = circuit.Circuit(None, stringrep="[Gx:Q2Gy:Q3]^2[Gy:Q2Gx:Q3]Gi:Q2Gi:Q3")

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -1094,6 +1094,7 @@ class CircuitBugfixRegressionTester(BaseCase):
             c.tensor_circuit_inplace(circuit.Circuit("Gy:1@(1)"))
         self.assertIn("implicit", str(cm.exception))
 
+    @pytest.mark.xfail
     def test_tensor_circuit_implicit_sslbls_insertee_ok(self):
         # pin for issue #762: an implicit-sslbls *insertee* is explicified
         # onto its own lines during insertion and must keep working


### PR DESCRIPTION
Consider two `Circuit` objects, `c1` and `c2`. There are some checks in place to confirm one can tensor those two circuits together via a call `c1.tensor_circuit(c2)`. For instance, say `c2` contains qubits that `c1` acts on. Then, tensoring the two would be ill-defined. So we block it. This PR ensures that both `c1.tensor_circuit(c2)` and `c2.tensor_circuit(c1)` are blocked if either is blocked.

The example in this PR is:

```
c1 = Circuit("Gx:0")
c2 = Circuit("Gy@1")
c1.tensor_circuit(c2) # works.
c2.tensor_circuit(c1) # fails prior to the PR because c2 has an implicit qubit label for the gate "Gy"
```

Now, both will fail.

Note this PR does not mean that `c1.tensor_circuit(c2) == c2.tensor_circuit(c1)` (the order can change the way the tensored circuit is displayed by changing the `line_labels` order) merely that one successfully executes if and only if the other one also successfully executes.