### PR TITLE
Reduce CI wall-clock latency, plus shift to Python 3.10 -- 3.13

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.0.0
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_ALL_LINUX: ./.github/ci-scripts/before_install.sh
           CIBW_BEFORE_ALL_MACOS: ./.github/ci-scripts/before_install_macos.sh

--- a/.github/workflows/beta-master.yml
+++ b/.github/workflows/beta-master.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      run-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.use-cython == 'true' }} # cover exactly one job
       use-cython: ${{ matrix.use-cython }}
       run-unit-tests: 'true'
       run-integration-tests: 'true'

--- a/.github/workflows/beta-master.yml
+++ b/.github/workflows/beta-master.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         use-cython: ['true', 'false']
     uses: ./.github/workflows/reuseable-main.yml
     name: Run pyGSTi tests

--- a/.github/workflows/beta-master.yml
+++ b/.github/workflows/beta-master.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         use-cython: ['true', 'false']
     uses: ./.github/workflows/reuseable-main.yml
     name: Run pyGSTi tests

--- a/.github/workflows/bugfix.yml
+++ b/.github/workflows/bugfix.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      run-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.use-cython == 'true' }} # cover exactly one job
       use-cython: 'true' # Cython only
       run-unit-tests: 'true'
       run-integration-tests: 'true'

--- a/.github/workflows/bugfix.yml
+++ b/.github/workflows/bugfix.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest] # No Mac
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         use-cython: ['true', 'false']
     uses: ./.github/workflows/reuseable-main.yml
     name: Run pyGSTi tests

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      run-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.use-cython == 'true' }} # cover exactly one job
       use-cython: 'true' # Cython only
       run-unit-tests: 'true'
       run-integration-tests: 'true'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest] # No Mac
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         use-cython: ['true', 'false']
     uses: ./.github/workflows/reuseable-main.yml
     name: Run pyGSTi tests

--- a/.github/workflows/feature-branches.yml
+++ b/.github/workflows/feature-branches.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.9, '3.12'] # Only extremal Python versions
+        python-version: ['3.10', '3.13'] # Only extremal Python versions
     uses: ./.github/workflows/reuseable-main.yml
     name: Run pyGSTi tests
     with:

--- a/.github/workflows/feature-branches.yml
+++ b/.github/workflows/feature-branches.yml
@@ -25,6 +25,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      run-coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' }} # cover exactly one job
       use-cython: 'true' # Only test environment with Cython
       run-unit-tests: 'true'
       run-integration-tests: 'true'

--- a/.github/workflows/reuseable-main.yml
+++ b/.github/workflows/reuseable-main.yml
@@ -28,6 +28,14 @@ on:
       run-notebook-tests:
         required: true
         type: string
+      # Whether THIS matrix entry measures coverage. Callers set it true for exactly
+      # one job (ubuntu + highest Python, where coverage.py's sysmon core keeps the
+      # tracer cheap on 3.12+). CI never uploads the report, so measuring it on every
+      # job is pure overhead; one job preserves a human-readable number in the logs.
+      run-coverage:
+        required: false
+        type: string
+        default: 'false'
 
 env:
   SKIP_DEAP: 1
@@ -107,14 +115,21 @@ jobs:
         flake8 . --exit-zero --statistics
     - name: Run unit tests
       if: ${{ inputs.run-unit-tests == 'true' }}
+      # bash on every runner (Git Bash on Windows) so $COV_FLAG expands portably.
+      shell: bash
+      env:
+        COV_FLAG: ${{ inputs.run-coverage == 'true' && '--cov=pygsti' || '' }}
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
-        python -m pytest -n auto --dist loadscope --cov=pygsti --durations=25 test/unit
+        python -m pytest -n auto --dist loadscope $COV_FLAG --durations=25 test/unit
     - name: Run workflow tests
       if: ${{ inputs.run-integration-tests == 'true' }}
+      shell: bash
+      env:
+        COV_FLAG: ${{ inputs.run-coverage == 'true' && '--cov=pygsti' || '' }}
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
-        python -m pytest -n auto --dist loadscope --cov=pygsti test/integration
+        python -m pytest -n auto --dist loadscope $COV_FLAG test/integration
     - name: Run test_packages
       if: ${{ inputs.run-extra-tests == 'true' }}
       run: |

--- a/.github/workflows/reuseable-main.yml
+++ b/.github/workflows/reuseable-main.yml
@@ -36,6 +36,13 @@ env:
   # instead of pip's default CUDA build, which drags in ~2.5 GB of nvidia-* wheels
   # that CI never uses. uv honors this for every resolution in the job.
   UV_TORCH_BACKEND: cpu
+  # Use coverage.py's sys.monitoring core (PEP 669) for --cov runs. Python 3.12's
+  # specializing adaptive interpreter de-optimizes the legacy C trace function,
+  # which made coverage of call-heavy tests (e.g. the errgenproptools error-generator
+  # composition tests) ~40x slower on 3.12 than on 3.9 -- a Python-version effect
+  # previously misread as a numpy-2 regression. sysmon restores near-native speed;
+  # it falls back gracefully (with a CoverageWarning) on Python < 3.12.
+  COVERAGE_CORE: sysmon
 
 jobs:
   build-and-test:

--- a/.github/workflows/reuseable-main.yml
+++ b/.github/workflows/reuseable-main.yml
@@ -94,14 +94,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-uv-
     - name: Install build and lint tools
-      # setuptools is needed by the explicit `setup.py build_ext` call below (an
-      # editable install does not leave it in the environment); flake8 for linting.
+      # flake8 for the lint step; setuptools/wheel kept on hand for any dependency that
+      # still imports pkg_resources at runtime.
       run: uv pip install --system setuptools wheel flake8
     - name: Install package (Cython)
       if: ${{ inputs.use-cython == 'true' }}
+      # The PEP 660 editable install compiles the Cython extensions in-place via build
+      # isolation, so a separate `setup.py build_ext --inplace` is redundant (verified:
+      # the editable install alone yields importable .so for all 19 extensions).
       run: |
         uv pip install --system -e .[testing]
-        python setup.py build_ext --inplace
     - name: Install package (No Cython, Linux only)
       if: ${{ inputs.use-cython != 'true' && inputs.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/reuseable-main.yml
+++ b/.github/workflows/reuseable-main.yml
@@ -60,15 +60,24 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
+    # uv gives fast, parallel installs and CPU-only torch resolution (see env above).
+    # The astral-sh/setup-uv action is blocked by the org Actions allowlist, so we
+    # bootstrap uv from PyPI with the stock pip (a `run:` step is not an action) and
+    # cache its downloads with the GitHub-owned actions/cache.
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      run: python -m pip install --upgrade pip uv
+    - name: Cache uv downloads
+      uses: actions/cache@v4
       with:
-        enable-cache: true
-        # Key the uv cache on the real dependency manifests. (The old pip cache
-        # hashed setup.py + requirements.txt, but the deps actually live in pyproject.toml.)
-        cache-dependency-glob: |
-          **/pyproject.toml
-          **/setup.py
+        # Default uv cache dir, listed for each OS; non-matching paths are skipped.
+        path: |
+          ~/.cache/uv
+          ~/Library/Caches/uv
+          ~\AppData\Local\uv\cache
+        # Key on the real dependency manifests (deps live in pyproject.toml).
+        key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-uv-
     - name: Install build and lint tools
       # setuptools is needed by the explicit `setup.py build_ext` call below (an
       # editable install does not leave it in the environment); flake8 for linting.

--- a/.github/workflows/reuseable-main.yml
+++ b/.github/workflows/reuseable-main.yml
@@ -32,6 +32,10 @@ on:
 env:
   SKIP_DEAP: 1
   PYGSTI_NO_CUSTOMLM_SIGINT: 1
+  # Resolve PyTorch (a transitive test dependency) from the CPU-only wheel index
+  # instead of pip's default CUDA build, which drags in ~2.5 GB of nvidia-* wheels
+  # that CI never uses. uv honors this for every resolution in the job.
+  UV_TORCH_BACKEND: cpu
 
 jobs:
   build-and-test:
@@ -56,25 +60,28 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Cache pip packages
-      uses: actions/cache@v4
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
       with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('**/*requirements.txt') }}
-    - name: Install pip packages
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install wheel
-        python -m pip install flake8
+        enable-cache: true
+        # Key the uv cache on the real dependency manifests. (The old pip cache
+        # hashed setup.py + requirements.txt, but the deps actually live in pyproject.toml.)
+        cache-dependency-glob: |
+          **/pyproject.toml
+          **/setup.py
+    - name: Install build and lint tools
+      # setuptools is needed by the explicit `setup.py build_ext` call below (an
+      # editable install does not leave it in the environment); flake8 for linting.
+      run: uv pip install --system setuptools wheel flake8
     - name: Install package (Cython)
       if: ${{ inputs.use-cython == 'true' }}
       run: |
-        python -m pip install -e .[testing]
+        uv pip install --system -e .[testing]
         python setup.py build_ext --inplace
     - name: Install package (No Cython, Linux only)
       if: ${{ inputs.use-cython != 'true' && inputs.os == 'ubuntu-latest' }}
       run: |
-        PYGSTI_CYTHON_SKIP=1 python -m pip install -e .[testing_no_cython]
+        PYGSTI_CYTHON_SKIP=1 uv pip install --system -e .[testing_no_cython]
     - name: Lint with flake8 (Linux only)
       if: ${{ inputs.os == 'ubuntu-latest'}}
       run: |
@@ -103,7 +110,7 @@ jobs:
         # Tutorials live as MyST Markdown under docs/markdown/; jupytext
         # materializes the paired .ipynb mirror under docs/notebooks/ for
         # nbval to consume.
-        pip install -e .[docs]
+        uv pip install --system -e .[docs]
         (cd docs && jupytext --sync 'markdown/**/*.md')
 
         # Download and compile CHP for the Clifford-simulation notebook;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In particular, there are a number of characterization protocols currently implem
 
 PyGSTi is designed with a modular structure so as to be highly customizable
 and easily integrated to new or existing python software.  It runs using
-python 3.9 or higher.  To facilitate integration with software for running
+python 3.10 or higher.  To facilitate integration with software for running
 cloud-QIP experiments, pyGSTi `Circuit` objects can be converted to IBM's
 **OpenQASM** and Rigetti Quantum Computing's **Quil** circuit description languages.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies=[
     'networkx',
     'tqdm>=4.42.0'
 ]
-requires-python='>=3.9'
+requires-python='>=3.10'
 keywords=[
     'pygsti',
     'tomography',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from warnings import warn
 from collections import defaultdict
 import os
+import sys
 
 
 try:
@@ -52,7 +53,12 @@ class our_build_ext(build_ext):
 
     def finalize_options(self):
         super().finalize_options()
-        if self.parallel is None:  # respect explicit -j / config
+        if self.parallel is None and sys.platform != "win32":  # respect explicit -j / config
+            """
+            That's a known failure mode of parallel build_ext on Windows:
+            a file-collision race between concurrent cl.exe processes. So
+            we guard on sys.platform != "win32".
+            """
             self.parallel = int(os.environ.get("BUILD_JOBS", os.cpu_count()))
     
     def build_extensions(self):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from warnings import warn
 from collections import defaultdict
 import os
 
+
 try:
     from setuptools import setup, find_packages
     from setuptools import Extension
@@ -12,6 +13,7 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
     from distutils.command.build_ext import build_ext
+
 
 # Configure setuptools_scm to build a custom version (for more info,
 # see https://stackoverflow.com/a/78657279 and https://setuptools-scm.readthedocs.io/en/latest/extending)
@@ -35,6 +37,7 @@ def custom_version(version):
 
     return local_scheme
 
+
 #Create a custom command class that allows us to specify different compiler flags
 # based on the compiler (~platform) being used (see
 # https://stackoverflow.com/questions/30985862/how-to-identify-compiler-before-defining-cython-extensions)
@@ -44,7 +47,14 @@ for compiler, args in [
         ('gcc', ["-std=c++11", "-Wno-deprecated"])]:
     BUILD_ARGS[compiler] = args
 
-class build_ext_compiler_check(build_ext):
+
+class our_build_ext(build_ext):
+
+    def finalize_options(self):
+        super().finalize_options()
+        if self.parallel is None:  # respect explicit -j / config
+            self.parallel = int(os.environ.get("BUILD_JOBS", os.cpu_count()))
+    
     def build_extensions(self):
         compiler = self.compiler.compiler_type
         args = BUILD_ARGS[compiler]
@@ -53,6 +63,7 @@ class build_ext_compiler_check(build_ext):
             if ext.language == "c++":  # only do this for c++ files, so we can specify -std=c++11, etc.
                 ext.extra_compile_args = args
         build_ext.build_extensions(self)
+
 
 # Check if environment can try to build extensions
 try:
@@ -63,6 +74,12 @@ try:
         warn("PYGSTI_SKIP_CYTHON env variable defined. Installing without Cython extensions...")
         extensions = None
     else:
+        common_evotypes_kwargs = dict(
+            include_dirs=['.', 'pygsti/evotypes', np.get_include()],
+            language="c++",
+            extra_link_args=["-std=c++11"],
+            extra_compile_args=['-O3']
+        )
         ext_modules = [
             Extension(
                 "pygsti.tools.fastcalc",
@@ -110,9 +127,7 @@ try:
                     "pygsti/evotypes/densitymx/statereps.pyx",
                     "pygsti/evotypes/densitymx/statecreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.densitymx.opreps",
@@ -121,9 +136,7 @@ try:
                     "pygsti/evotypes/densitymx/opcreps.cpp",
                     "pygsti/evotypes/densitymx/statecreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.densitymx.effectreps",
@@ -133,9 +146,7 @@ try:
                     "pygsti/evotypes/densitymx/statecreps.cpp",
                     "pygsti/evotypes/densitymx/opcreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.statevec.statereps",
@@ -143,9 +154,7 @@ try:
                     "pygsti/evotypes/statevec/statereps.pyx",
                     "pygsti/evotypes/statevec/statecreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.statevec.opreps",
@@ -154,9 +163,7 @@ try:
                     "pygsti/evotypes/statevec/opcreps.cpp",
                     "pygsti/evotypes/statevec/statecreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.statevec.effectreps",
@@ -166,9 +173,7 @@ try:
                     "pygsti/evotypes/statevec/statecreps.cpp",
                     "pygsti/evotypes/statevec/opcreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.statevec.termreps",
@@ -179,9 +184,7 @@ try:
                     "pygsti/evotypes/statevec/opcreps.cpp",
                     "pygsti/evotypes/statevec/effectcreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.stabilizer.statereps",
@@ -189,9 +192,7 @@ try:
                     "pygsti/evotypes/stabilizer/statereps.pyx",
                     "pygsti/evotypes/stabilizer/statecreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.stabilizer.opreps",
@@ -200,9 +201,7 @@ try:
                     "pygsti/evotypes/stabilizer/opcreps.cpp",
                     "pygsti/evotypes/stabilizer/statecreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.stabilizer.effectreps",
@@ -212,9 +211,7 @@ try:
                     "pygsti/evotypes/stabilizer/statecreps.cpp",
                     "pygsti/evotypes/stabilizer/opcreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.evotypes.stabilizer.termreps",
@@ -225,9 +222,7 @@ try:
                     "pygsti/evotypes/stabilizer/opcreps.cpp",
                     "pygsti/evotypes/stabilizer/effectcreps.cpp"
                 ],
-                include_dirs=['.', 'pygsti/evotypes', np.get_include()],
-                language="c++",
-                extra_link_args=["-std=c++11"]
+                **common_evotypes_kwargs
             ),
             Extension(
                 "pygsti.forwardsims.mapforwardsim_calc_densitymx",
@@ -277,7 +272,7 @@ except ImportError:
 try:
     setup(
         use_scm_version={'version_scheme': 'no-guess-dev', 'version_file': "pygsti/_version.py", 'local_scheme': custom_version},
-        cmdclass={'build_ext': build_ext_compiler_check},
+        cmdclass={'build_ext': our_build_ext},
         ext_modules=extensions,
         packages=find_packages(where='.', include=['pygsti']),
         package_data={


### PR DESCRIPTION
This branch substantially cuts the wall-clock **time-to-green** of a CI run (40+ minutes on the slowest leg today) through a sequence of independent changes to the reusable test workflow and packaging. The net effect is that CI now takes less than 20 minutes. Once merged, this PR will resolve #606.

The error-generator unit tests that dominated the Python-3.12 job (`test_errgenproptools.py::…::{test_errorgen_composition, test_iterative_error_generator_composition}`, ~920 s combined and pinned to one `xdist` worker by `--dist loadscope`) are slow because **coverage.py's legacy C trace function is de-optimized by Python 3.12's specializing adaptive interpreter** (PEP 659). Switching coverage to its `sys.monitoring` core (PEP 669) restores near-native speed: the same two tests drop from ~595 s / ~325 s to a few seconds each.

The only remotely controversial change in this PR is dropping support for Python 3.9. That version reached end-of-life in October 2025 according to the Python Software Foundation. Dropping support for it here shaves almost 10 minutes off build time (one of our dependencies, `stim`, has no Python 3.9 wheels and so has an expensive build-from-source). We could add Python 3.9 back if we pinned the `stim` version in the 3.9 build to something that has a wheel.

## Changes

### 1. Faster installs (foundation)
- Move the install path to **`uv`** with dependency caching (`actions/cache` over the uv cache), and resolve PyTorch — a transitive test dependency — from the **CPU-only** wheel index (`UV_TORCH_BACKEND=cpu`) instead of pip's default CUDA build, which otherwise drags in ~2.5 GB of unused `nvidia-*` wheels per job.
- `setup.py` build speed-ups, and disable parallel extension builds on Windows (a known MSVC parallel `build_ext` failure mode).

### 2. Coverage via `sys.monitoring` — the dominant latency lever
- Set `COVERAGE_CORE: sysmon` at the workflow level so `--cov` runs use coverage.py's PEP 669 core. On Python 3.12 the legacy C tracer made coverage of call-heavy tests dramatically slower (the errgen composition tests ran ~595 s / ~325 s under coverage vs a few seconds without); `sysmon` removes essentially all of that overhead. It falls back gracefully (with a `CoverageWarning`) on Python < 3.12. Coverage *data* is unchanged.

### 3. Test Python 3.10–3.13 (drop 3.9, add 3.13)
- `requires-python` → `>=3.10`; every workflow matrix moves to `3.10–3.13` (feature branches keep an extremal pair, now `3.10`/`3.13`).
- Dropping 3.9 removes the slowest jobs (3.9 lacked stim/numpy-2 wheels and built more from source). Adding 3.13 brings the test set up to the current Python.

### 4. Measure coverage on a single job
- CI computed `--cov` on **every** matrix job but never uploaded or consumed the result, so it was pure overhead. A new `run-coverage` input (default `'false'`) gates `--cov=pygsti`, and each caller enables it for **exactly one** job — `ubuntu-latest` + Python 3.13 — where `sysmon` keeps the tracer cheap. The steps use `shell: bash` so the conditional flag expands on Windows runners too.

### 5. Drop the redundant explicit `build_ext`
- The Cython install step ran `uv pip install -e .[testing]` **and then** `python setup.py build_ext --inplace`, recompiling all extensions a second time (~40 s/job). The PEP 660 editable install already compiles them in-place via build isolation — verified on a clean checkout: the editable install alone yields importable `.so` for all 19 extensions.

### 6. Consistency
- Build cp310–cp313 wheels (drop cp39, add cp313) so the release matrix matches the supported set, and update the README's stated minimum to "python 3.10 or higher".

## Why the Python version changes compose

`sysmon` alone is necessary but not sufficient: time-to-green was gated by the **3.9** jobs, which paid big overhead due to building `stim` from source.

Once 3.9 is gone, the tests for `beta` and `master` would hit bottlenecks with **3.11**. That version has the specializing interpreter (the performance hit) but no `sys.monitoring` (3.12+ only). 

Assuming we proceed with the 3.9 removal it's natural to bump the highest-tested Python version to 3.13. Our develop tests only run the lowest-version and highest-version supported Python, which become 3.10 and 3.13 after this PR. Strictly speaking, we could run efficient coverage tests with Python 3.12.

## Verification

- All six workflow YAML files parse.
- `COVERAGE_CORE=sysmon`: the two errgen tests run in ~24 s combined under the exact CI invocation (vs ~920 s on the legacy tracer); full `test/unit/tools` green.
- **Python 3.13, fresh environment:** the full dependency closure (numpy 2.4, scipy, stim, qiskit, torch, cirq, cvxpy, jupyter, …) installs cleanly; the editable install compiles all 19 Cython extensions in-place; **full `test/unit` = 2335 passed, 0 failed** (one MPI-gated test skips only because that local env was built without MPI; CI has it).
- Coverage gating traced by hand and by an independent review: exactly one coverage job per workflow, always `ubuntu` + `3.13` + cython.

## Notes / follow-ups (not in this PR)

- The cp313 wheel build in `autodeploy.yml` only runs on release, so it is **not exercised by this PR** — first validated at the next release.
- Coverage is computed but **never uploaded** anywhere (no Codecov step, no `coverage xml`). This PR keeps one human-readable coverage report on the 3.13 job at near-zero cost; dropping CI coverage entirely, or wiring a real upload, are both reasonable separate decisions.
- Pre-existing items noticed while here, left for separate PRs: `develop.yml`/`bugfix.yml` declare a `use-cython: ['true','false']` matrix but force `'true'`, so every job builds twice; the no-cython install step sets `PYGSTI_CYTHON_SKIP` while `setup.py` checks `PYGSTI_SKIP_CYTHON`; and Python 3.13 surfaces `SyntaxWarning: invalid escape sequence` for LaTeX in two `errgenproptools.py` docstrings (harmless today — raw-string them).
