### PR TITLE
Fix Colab/Binder launch links for ReadTheDocs notebooks

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -47,6 +47,52 @@ jobs:
         git checkout beta
         git merge --ff-only ${GITHUB_SHA} && git push origin beta
 
+  docs-notebooks: # Rebuild the ReadTheDocs "develop-with-notebooks" branch
+    # ReadTheDocs builds the hosted docs from `develop-with-notebooks`, NOT from
+    # `develop`. That branch is `develop` plus jupytext-generated *.ipynb
+    # companions committed next to each notebook *.md, so the Colab/Binder launch
+    # buttons (which fetch from GitHub) resolve to real notebooks. We regenerate
+    # the whole branch as a single atomic, force-pushed commit so RTD never sees
+    # a half-built state.
+    runs-on: ubuntu-latest
+
+    # Only after tests pass on a push to develop.
+    needs: build
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.PYGSTI_TOKEN }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install jupytext
+      run: pip install 'jupytext>=1.16'
+    - name: Build develop-with-notebooks branch
+      run: |
+        git config --global user.name 'PyGSTi'
+        git config --global user.email 'pygsti@noreply.github.com'
+        # Start the branch from the exact develop commit that just passed tests.
+        git checkout -B develop-with-notebooks ${GITHUB_SHA}
+        # Generate an .ipynb next to each notebook .md. --sync honors
+        # docs/jupytext.toml (formats = "ipynb,md:myst") and skips plain-markdown
+        # pages that lack a jupytext header (index/landing pages).
+        shopt -s globstar
+        jupytext --sync docs/markdown/**/*.md
+        # Point the hosted build's launch links at this branch (the
+        # edit_button_branch extension keeps Show source / Suggest edit on develop).
+        # Only the repository.branch key (2-space indent) is rewritten; the
+        # pygsti_edit_branch value stays on develop. The trailing comment is kept.
+        sed -i -E 's|^(  branch: )develop\b(.*)$|\1develop-with-notebooks\2|' docs/_config.yml
+        grep -q '^  branch: develop-with-notebooks' docs/_config.yml  # fail loudly if the rewrite missed
+        # Force-add the generated notebooks (gitignored on develop) + config change.
+        git add -f docs/markdown
+        git add docs/_config.yml
+        git commit -m "Auto-build notebooks for ReadTheDocs [skip ci]"
+        git push --force origin develop-with-notebooks
+
 
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,9 @@ test/test_packages/cmp_chk_files/Fake_Dataset_none.txt.cache
 docs/_autosummary
 docs/_autosummary_manual
 docs/_build
-docs/notebooks/**/*.ipynb
+# jupytext-generated notebook companions (see docs/jupytext.toml). These are
+# build artifacts on develop; CI commits them on the develop-with-notebooks branch.
+docs/markdown/**/*.ipynb
 docs/tutorial_files
 docs/example_files
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,6 +56,11 @@ sphinx:
   # from package metadata) into the MyST substitution {{ pygsti_version }}.
   local_extensions:
     pygsti_version_sub: _ext
+    # Pins the source/edit/repo buttons to `pygsti_edit_branch` (below) so they
+    # keep pointing at the canonical source branch even when the hosted docs are
+    # built from the auto-generated `develop-with-notebooks` branch (whose
+    # repository.branch is rewritten by CI so Colab launch links resolve).
+    edit_button_branch: _ext
   extra_extensions:
   - 'sphinx.ext.napoleon'
   - 'sphinx.ext.autodoc'
@@ -65,6 +70,11 @@ sphinx:
   - 'sphinx.ext.mathjax'
   config:
     add_module_names: False
+    # Canonical, human-editable source branch. The hosted docs are built from
+    # the auto-generated `develop-with-notebooks` branch (so Colab launch links
+    # can reach committed .ipynb companions); the edit_button_branch extension
+    # uses this value to keep "Suggest edit"/"Show source" links on `develop`.
+    pygsti_edit_branch: develop
     # Light/dark logo: in light mode show the dark-content logo (legible on a
     # light background); in dark mode show the white-content logo. Files live in
     # docs/_static, which JB adds to html_static_path automatically.
@@ -85,7 +95,9 @@ sphinx:
     #   - pygsti.drivers.longsequence  the longsequence driver module + its functions
     #   - pygsti.evotypes.*          ~191 pages of internal evolution-type rep machinery
     exclude_patterns:
-    - "notebooks/"
+    # Treat .md as the source for each page; the paired .ipynb (committed only on
+    # the develop-with-notebooks build branch) must not be picked up as a
+    # duplicate source document. The launch-button rewrite still sees it on disk.
     - "**/*.ipynb"
     - "_autosummary/pygsti.report.*"
     - "_autosummary/pygsti.modelpacks.*"

--- a/docs/_ext/edit_button_branch.py
+++ b/docs/_ext/edit_button_branch.py
@@ -1,0 +1,61 @@
+"""Local Sphinx extension: pin the source/edit buttons to a fixed branch.
+
+The hosted docs are built from an auto-generated ``develop-with-notebooks``
+branch that carries committed ``.ipynb`` companions, so the Colab/Binder launch
+links resolve to real notebooks on GitHub. sphinx-book-theme derives a single
+``repository_branch`` for *both* the launch buttons *and* the "Show source" /
+"Suggest edit" buttons, so without intervention those edit links would send
+contributors to the throwaway build branch (where hand edits are clobbered on the
+next sync).
+
+This extension rewrites only the source/edit button URLs back to the canonical
+source branch named by the ``pygsti_edit_branch`` config value, leaving the
+launch buttons on the build branch. It is a no-op when:
+  * ``pygsti_edit_branch`` is unset, or
+  * the build branch already equals ``pygsti_edit_branch`` (e.g. local builds or
+    a plain ``develop`` build), or
+  * the source/edit buttons are not enabled.
+"""
+
+from pydata_sphinx_theme.utils import get_theme_options_dict
+from sphinx.util import logging
+
+LOGGER = logging.getLogger(__name__)
+
+#: Labels (set by sphinx_book_theme) of the buttons whose URLs embed the branch.
+_BRANCHED_BUTTON_LABELS = ("source-file-button", "source-edit-button")
+
+
+def _rewrite(buttons, build_branch, edit_branch):
+    """Recursively rewrite branch segments in source/edit button URLs."""
+    for button in buttons:
+        if button.get("type") == "group":
+            _rewrite(button.get("buttons", []), build_branch, edit_branch)
+        elif button.get("label") in _BRANCHED_BUTTON_LABELS:
+            url = button.get("url", "")
+            for segment in ("/edit/", "/blob/"):
+                url = url.replace(
+                    f"{segment}{build_branch}/", f"{segment}{edit_branch}/"
+                )
+            button["url"] = url
+
+
+def _on_html_page_context(app, pagename, templatename, context, doctree):
+    edit_branch = app.config.pygsti_edit_branch
+    if not edit_branch:
+        return
+    build_branch = get_theme_options_dict(app).get("repository_branch")
+    if not build_branch or build_branch == edit_branch:
+        return
+    header_buttons = context.get("header_buttons")
+    if not header_buttons:
+        return
+    _rewrite(header_buttons, build_branch, edit_branch)
+
+
+def setup(app):
+    app.add_config_value("pygsti_edit_branch", None, "html")
+    # priority > 501 so this runs after sphinx_book_theme.add_source_buttons,
+    # which is connected to html-page-context at priority 501.
+    app.connect("html-page-context", _on_html_page_context, priority=900)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/jupytext.toml
+++ b/docs/jupytext.toml
@@ -1,11 +1,19 @@
-# jupytext pairing: every file in markdown/ is paired with one in notebooks/.
+# jupytext pairing: every notebook *.md under markdown/ is paired with an
+# *.ipynb sitting NEXT TO IT in the same directory.
 #
 # CONTRIBUTOR NOTE: The *.md files under markdown/ are the canonical source.
-# The notebooks/ directory is gitignored — it's a build artifact materialized
-# by `jupytext --sync markdown/**/*.md`. Edits made directly to a generated
-# .ipynb will be overwritten on the next sync unless you sync them BACK first:
-#   jupytext --sync notebooks/path/to/foo.ipynb
+# The paired *.ipynb files are gitignored build artifacts (see .gitignore:
+# docs/markdown/**/*.ipynb). Materialize / refresh them locally with:
+#   jupytext --sync markdown/**/*.md
+# (Plain markdown pages without a jupytext header -- e.g. index/landing pages --
+# are skipped automatically.) Edits made directly to a generated .ipynb will be
+# overwritten on the next sync unless you sync them BACK first:
+#   jupytext --sync markdown/path/to/foo.ipynb
 # When in doubt, edit the .md.
-[formats]
-"notebooks/" = "ipynb"
-"markdown/" = "md:myst"
+#
+# Why same-directory pairing matters: sphinx-book-theme only rewrites the
+# Colab/Binder launch link from foo.md to foo.ipynb when an .ipynb of the same
+# basename exists alongside the .md at build time. The hosted docs are built from
+# the auto-generated `develop-with-notebooks` branch, where these .ipynb files are
+# committed by CI (see .github/workflows/develop.yml).
+formats = "ipynb,md:myst"


### PR DESCRIPTION
Clicking **Colab** (or **Binder**) on a hosted tutorial page is broken. For example, as of ~1pm on June 15, the launch link on [Instruments](https://pygsti.readthedocs.io/en/develop/markdown/objects/Instruments.html) fails in Colab with:

```
SyntaxError: No number after minus sign in JSON at position 1 (line 1 column 2)
```

The launch buttons point at the page's MyST Markdown source on GitHub:

```
https://colab.research.google.com/github/sandialabs/pyGSTi/blob/develop/docs/markdown/objects/Instruments.md
```

Colab can only open a Jupyter notebook, which it parses as JSON. It fetches the `.md`, tries `JSON.parse`, and chokes on the leading `---` of the jupytext YAML front matter (`-` at position 0, second `-` at position 1) — hence the error above. The same applies to every notebook page in the docs.

## Why this happens

The docs are a Jupyter Book whose canonical sources are jupytext MyST `.md` files under `docs/markdown/`. `sphinx-book-theme` builds the launch URL as `…/blob/{branch}/{path_to_docs}/{pagename}{extension}` and only rewrites `{extension}` from `.md` to `.ipynb` when an `.ipynb` of the same basename exists **next to the `.md`** at build time. Today the paired notebooks live in a separate, gitignored `docs/notebooks/` tree, so:

1. the build-time rewrite never fires (wrong directory), and
2. even if it did, the notebook isn't on GitHub for Colab to fetch.

Crucially, the launch button reads from **GitHub**, not from ReadTheDocs. So generating notebooks only during the RTD build cannot fix Colab (unlike the HTML, which RTD serves itself). A real `.ipynb` has to exist on a GitHub branch at the path the button references.

## Approach

Keep `.md` as the canonical source on `develop` (clean diffs, no committed build artifacts), and build the hosted docs from an auto-generated `develop-with-notebooks` branch that carries jupytext-built `.ipynb` companions next to each `.md`. On that branch the build-time rewrite fires and Colab/Binder resolve to real notebooks.

A new CI job rebuilds `develop-with-notebooks` after tests pass on `develop`, modeled on the existing post-test `beta` push job (`develop.yml`). It regenerates the branch as a **single atomic, force-pushed commit** (notebooks + a one-line `repository.branch` rewrite) so RTD never triggers on a half-built state.

## Changes

- **`docs/jupytext.toml`** — pair each notebook `.md` with an `.ipynb` in the *same* directory (`formats = "ipynb,md:myst"`). Same-directory pairing is what lets `sphinx-book-theme` rewrite the launch link to `.ipynb`. Plain-markdown index/landing pages (no jupytext header) are skipped automatically by `jupytext --sync`.
- **`.gitignore`** — replace `docs/notebooks/**/*.ipynb` with `docs/markdown/**/*.ipynb` so locally synced notebooks stay out of `develop`.
- **`docs/_config.yml`** — drop the now-unused `notebooks/` exclude (keep `**/*.ipynb`, which prevents Sphinx duplicate-document errors); register the new local extension; add `pygsti_edit_branch: develop`.
- **`docs/_ext/edit_button_branch.py`** — new local Sphinx extension that keeps the "Show source" / "Suggest edit" buttons pointed at `develop` while the launch buttons use the build branch. (No-op today, since those buttons aren't enabled; it's a safety net so the edit links don't drift onto the auto-generated branch if they're turned on later.)
- **`.github/workflows/develop.yml`** — new `docs-notebooks` job (after `build`, on push to `develop`): generate `.ipynb` next to each `.md`, rewrite `repository.branch` in `_config.yml`, then commit and force-push `develop-with-notebooks` in one commit.

## Validation

- Reproduced the exact broken `.md` launch URL with a minimal Jupyter Book build using the same `sphinx-book-theme` 1.2.0 that RTD uses.
- `jupytext --sync` over the real `docs/markdown/` tree: 92 notebooks generated, 9 plain-markdown pages correctly skipped.
- End-to-end build with the real `Instruments.md` + generated `.ipynb`, the build-branch config, and the new extension produced:
  - Colab → `…/blob/develop-with-notebooks/docs/markdown/objects/Instruments.ipynb`
  - Binder → `…/develop-with-notebooks/…/Instruments.ipynb`
  - Edit → `…/edit/develop/docs/markdown/objects/Instruments.md`
- The `_config.yml` branch rewrite is anchored to the `repository.branch` key (preserving its trailing comment), leaves `pygsti_edit_branch: develop` untouched, and is guarded by a `grep` that fails the job loudly if it ever misses.

## Required follow-up on ReadTheDocs (not in this PR)

1. Point the RTD build at the `develop-with-notebooks` branch. This changes the public slug to `pygsti.readthedocs.io/en/develop-with-notebooks/`.
2. Add an RTD redirect `/en/develop/* → /en/develop-with-notebooks/*` to preserve existing links.

`develop-with-notebooks` is created by the new job, so it won't exist until this is merged and the next `develop` build passes (or `develop.yml` is run via `workflow_dispatch`).
