### PR TITLE
Support for numpy 2.5: address deprecation warnings

### DIFF
--- a/pygsti/algorithms/gaugeopt.py
+++ b/pygsti/algorithms/gaugeopt.py
@@ -16,6 +16,7 @@ import warnings as _warnings
 import numpy as _np
 
 from pygsti import baseobjs as _baseobjs
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti import optimize as _opt
 from pygsti import tools as _tools
 from pygsti.tools.optools import relaxed_scalar_tolerance as _relaxed_tol
@@ -851,7 +852,7 @@ def _legacy_create_least_squares_objective(model, target_model,
         #S       = gauge_group_el.transform_matrix
         S_inv = gauge_group_el.transform_matrix_inverse
         dS = gauge_group_el.deriv_wrt_params(wrtIndices)  # shape (d*d),n
-        dS.shape = (d, d, n)  # call it (d1,d2,n)
+        dS = _compat.reshape_no_copy(dS, (d, d, n))  # call it (d1,d2,n)
         dS = _np.rollaxis(dS, 2)  # shape (n, d1, d2)
         assert(dS.shape == (n, d, d))
 
@@ -1028,7 +1029,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl_pre, mdl_post,
     #S       = gauge_group_el.transform_matrix
     S_inv = gauge_group_el.transform_matrix_inverse
     dS = gauge_group_el.deriv_wrt_params(wrt_filter)  # shape (d*d),n
-    dS.shape = (d, d, n)  # call it (d1,d2,n)
+    dS = _compat.reshape_no_copy(dS, (d, d, n))  # call it (d1,d2,n)
     dS = _np.rollaxis(dS, 2)  # shape (n, d1, d2)
 
     for i, (gl, gate) in enumerate(mdl_post.operations.items()):
@@ -1099,7 +1100,7 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl_pre, mdl_post,
     n = N if (wrt_filter is None) else len(wrt_filter)
     S_inv = gauge_group_el.transform_matrix_inverse
     dS = gauge_group_el.deriv_wrt_params(wrt_filter)  # shape (d*d),n
-    dS.shape = (d, d, n)  # call it (d1,d2,n)
+    dS = _compat.reshape_no_copy(dS, (d, d, n))  # call it (d1,d2,n)
     dS = _np.rollaxis(dS, 2)  # shape (n, d1, d2)
 
     # d( sqrt(|denMx|_Tr) ) = (0.5 / sqrt(|denMx|_Tr)) * d( |denMx|_Tr )

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -24,6 +24,7 @@ from pygsti.algorithms import grasp as _grasp
 from pygsti.algorithms import scoring as _scoring
 from pygsti import circuits as _circuits
 from pygsti import baseobjs as _baseobjs
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import mpitools as _mpit
 from pygsti.models import ExplicitOpModel as _ExplicitOpModel
 from pygsti.models import ImplicitOpModel as _ImplicitOpModel
@@ -1449,7 +1450,7 @@ def test_germ_set_finitel(model, germs_to_test, length, weights=None,
 
     op_dim = model.dim
     dprods = model.sim.bulk_dproduct(germToPowL, flat=True)  # shape (nGerms*flattened_op_dim, vec_model_dim)
-    dprods.shape = (nGerms, op_dim**2, dprods.shape[1])
+    dprods = _compat.reshape_no_copy(dprods, (nGerms, op_dim**2, dprods.shape[1]))
 
     germLengths = _np.array([len(germ) for germ in germs_to_test], 'd')
 

--- a/pygsti/baseobjs/_compatibility.py
+++ b/pygsti/baseobjs/_compatibility.py
@@ -12,6 +12,43 @@ Tools for general compatibility.
 
 import numbers as _numbers
 
+import numpy as _np
+from numpy.lib import NumpyVersion as _NumpyVersion
+
+# The ``copy`` keyword of ``numpy.reshape`` was added in NumPy 2.1; direct
+# assignment to ``ndarray.shape`` was deprecated in NumPy 2.5.
+_NUMPY_HAS_RESHAPE_COPY = _NumpyVersion(_np.__version__) >= '2.1.0'
+
+
+def reshape_no_copy(a, shape):
+    """
+    Return a view of `a` with the given `shape` without copying its data.
+
+    Forward-compatible replacement for the idiom ``a.shape = shape``, which was
+    deprecated in NumPy 2.5. Like that idiom, this raises (rather than copying)
+    if the requested shape is incompatible with `a`'s memory layout, preserving
+    the no-copy guarantee that callers rely on.
+
+    Parameters
+    ----------
+    a : numpy.ndarray
+        Array to reshape.
+
+    shape : int or tuple or list of int
+        The new shape. May be a single int, or a tuple/list of ints that may
+        contain a single ``-1`` to infer one dimension.
+
+    Returns
+    -------
+    numpy.ndarray
+        A view of `a` (sharing its memory) with the requested shape.
+    """
+    if _NUMPY_HAS_RESHAPE_COPY:            # numpy >= 2.1
+        return _np.reshape(a, shape, copy=False)
+    view = a.view()                        # numpy < 2.1: copy= kwarg unavailable
+    view.shape = shape                     # in-place; raises if a copy is needed; not deprecated < 2.5
+    return view
+
 
 def isint(x):
     """

--- a/pygsti/baseobjs/resourceallocation.py
+++ b/pygsti/baseobjs/resourceallocation.py
@@ -18,6 +18,7 @@ from hashlib import blake2b as _blake2b
 
 import numpy as _np
 
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.profiler import DummyProfiler as _DummyProfiler
 
 _dummy_profiler = _DummyProfiler()
@@ -343,7 +344,7 @@ class ResourceAllocation(object):
                 offset = 0
                 for slc_or_indx_array, shape, size in zip(slices, shapes, sizes):
                     if slc_or_indx_array is None: continue  # signals a non-unit-leader proc that shouldn't do anything
-                    data = gathered_data[offset:offset + size]; offset += size; data.shape = shape
+                    data = gathered_data[offset:offset + size]; offset += size; data = _compat.reshape_no_copy(data, shape)
                     result[slc_or_indx_array] = data
 
         self.comm.barrier()  # make sure result is completely filled before returniing

--- a/pygsti/extras/interpygate/core.py
+++ b/pygsti/extras/interpygate/core.py
@@ -19,6 +19,7 @@ from scipy.interpolate import LinearNDInterpolator as _linND
 from ...modelmembers.operations import DenseOperator as _DenseOperator
 from ...modelmembers.operations.opfactory import OpFactory as _OpFactory
 from ...baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
+from pygsti.baseobjs import _compatibility as _compat
 from ...tools import optools as _ot
 
 try:
@@ -532,7 +533,7 @@ class InterpolatedQuantityFactory(object):
         if rank in root_ranks:
             #Only root ranks store data (fn_to_interpolate only needs to return results on root proc)
             flat_data = _np.empty(len(my_points) * int(_np.prod(expected_fn_output_shape)), dtype='d')
-            data = flat_data.view(); data.shape = (len(my_points),) + expected_fn_output_shape
+            data = flat_data.view(); data = _compat.reshape_no_copy(data, (len(my_points),) + expected_fn_output_shape)
             if (comm is not None):
                 printer.log("Group %d processing %d points on %d processors." % (color, len(my_points),
                                                                                  mpi_workers_per_process))
@@ -566,7 +567,7 @@ class InterpolatedQuantityFactory(object):
 
         self.points = all_points
         self.data = flat_data.view()
-        self.data.shape = (len(all_points),) + self.qty_shape  # indices are (iPoint, <data_indices>)
+        self.data = _compat.reshape_no_copy(self.data, (len(all_points),) + self.qty_shape)  # indices are (iPoint, <data_indices>)
 
     def build(self, comm=None, mpi_workers_per_process=1, verbosity=0):
 

--- a/pygsti/forwardsims/matrixforwardsim.py
+++ b/pygsti/forwardsims/matrixforwardsim.py
@@ -25,6 +25,7 @@ from pygsti.layouts.matrixlayout import MatrixCOPALayout as _MatrixCOPALayout
 from pygsti.baseobjs.profiler import DummyProfiler as _DummyProfiler
 from pygsti.baseobjs.resourceallocation import ResourceAllocation as _ResourceAllocation
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import mpitools as _mpit
 from pygsti.tools import sharedmemtools as _smt
 from pygsti.tools import slicetools as _slct
@@ -471,7 +472,7 @@ class SimpleMatrixForwardSimulator(_ForwardSimulator):
                 if m < l:
                     x0 = _np.kron(_np.transpose(prods[(0, m - 1)]), prods[(m + 1, l - 1)])  # (dim**2, dim**2)
                     x = _np.dot(_np.transpose(dop_dopLabel1[opLabel1]), x0); xv = x.view()  # (nDerivCols1,dim**2)
-                    xv.shape = (nDerivCols1, dim, dim)  # (reshape without copying - throws error if copy is needed)
+                    xv = _compat.reshape_no_copy(xv, (nDerivCols1, dim, dim))  # (reshape without copying - throws error if copy is needed)
                     y = _np.dot(_np.kron(xv, _np.transpose(prods[(l + 1, N - 1)])), dop_dopLabel2[opLabel2])
                     # above: (nDerivCols1,dim**2,dim**2) * (dim**2,nDerivCols2) = (nDerivCols1,dim**2,nDerivCols2)
                     flattened_d2prod[:, inds1, inds2] += _np.swapaxes(y, 0, 1)
@@ -480,7 +481,7 @@ class SimpleMatrixForwardSimulator(_ForwardSimulator):
                 elif l < m:
                     x0 = _np.kron(_np.transpose(prods[(l + 1, m - 1)]), prods[(m + 1, N - 1)])  # (dim**2, dim**2)
                     x = _np.dot(_np.transpose(dop_dopLabel1[opLabel1]), x0); xv = x.view()  # (nDerivCols1,dim**2)
-                    xv.shape = (nDerivCols1, dim, dim)  # (reshape without copying - throws error if copy is needed)
+                    xv = _compat.reshape_no_copy(xv, (nDerivCols1, dim, dim))  # (reshape without copying - throws error if copy is needed)
                     # transposes each of the now un-vectorized dim x dim mxs corresponding to a single kl
                     xv = _np.swapaxes(xv, 1, 2)
                     y = _np.dot(_np.kron(prods[(0, l - 1)], xv), dop_dopLabel2[opLabel2])

--- a/pygsti/modelmembers/operations/composedop.py
+++ b/pygsti/modelmembers/operations/composedop.py
@@ -21,6 +21,7 @@ from pygsti.modelmembers.operations.experrorgenop import ExpErrorgenOp as _ExpEr
 from pygsti.modelmembers import modelmember as _modelmember, term as _term
 from pygsti.evotypes import Evotype as _Evotype
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.basis import ExplicitBasis as _ExplicitBasis
 from pygsti.baseobjs.errorgenlabel import GlobalElementaryErrorgenLabel as _GlobalElementaryErrorgenLabel
 from pygsti.baseobjs.polynomial import Polynomial as _Polynomial
@@ -405,7 +406,7 @@ class ComposedOp(_LinearOperator):
         for i, (op, factorgate_local_inds) in enumerate(zip(self.factorops, self._submember_rpindices)):
             if op.num_params == 0: continue  # no contribution
             deriv = op.deriv_wrt_params(None)  # TODO: use filter?? / make relative to this operation...
-            deriv.shape = (self.dim, self.dim, op.num_params)
+            deriv = _compat.reshape_no_copy(deriv, (self.dim, self.dim, op.num_params))
 
             if i > 0:  # factors before ith
                 pre = self.factorops[0].to_dense("minimal")
@@ -425,7 +426,7 @@ class ComposedOp(_LinearOperator):
             #    self.gpindices, op.gpindices)
             derivMx[:, :, factorgate_local_inds] += deriv
 
-        derivMx.shape = (self.dim**2, self.num_params)
+        derivMx = _compat.reshape_no_copy(derivMx, (self.dim**2, self.num_params))
         if wrt_filter is None:
             return derivMx
         else:

--- a/pygsti/modelmembers/operations/denseop.py
+++ b/pygsti/modelmembers/operations/denseop.py
@@ -20,6 +20,7 @@ from pygsti.modelmembers.operations.linearop import LinearOperator as _LinearOpe
 from pygsti.modelmembers.operations.krausop import KrausOperatorInterface as _KrausOperatorInterface
 from pygsti.evotypes import Evotype as _Evotype
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.basis import Basis as _Basis
 from pygsti.tools import basistools as _bt
 from pygsti.tools import matrixtools as _mt
@@ -66,7 +67,7 @@ def finite_difference_deriv_wrt_params(operation, wrt_filter, eps=1e-7):
         op2.from_vector(p_plus_dp)
         fd_deriv[:, :, i] = (op2 - operation) / eps
 
-    fd_deriv.shape = [dim**2, operation.num_params]
+    fd_deriv = _compat.reshape_no_copy(fd_deriv, [dim**2, operation.num_params])
     if wrt_filter is None:
         return fd_deriv
     else:

--- a/pygsti/modelmembers/operations/experrorgenop.py
+++ b/pygsti/modelmembers/operations/experrorgenop.py
@@ -24,6 +24,7 @@ from pygsti.modelmembers.operations.embeddederrorgen import EmbeddedErrorgen as 
 from pygsti.modelmembers import modelmember as _modelmember, term as _term
 from pygsti.modelmembers.errorgencontainer import ErrorGeneratorContainer as _ErrorGeneratorContainer
 from pygsti.baseobjs.polynomial import Polynomial as _Polynomial
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti import SpaceT
 
 IMAG_TOL = 1e-7  # tolerance for imaginary part being considered zero
@@ -239,7 +240,7 @@ class ExpErrorgenOp(_LinearOperator, _ErrorGeneratorContainer):
 
             #Deriv wrt hamiltonian params
             derrgen = self.errorgen.deriv_wrt_params(None)  # apply filter below; cache *full* deriv
-            derrgen.shape = (d2, d2, -1)  # separate 1st d2**2 dim to (d2,d2)
+            derrgen = _compat.reshape_no_copy(derrgen, (d2, d2, -1))  # separate 1st d2**2 dim to (d2,d2)
             dexpL = _d_exp_x(self.errorgen.to_dense("minimal"), derrgen, self.exp_err_gen)
             derivMx = dexpL.reshape(d2**2, self.num_params)  # [iFlattenedOp,iParam]
 
@@ -312,8 +313,8 @@ class ExpErrorgenOp(_LinearOperator, _ErrorGeneratorContainer):
             #Deriv wrt other params
             dEdp = self.errorgen.deriv_wrt_params(None)  # filter later, cache *full*
             d2Edp2 = self.errorgen.hessian_wrt_params(None, None)  # hessian
-            dEdp.shape = (d2, d2, nP)  # separate 1st d2**2 dim to (d2,d2)
-            d2Edp2.shape = (d2, d2, nP, nP)  # ditto
+            dEdp = _compat.reshape_no_copy(dEdp, (d2, d2, nP))  # separate 1st d2**2 dim to (d2,d2)
+            d2Edp2 = _compat.reshape_no_copy(d2Edp2, (d2, d2, nP, nP))  # ditto
 
             series, series2 = _d2_exp_series(self.errorgen.to_dense("minimal"), dEdp, d2Edp2)
             term1 = series2

--- a/pygsti/modelmembers/operations/fullcptpop.py
+++ b/pygsti/modelmembers/operations/fullcptpop.py
@@ -17,6 +17,7 @@ from pygsti.modelmembers.operations.krausop import KrausOperatorInterface as _Kr
 
 from pygsti.evotypes import Evotype as _Evotype
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.basis import Basis as _Basis
 from pygsti.tools import jamiolkowski as _jt
 from pygsti.tools import basistools as _bt
@@ -264,7 +265,7 @@ class FullCPTPOp(_KrausOperatorInterface, _LinearOperator):
         dVdp += _np.einsum('bml,ma,ab->lab', conj_basis_mxs, Lbar, F2)  # only b > a nonzero (F2)
         dVdp += _np.einsum('mbl,ma,ab->lab', conj_basis_mxs, L, F2.conjugate())  # ditto
 
-        dVdp.shape = [dVdp.shape[0], nP]  # jacobian with respect to "p" params,
+        dVdp = _compat.reshape_no_copy(dVdp, [dVdp.shape[0], nP])  # jacobian with respect to "p" params,
         # which don't include normalization for TP-constraint
 
         #Now get jacobian of actual params wrt the params used above. Denote the actual

--- a/pygsti/modelmembers/operations/linearop.py
+++ b/pygsti/modelmembers/operations/linearop.py
@@ -16,6 +16,7 @@ import numpy as _np
 
 from pygsti.baseobjs.basis import Basis as _Basis
 from pygsti.baseobjs.opcalc import bulk_eval_compact_polynomials_complex as _bulk_eval_compact_polynomials_complex
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.modelmembers import modelmember as _modelmember
 from pygsti.tools import optools as _ot
 from pygsti.tools import matrixtools as _mt
@@ -767,7 +768,7 @@ def finite_difference_deriv_wrt_params(operation, wrt_filter, eps=1e-7):
         op2.from_vector(p_plus_dp)
         fd_deriv[:, :, ii] = (op2.to_dense("minimal") - dense_operation) / eps
 
-    fd_deriv.shape = [dim**2, len(wrt_filter)]
+    fd_deriv = _compat.reshape_no_copy(fd_deriv, [dim**2, len(wrt_filter)])
     return fd_deriv
 
 

--- a/pygsti/modelmembers/operations/repeatedop.py
+++ b/pygsti/modelmembers/operations/repeatedop.py
@@ -15,6 +15,7 @@ import scipy.sparse as _sps
 
 from pygsti.modelmembers.operations.linearop import LinearOperator as _LinearOperator
 from pygsti.evotypes import Evotype as _Evotype
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti import SpaceT
 
 
@@ -200,7 +201,7 @@ class RepeatedOp(_LinearOperator):
             mx_powers[i] = _np.dot(mx_powers[i - 1], mx)
 
         dmx = _np.transpose(self.repeated_op.deriv_wrt_params(wrt_filter))  # (num_params, dim^2)
-        dmx.shape = (dmx.shape[0], self.dim, self.dim)  # set shape for multiplication below
+        dmx = _compat.reshape_no_copy(dmx, (dmx.shape[0], self.dim, self.dim))  # set shape for multiplication below
 
         deriv = _np.zeros((self.dim, dmx.shape[0], self.dim), 'd')
         for k in range(1, self.num_repetitions + 1):

--- a/pygsti/modelmembers/povms/composedeffect.py
+++ b/pygsti/modelmembers/povms/composedeffect.py
@@ -16,6 +16,7 @@ import numpy as _np
 from pygsti.modelmembers.povms.effect import POVMEffect as _POVMEffect
 from pygsti.modelmembers import modelmember as _modelmember, term as _term
 from pygsti.modelmembers.states.staticstate import StaticState as _StaticState
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti import SpaceT
 
 class ComposedPOVMEffect(_POVMEffect):  # , _ErrorMapContainer
@@ -302,7 +303,7 @@ class ComposedPOVMEffect(_POVMEffect):  # , _ErrorMapContainer
         dmVec = self.effect_vec.to_dense("minimal")
 
         derrgen = self.error_map.deriv_wrt_params(wrt_filter)  # shape (dim*dim, n_params)
-        derrgen.shape = (self.dim, self.dim, derrgen.shape[1])  # => (dim,dim,n_params)
+        derrgen = _compat.reshape_no_copy(derrgen, (self.dim, self.dim, derrgen.shape[1]))  # => (dim,dim,n_params)
 
         # self.error_map acts on the *state* vector before dmVec acts
         # as an effect:  E.dag -> dot(E.dag,errmap) ==> E -> dot(errmap.dag,E)
@@ -335,7 +336,7 @@ class ComposedPOVMEffect(_POVMEffect):  # , _ErrorMapContainer
         dmVec = self.effect_vec.to_dense("minimal")
 
         herrgen = self.error_map.hessian_wrt_params(wrt_filter1, wrt_filter2)  # shape (dim*dim, nParams1, nParams2)
-        herrgen.shape = (self.dim, self.dim, herrgen.shape[1], herrgen.shape[2])  # => (dim,dim,nParams1, nParams2)
+        herrgen = _compat.reshape_no_copy(herrgen, (self.dim, self.dim, herrgen.shape[1], herrgen.shape[2]))  # => (dim,dim,nParams1, nParams2)
 
         # self.error_map acts on the *state* vector before dmVec acts
         # as an effect:  E.dag -> dot(E.dag,errmap) ==> E -> dot(errmap.dag,E)

--- a/pygsti/modelmembers/povms/conjugatedeffect.py
+++ b/pygsti/modelmembers/povms/conjugatedeffect.py
@@ -16,6 +16,7 @@ import copy as _copy
 from pygsti.modelmembers.povms.effect import POVMEffect as _POVMEffect
 from pygsti.modelmembers import term as _term
 from pygsti.tools import matrixtools as _mt
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti import SpaceT
 
 
@@ -41,7 +42,7 @@ class DenseEffectInterface(object):
         Direct access the the underlying data as column vector, i.e, a (dim,1)-shaped array.
         """
         bv = self._ptr.view()
-        bv.shape = (bv.size, 1)  # 'base' is by convention a (N,1)-shaped array
+        bv = _compat.reshape_no_copy(bv, (bv.size, 1))  # 'base' is by convention a (N,1)-shaped array
         return bv
 
     def __copy__(self):

--- a/pygsti/modelmembers/povms/tensorprodeffect.py
+++ b/pygsti/modelmembers/povms/tensorprodeffect.py
@@ -18,6 +18,7 @@ import numpy as _np
 from pygsti.modelmembers.povms.effect import POVMEffect as _POVMEffect
 from pygsti.modelmembers import modelmember as _modelmember, term as _term
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import listtools as _lt
 from pygsti.tools import matrixtools as _mt
 from pygsti.tools import slicetools as _slct
@@ -349,7 +350,7 @@ class TensorProductPOVMEffect(_POVMEffect):
 
             if vec.num_params == 0: continue  # no contribution
             deriv = vec.deriv_wrt_params(None)  # TODO: use filter?? / make relative to this gate...
-            deriv.shape = (fct_dim, vec.num_params)
+            deriv = _compat.reshape_no_copy(deriv, (fct_dim, vec.num_params))
 
             if i > 0:  # factors before ith
                 pre = self.factors[0][self.effectLbls[0]].to_dense("minimal")
@@ -367,7 +368,7 @@ class TensorProductPOVMEffect(_POVMEffect):
                 "Error: gpindices has not been initialized for factor %d - cannot compute derivative!" % i
             derivMx[:, fct_local_inds] += deriv
 
-        derivMx.shape = (dim, self.num_params)  # necessary?
+        derivMx = _compat.reshape_no_copy(derivMx, (dim, self.num_params))  # necessary?
         if wrt_filter is None:
             return derivMx
         else:

--- a/pygsti/modelmembers/states/__init__.py
+++ b/pygsti/modelmembers/states/__init__.py
@@ -28,6 +28,7 @@ from .staticstate import StaticState
 from .tensorprodstate import TensorProductState
 from .tpstate import TPState
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import basistools as _bt
 from pygsti.baseobjs import Basis
 from pygsti.tools import optools as _ot
@@ -367,7 +368,7 @@ def finite_difference_deriv_wrt_params(state, wrt_filter=None, eps=1e-7):
         state2.from_vector(p_plus_dp, close=True)
         fd_deriv[:, i:i + 1] = (state2 - state) / eps
 
-    fd_deriv.shape = [dim, state.num_params]
+    fd_deriv = _compat.reshape_no_copy(fd_deriv, [dim, state.num_params])
     if wrt_filter is None:
         return fd_deriv
     else:

--- a/pygsti/modelmembers/states/composedstate.py
+++ b/pygsti/modelmembers/states/composedstate.py
@@ -17,6 +17,7 @@ from pygsti.modelmembers.states.state import State as _State
 from pygsti.modelmembers.states.staticstate import StaticState as _StaticState
 from pygsti.modelmembers import modelmember as _modelmember, term as _term
 from pygsti.modelmembers.errorgencontainer import ErrorMapContainer as _ErrorMapContainer
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti import SpaceT
 
 class ComposedState(_State):
@@ -300,7 +301,7 @@ class ComposedState(_State):
         dmVec = self.state_vec.to_dense("minimal")
 
         derrgen = self.error_map.deriv_wrt_params(wrt_filter)  # shape (dim*dim, n_params)
-        derrgen.shape = (self.dim, self.dim, derrgen.shape[1])  # => (dim,dim,n_params)
+        derrgen = _compat.reshape_no_copy(derrgen, (self.dim, self.dim, derrgen.shape[1]))  # => (dim,dim,n_params)
 
         #derror map acts on dmVec
         #return _np.einsum("ijk,j->ik", derrgen, dmVec) # return shape = (dim,n_params)
@@ -332,7 +333,7 @@ class ComposedState(_State):
         dmVec = self.state_vec.to_dense("minimal")
 
         herrgen = self.error_map.hessian_wrt_params(wrt_filter1, wrt_filter2)  # shape (dim*dim, nParams1, nParams2)
-        herrgen.shape = (self.dim, self.dim, herrgen.shape[1], herrgen.shape[2])  # => (dim,dim,nParams1, nParams2)
+        herrgen = _compat.reshape_no_copy(herrgen, (self.dim, self.dim, herrgen.shape[1], herrgen.shape[2]))  # => (dim,dim,nParams1, nParams2)
 
         #derror map acts on dmVec
         #return _np.einsum("ijkl,j->ikl", herrgen, dmVec) # return shape = (dim,n_params)

--- a/pygsti/modelmembers/states/cptpstate.py
+++ b/pygsti/modelmembers/states/cptpstate.py
@@ -16,6 +16,7 @@ from pygsti.modelmembers.states.densestate import DenseState as _DenseState
 from pygsti.modelmembers.states.state import State as _State
 from pygsti.evotypes import Evotype as _Evotype
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.basis import Basis as _Basis
 from pygsti.tools import matrixtools as _mt
 
@@ -320,7 +321,7 @@ class CPTPState(_DenseState):
         dVdp += _np.einsum('bml,ma,ab->lab', conj_basis_mxs, Lbar, F2)         # only b > a nonzero (F2)
         dVdp += _np.einsum('mbl,ma,ab->lab', conj_basis_mxs, L,    F2.conj())  # ditto
 
-        dVdp.shape = [dVdp.shape[0], nP]  # jacobian with respect to "p" params,
+        dVdp = _compat.reshape_no_copy(dVdp, [dVdp.shape[0], nP])  # jacobian with respect to "p" params,
         # which don't include normalization for TP-constraint
 
         #Now get jacobian of actual params wrt the params used above. Denote the actual

--- a/pygsti/modelmembers/states/densestate.py
+++ b/pygsti/modelmembers/states/densestate.py
@@ -17,6 +17,7 @@ import copy as _copy
 from pygsti.modelmembers.states.state import State as _State
 from pygsti.evotypes import Evotype as _Evotype
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.basis import Basis as _Basis
 from pygsti.tools import basistools as _bt
 from pygsti.tools import matrixtools as _mt
@@ -62,7 +63,7 @@ class DenseStateInterface(object):
         Direct access the the underlying data as column vector, i.e, a (dim,1)-shaped array.
         """
         bv = self._ptr.view()
-        bv.shape = (bv.size, 1)  # 'base' is by convention a (N,1)-shaped array
+        bv = _compat.reshape_no_copy(bv, (bv.size, 1))  # 'base' is by convention a (N,1)-shaped array
         return bv
 
     def __copy__(self):

--- a/pygsti/modelmembers/states/state.py
+++ b/pygsti/modelmembers/states/state.py
@@ -500,11 +500,11 @@ class State(_modelmember.ModelMember):
         """
         if isinstance(v, State):
             vector = v.to_dense("minimal").copy()
-            vector.shape = (vector.size, 1)
+            vector = _compat.reshape_no_copy(vector, (vector.size, 1))
         elif isinstance(v, _np.ndarray):
             vector = v.copy()
             if len(vector.shape) == 1:  # convert (N,) shape vecs to (N,1)
-                vector.shape = (vector.size, 1)
+                vector = _compat.reshape_no_copy(vector, (vector.size, 1))
         else:
             try:
                 len(v)

--- a/pygsti/modelmembers/states/tensorprodstate.py
+++ b/pygsti/modelmembers/states/tensorprodstate.py
@@ -19,6 +19,7 @@ import numpy as _np
 from pygsti.modelmembers.states.state import State as _State
 from pygsti.modelmembers import modelmember as _modelmember, term as _term
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import listtools as _lt
 from pygsti.tools import matrixtools as _mt
 from pygsti import SpaceT
@@ -296,7 +297,7 @@ class TensorProductState(_State):
 
             if vec.num_params == 0: continue  # no contribution
             deriv = vec.deriv_wrt_params(None)  # TODO: use filter?? / make relative to this gate...
-            deriv.shape = (fct_dim, vec.num_params)
+            deriv = _compat.reshape_no_copy(deriv, (fct_dim, vec.num_params))
 
             if i > 0:  # factors before ith
                 pre = self.factors[0].to_dense("minimal")
@@ -314,7 +315,7 @@ class TensorProductState(_State):
                 "Error: gpindices has not been initialized for factor %d - cannot compute derivative!" % i
             derivMx[:, fct_local_inds] += deriv
 
-        derivMx.shape = (dim, self.num_params)  # necessary?
+        derivMx = _compat.reshape_no_copy(derivMx, (dim, self.num_params))  # necessary?
         if wrt_filter is None:
             return derivMx
         else:

--- a/pygsti/modelmembers/states/tpstate.py
+++ b/pygsti/modelmembers/states/tpstate.py
@@ -23,6 +23,7 @@ except ImportError:
 import numpy as _np
 from pygsti.baseobjs import Basis as _Basis
 from pygsti.baseobjs import statespace as _statespace
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.modelmembers.torchable import Torchable as _Torchable
 from pygsti.modelmembers.states.densestate import DenseState as _DenseState
 from pygsti.modelmembers.states.state import State as _State
@@ -83,7 +84,7 @@ class TPState(_DenseState, _Torchable):
         Direct access the the underlying data as column vector, i.e, a (dim,1)-shaped array.
         """
         bv = self._ptr.view()
-        bv.shape = (bv.size, 1)
+        bv = _compat.reshape_no_copy(bv, (bv.size, 1))
         return _ProtectedArray(bv, indices_to_protect=(0, 0))
 
     def set_dense(self, vec):

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -25,6 +25,7 @@ from pygsti.baseobjs import (
     statespace as _statespace,
     ExplicitStateSpace as _ExplicitStateSpace
 )
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.modelmembers import operations as _op
 from pygsti.baseobjs.basis import Basis as _Basis, BuiltinBasis as _BuiltinBasis
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
@@ -260,7 +261,7 @@ class InverseGaugeGroupElement(GaugeGroupElement):
         dT = self.inverse_element.deriv_wrt_params(wrt_filter)  # shape (d*d, n)
         d, n = int(round(_np.sqrt(dT.shape[0]))), dT.shape[1]
 
-        dT.shape = (d, d, n)  # call it (d1,d2,n)
+        dT = _compat.reshape_no_copy(dT, (d, d, n))  # call it (d1,d2,n)
         dT = _np.rollaxis(dT, 2)  # shape (n, d1, d2)
         deriv = -_np.dot(Tinv, _np.dot(dT, Tinv))  # d,d * (n,d,d * d,d) => d,d * n,d,d => d,n,d
         return _np.swapaxes(deriv, 1, 2).reshape(d * d, n)  # d,n,d => d,d,n => (d*d, n)

--- a/pygsti/objectivefns/objectivefns.py
+++ b/pygsti/objectivefns/objectivefns.py
@@ -29,6 +29,7 @@ from pygsti.circuits.circuitlist import CircuitList as _CircuitList
 from pygsti.baseobjs.resourceallocation import ResourceAllocation as _ResourceAllocation
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.models.model import OpModel as _OpModel, Model as _Model
 
 
@@ -4602,7 +4603,7 @@ class TimeIndependentMDCObjectiveFunction(MDCObjectiveFunction):
             self.model.from_vector(paramvec)
     
         dprobs = self.jac[0:self.nelements, :]
-        dprobs.shape = (self.nelements, self.nparams)
+        dprobs = _compat.reshape_no_copy(dprobs, (self.nelements, self.nparams))
 
         with self.resource_alloc.temporarily_track_memory(2 * self.nelements):
             self.model.sim.bulk_fill_dprobs(dprobs, self.layout, self.probs)
@@ -5521,7 +5522,7 @@ class TimeDependentChi2Function(TimeDependentMDCObjectiveFunction):
         """
         tm = _time.time()
         dprobs = self.jac.view()  # avoid mem copying: use jac mem for dprobs
-        dprobs.shape = (self.nelements, self.nparams)
+        dprobs = _compat.reshape_no_copy(dprobs, (self.nelements, self.nparams))
         if paramvec is not None: self.model.from_vector(paramvec)
 
         fsim = self.model.sim
@@ -5666,7 +5667,7 @@ class TimeDependentPoissonPicLogLFunction(TimeDependentMDCObjectiveFunction):
                                       self.dataset, self.min_prob_clip, self.radius, self.prob_clip_interval,
                                       self._ds_cache)
         v = _np.sqrt(v)
-        v.shape = [self.nelements]  # reshape ensuring no copy is needed
+        v = _compat.reshape_no_copy(v, [self.nelements])  # reshape ensuring no copy is needed
 
         self.raw_objfn.resource_alloc.profiler.add_time("Time-dep dlogl: OBJECTIVE", tm)
         return v  # Note: no test for whether probs is in [0,1] so no guarantee that
@@ -5700,7 +5701,7 @@ class TimeDependentPoissonPicLogLFunction(TimeDependentMDCObjectiveFunction):
         """
         tm = _time.time()
         dlogl = self.jac[0:self.nelements, :]  # avoid mem copying: use jac mem for dlogl
-        dlogl.shape = (self.nelements, self.nparams)
+        dlogl = _compat.reshape_no_copy(dlogl, (self.nelements, self.nparams))
         if paramvec is not None: self.model.from_vector(paramvec)
         unit_ralloc = self.layout.resource_alloc('param-processing')
         shared_mem_leader = unit_ralloc.is_host_leader
@@ -5838,7 +5839,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
         #OLD: dGdp = mdl.dproduct((gl,)) but wasteful
         dgate_dp = gate.deriv_wrt_params()  # shape (dim**2, nP)
         dgate_dp = _np.swapaxes(dgate_dp, 0, 1)  # shape (nP, dim**2, )
-        dgate_dp.shape = (nparams, mdl.dim, mdl.dim)
+        dgate_dp = _compat.reshape_no_copy(dgate_dp, (nparams, mdl.dim, mdl.dim))
 
         # Let M be the "shuffle" operation performed by fast_jamiolkowski_iso_std
         # which maps a gate onto the choi-jamiolkowsky "basis" (i.e. performs that C-J

--- a/pygsti/optimize/arraysinterface.py
+++ b/pygsti/optimize/arraysinterface.py
@@ -12,6 +12,7 @@ Implements the ArraysInterface object and supporting functionality.
 
 import numpy as _np
 
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import sharedmemtools as _smt
 
 
@@ -1024,7 +1025,7 @@ class DistributedArraysInterface(ArraysInterface):
         """
         # assumes x's are in "fine" mode
         local_dot = _np.array(_np.dot(x1, x2))
-        local_dot.shape = (1,)  # for compatibility with allreduce_sum
+        local_dot = _compat.reshape_no_copy(local_dot, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_sum(result, local_dot,
                                           unit_ralloc=self.layout.resource_alloc('param-fine'))
@@ -1063,7 +1064,7 @@ class DistributedArraysInterface(ArraysInterface):
         """
         # assumes x's are in "fine" mode
         local_infnorm = _np.array(_np.linalg.norm(x, ord=_np.inf))
-        local_infnorm.shape = (1,)  # for compatibility with allreduce_sum
+        local_infnorm = _compat.reshape_no_copy(local_infnorm, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_max(result, local_infnorm,
                                           unit_ralloc=self.layout.resource_alloc('param-fine'))
@@ -1087,7 +1088,7 @@ class DistributedArraysInterface(ArraysInterface):
         """
         # assumes x's are in "fine" mode
         local_min = _np.array(_np.min(x))
-        local_min.shape = (1,)  # for compatibility with allreduce_sum
+        local_min = _compat.reshape_no_copy(local_min, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_min(result, local_min,
                                           unit_ralloc=self.layout.resource_alloc('param-fine'))
@@ -1111,7 +1112,7 @@ class DistributedArraysInterface(ArraysInterface):
         """
         # assumes x's are in "fine" mode
         local_max = _np.array(_np.max(x))
-        local_max.shape = (1,)  # for compatibility with allreduce_sum
+        local_max = _compat.reshape_no_copy(local_max, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_max(result, local_max,
                                           unit_ralloc=self.layout.resource_alloc('param-fine'))
@@ -1134,7 +1135,7 @@ class DistributedArraysInterface(ArraysInterface):
         float
         """
         local_dot = _np.array(_np.dot(f, f))
-        local_dot.shape = (1,)  # for compatibility with allreduce_sum
+        local_dot = _compat.reshape_no_copy(local_dot, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_sum(result, local_dot,
                                           unit_ralloc=self.layout.resource_alloc('atom-processing'))
@@ -1157,7 +1158,7 @@ class DistributedArraysInterface(ArraysInterface):
         float
         """
         local_norm2 = _np.array(_np.linalg.norm(j)**2)
-        local_norm2.shape = (1,)  # for compatibility with allreduce_sum
+        local_norm2 = _compat.reshape_no_copy(local_norm2, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_sum(result, local_norm2,
                                           unit_ralloc=self.layout.resource_alloc('param-processing'))
@@ -1180,7 +1181,7 @@ class DistributedArraysInterface(ArraysInterface):
         float
         """
         local_norm2 = _np.array(_np.linalg.norm(jtj)**2)
-        local_norm2.shape = (1,)  # for compatibility with allreduce_sum
+        local_norm2 = _compat.reshape_no_copy(local_norm2, (1,))  # for compatibility with allreduce_sum
         result, result_shm = _smt.create_shared_ndarray(self.resource_alloc, (1,), 'd')
         self.resource_alloc.allreduce_sum(result, local_norm2,
                                           unit_ralloc=self.layout.resource_alloc('param-fine'))

--- a/pygsti/optimize/customsolve.py
+++ b/pygsti/optimize/customsolve.py
@@ -14,6 +14,7 @@ import numpy as _np
 import scipy as _scipy
 
 from pygsti.optimize.arraysinterface import DistributedArraysInterface as _DistributedArraysInterface
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.tools import sharedmemtools as _smt
 from pygsti.tools import slicetools as _slct
 
@@ -485,7 +486,7 @@ def _tallskinny_custom_solve(a, b, resource_alloc):
         displacements = _np.concatenate(([0], _np.cumsum(sizes)))
         Rprime = _np.empty(displacements[-1], 'd')
         comm.Gatherv(Ri, [Rprime, sizes, displacements[0:-1], MPI.DOUBLE], root=0)
-        Rprime.shape = (displacements[-1] // nColsPerProc, nColsPerProc)
+        Rprime = _compat.reshape_no_copy(Rprime, (displacements[-1] // nColsPerProc, nColsPerProc))
         Q2, R = _scipy.linalg.qr(Rprime, mode='economic', check_finite=True)
         Q2 = _np.ascontiguousarray(Q2)
         Q2_sizes = _np.array([(s // nColsPerProc) * Q2.shape[1] for s in sizes], 'd')

--- a/pygsti/protocols/confidenceregionfactory.py
+++ b/pygsti/protocols/confidenceregionfactory.py
@@ -22,6 +22,7 @@ import scipy.stats as _stats
 from pygsti import optimize as _opt
 from pygsti import tools as _tools
 from pygsti.models.explicitcalc import P_RANK_TOL
+from pygsti.baseobjs import _compatibility as _compat
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
 from pygsti.circuits.circuitlist import CircuitList as _CircuitList
@@ -1151,10 +1152,10 @@ class ConfidenceRegionFactoryView(object):
         # to that expected by _do_mlgst_base, which is
         # (flat_f0_size, num_params)
         if len(grad_f.shape) == 1:
-            grad_f.shape = (1, grad_f.shape[0])
+            grad_f = _compat.reshape_no_copy(grad_f, (1, grad_f.shape[0]))
         else:
             flatDim = _np.prod(f0.shape)
-            grad_f.shape = (grad_f.shape[0], flatDim)
+            grad_f = _compat.reshape_no_copy(grad_f, (grad_f.shape[0], flatDim))
             grad_f = _np.transpose(grad_f)  # now shape == (flatDim, num_params)
         assert(len(grad_f.shape) == 2)
 
@@ -1175,7 +1176,7 @@ class ConfidenceRegionFactoryView(object):
         delta = _np.sqrt(delta2)  # error^2 -> error
 
         if hasattr(f0, 'shape'):
-            delta.shape = f0.shape  # reshape to un-flattened
+            delta = _compat.reshape_no_copy(delta, f0.shape)  # reshape to un-flattened
         else:
             assert(isinstance(f0, float))
             delta = delta.item()

--- a/pygsti/tools/basistools.py
+++ b/pygsti/tools/basistools.py
@@ -16,6 +16,7 @@ import numpy as _np
 
 from pygsti.baseobjs.basisconstructors import _basis_constructor_dict
 from pygsti.baseobjs import basis as _basis
+from pygsti.baseobjs import _compatibility as _compat
 
 
 @lru_cache(maxsize=1)
@@ -429,7 +430,7 @@ def state_to_stdmx(state_vec):
         A density matrix of shape (d,d), corresponding to the pure state
         given by the length-`d` array, `state_vec`.
     """
-    st_vec = state_vec.view(); st_vec.shape = (len(st_vec), 1)  # column vector
+    st_vec = state_vec.view(); st_vec = _compat.reshape_no_copy(st_vec, (len(st_vec), 1))  # column vector
     dm_mx = _np.kron(_np.conjugate(_np.transpose(st_vec)), st_vec)
     return dm_mx  # density matrix in standard (sigma-z) basis
 

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -23,6 +23,7 @@ import scipy.sparse as _sps
 import scipy.sparse.linalg as _spsl
 
 from pygsti.tools.basistools import change_basis
+from pygsti.baseobjs import _compatibility as _compat
 
 try:
     from . import fastcalc as _fastcalc
@@ -1465,7 +1466,7 @@ def _findx(a, inds, always_copy=False):
         if len(indx_tups) > 0:  # b/c a[()] just returns the entire array!
             inds = tuple(zip(*indx_tups))  # un-zips to one list per dim
             a_inds = a[inds].copy()  # a 1D array of flattened "fancy" a[inds]
-            a_inds.shape = a_inds_shape  # reshape
+            a_inds = _compat.reshape_no_copy(a_inds, a_inds_shape)  # reshape
         else:
             a_inds = _np.zeros(a_inds_shape, a.dtype)  # has zero elements
             assert(a_inds.size == 0)

--- a/pygsti/tools/mpitools.py
+++ b/pygsti/tools/mpitools.py
@@ -913,7 +913,7 @@ def mpidot(a, b, loc_row_slice, loc_col_slice, slice_tuples_by_rank, comm,
 
     rshape = (_slct.length(loc_row_slice), _slct.length(loc_col_slice))
     loc_result_flat = _np.empty(rshape[0] * rshape[1], a.dtype)
-    loc_result = loc_result_flat.view(); loc_result.shape = rshape
+    loc_result = loc_result_flat.view(); loc_result = _compat.reshape_no_copy(loc_result, rshape)
     loc_result[:, :] = _np.dot(a[loc_row_slice, :], b[:, loc_col_slice])
 
     # broadcast_com defines the group of processors this processor communicates with.
@@ -930,7 +930,7 @@ def mpidot(a, b, loc_row_slice, loc_col_slice, slice_tuples_by_rank, comm,
         cur_shape = (_slct.length(cur_row_slice), _slct.length(cur_col_slice))
         buf = loc_result_flat if (broadcast_comm.rank == r) else _np.empty(cur_shape[0] * cur_shape[1], a.dtype)
         broadcast_comm.Bcast(buf, root=r)
-        if broadcast_comm.rank != r: buf.shape = cur_shape
+        if broadcast_comm.rank != r: buf = _compat.reshape_no_copy(buf, cur_shape)
         else: buf = loc_result  # already of correct shape
         result[cur_row_slice, cur_col_slice] = buf
     comm.barrier()  # wait for all ranks to finish writing to result


### PR DESCRIPTION
Our CI builds are setup to error if we have an un-suppressed deprecation warnings. Numpy 2.5 deprecated manually setting the `shape` field of an array (a-la `x.shape = newshape`). We've used this pattern in many places within pyGSTi, and so CI builds started to fail after the numpy 2.5 release.

This PR replaces the explicit shape-assignment with the pattern `x = reshape_no_copy(x, newshape)`, where `reshape_no_copy` is a helper function that accounts for our support of numpy 1.x in earlier versions of Python.

The location of the helper function is in `baseobjs/_compatibility.py`. This is a pre-existing file. I'd have put it elsewhere if this file didn't already exist.
