### PR TITLE
Add hypothesis to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ networkx
 stim
 tqdm
 jupytext>=0.16
+hypothesis


### PR DESCRIPTION
The python package hypothesis required python 3.10+ which we now are requiring as well. Thus, we can add it to the requirements.txt file so that the package can be used in one of the test suites. Specifically, it is used in at least `test/unit/circuits/test_circuit_str_roundtrip.py`.