### PR TITLE
Be slightly more permissive with implicit state space labels when tensoring two circuits.

### DIFF
--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2510,7 +2510,24 @@ class Circuit(object):
         self_nonempty: bool = self.num_layers > 0 and len(self._line_labels) > 0
         expanded_self_has_implicit_sslbls = _sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None
         expanded_circ_has_implicit_sslbls = _sslbls_of_nested_lists_of_simple_labels(circuit._labels[:self.num_layers]) is None
-        if circ_nonempty and self_nonempty and (expanded_self_has_implicit_sslbls or expanded_circ_has_implicit_sslbls):
+        idle_circ_with_unknown_sslbls =  Circuit([_Label(())])
+        implicit_sslbls_matter = False
+        for i in range(min(len(self), len(circuit))):
+            lbl = self[i]
+            lbl2 = circuit[i]
+            assert isinstance(lbl, _Label)
+            assert isinstance(lbl2, _Label)
+            if lbl == idle_circ_with_unknown_sslbls and lbl2 != idle_circ_with_unknown_sslbls:
+                implicit_sslbls_matter = True
+                break
+            elif lbl != idle_circ_with_unknown_sslbls and lbl2 == idle_circ_with_unknown_sslbls:
+                implicit_sslbls_matter = True
+                break
+            elif lbl != lbl2 and (lbl.sslbls is None or lbl2.sslbls is None):
+                implicit_sslbls_matter = True
+                break
+
+        if circ_nonempty and self_nonempty and (expanded_self_has_implicit_sslbls or expanded_circ_has_implicit_sslbls) and (implicit_sslbls_matter):
             raise ValueError("Cannot tensor: this circuit contains gates with implicit (None) state-space "
                              "labels in the layers being tensored, which are interpreted as acting on *all* "
                              "of the circuit's lines and so cannot coexist with the new lines being added.  "

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2510,20 +2510,20 @@ class Circuit(object):
         self_nonempty: bool = self.num_layers > 0 and len(self._line_labels) > 0
         expanded_self_has_implicit_sslbls = _sslbls_of_nested_lists_of_simple_labels(self._labels[:circuit.num_layers]) is None
         expanded_circ_has_implicit_sslbls = _sslbls_of_nested_lists_of_simple_labels(circuit._labels[:self.num_layers]) is None
-        idle_circ_with_unknown_sslbls =  Circuit([_Label(())])
+        implicit_idle_layer = _Label(())
         implicit_sslbls_matter = False
         for i in range(min(len(self), len(circuit))):
             lbl = self[i]
             lbl2 = circuit[i]
             assert isinstance(lbl, _Label)
             assert isinstance(lbl2, _Label)
-            if lbl == idle_circ_with_unknown_sslbls and lbl2 != idle_circ_with_unknown_sslbls:
+            if lbl == implicit_idle_layer and lbl2 != implicit_idle_layer:
                 implicit_sslbls_matter = True
                 break
-            elif lbl != idle_circ_with_unknown_sslbls and lbl2 == idle_circ_with_unknown_sslbls:
+            elif lbl != implicit_idle_layer and lbl2 == implicit_idle_layer:
                 implicit_sslbls_matter = True
                 break
-            elif lbl != lbl2 and (lbl.sslbls is None or lbl2.sslbls is None):
+            elif lbl != implicit_idle_layer and lbl2 != implicit_idle_layer and (lbl.sslbls is None or lbl2.sslbls is None):
                 implicit_sslbls_matter = True
                 break
 


### PR DESCRIPTION
We are judging whether implicit state space labels are bad on a layer by layer basis. Basically both Labels need to have either a sslbl or are both the implicit idle

pseudocode of check
```
for i in range(min(len(c), len(c2)):
    if c[i] != c2[i] and c2 == implicit idle:
       raise ValueError
    elif c[i] == implicit_idle and c2[i] != c[i]:
       raise ValueError
    elif c[i] != implicit_idle and c2[i] != implicit_idle and (c[i].sslbls is None or c2[i].sslbls is None):
       raise ValueError
```