### PR TITLE
speed up readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,11 @@ build:
   commands:
     # rtd-requirements.txt installs `.[docs]` which pulls in pyGSTi itself
     # plus jupyter-book, jupytext, matplotlib, numpy.
-    - pip install -r rtd-requirements.txt
+    # PYGSTI_SKIP_CYTHON: the API docs only need pyGSTi importable; the
+    # pure-Python fallback reps suffice, so don't spend build time compiling.
+    - PYGSTI_SKIP_CYTHON=1 pip install -r rtd-requirements.txt
     - jb build docs/
+    # .doctrees is Sphinx's intermediate cache (~130 MB); don't publish it.
+    - rm -rf docs/_build/html/.doctrees
     - mkdir -p $READTHEDOCS_OUTPUT/html
     - cp -r docs/_build/html/. $READTHEDOCS_OUTPUT/html/


### PR DESCRIPTION
Our current ReadTheDocs build is inefficient in two ways. First, it builds optional Cython extensions, while the pure-python suffices for imports (and imports are all that's needed for the docs to build). Second, it saves an unnecessary cache that's a bit over 100 MB. This PR turns both of those behaviors off.