### PR TITLE
Fix EmbeddedOp inheriting wrong dense-rep preference from embedded op

### DIFF
--- a/pygsti/modelmembers/operations/embeddedop.py
+++ b/pygsti/modelmembers/operations/embeddedop.py
@@ -19,6 +19,7 @@ from pygsti.modelmembers.operations.linearop import LinearOperator as _LinearOpe
 from pygsti.modelmembers import modelmember as _modelmember
 from pygsti.baseobjs.statespace import StateSpace as _StateSpace
 from pygsti.baseobjs.errorgenlabel import GlobalElementaryErrorgenLabel as _GlobalElementaryErrorgenLabel, LocalElementaryErrorgenLabel as _LocalElementaryErrorgenLabel
+from pygsti.evotypes.evotype import Evotype as _Evotype
 from pygsti import SpaceT
 
 
@@ -56,7 +57,11 @@ class EmbeddedOp(_LinearOperator):
         assert(len(self.embedded_op.state_space.sole_tensor_product_block_labels) == len(target_labels)), \
             "Embedded operation's state space has a different number of components than the number of target labels!"
 
-        evotype = operation_to_embed._evotype
+        # Re-derive prefer_dense_reps for our own (parent) state_space instead of
+        # inheriting operation_to_embed's, which can be wrong/huge. See issue #543.
+        evotype = _Evotype.cast(
+            operation_to_embed._evotype.name, state_space=_StateSpace.cast(state_space)
+        )
         rep = self._create_rep_object(evotype, state_space)
 
         self._cached_embedded_errorgen_labels_global = None


### PR DESCRIPTION
# Fix `EmbeddedOp` inheriting an inappropriate dense-representation preference from its embedded operator

This PR fixes a memory-blowup bug in `EmbeddedOp` (`pygsti/modelmembers/operations/embeddedop.py`) where embedding a small operator (e.g. a single-qubit custom/time-dependent gate) into a much larger multi-qubit model can cause pyGSTi to eagerly allocate a dense representation sized to the *entire* parent state space, rather than a small representation local to the embedded operator. For a model with more than a handful of qubits, this can mean allocating many GB of memory for what should be a trivial single-qubit operator.

This resolves [#543](#543).

## Root Cause

`EmbeddedOp.__init__` decides how to represent itself (`'dense'` vs `'embedded'`) by reusing the *embedded* operator's own `Evotype` object:

```python
evotype = operation_to_embed._evotype
rep = self._create_rep_object(evotype, state_space)
```

`_create_rep_object` then picks a representation-type order based on `evotype.prefer_dense_reps`:

```python
rep_type_order = ('dense', 'embedded') if evotype.prefer_dense_reps else ('embedded', 'dense')
```

The problem is that `operation_to_embed._evotype.prefer_dense_reps` was decided when the *embedded* operator itself was constructed, based on the embedded operator's own (typically small, local) state space -- via the heuristic introduced in 5c5b06a6d ("First pass at updating default evotype behavior"):

```python
default_prefer_dense_reps = False if state_space.dim > 64 else True  # HARDCODED
```

So a small operator (e.g. a 1-qubit gate, `state_space.dim == 4`) will have `prefer_dense_reps=True` by design, since a dense $4 \times 4$ matrix is cheap. But `EmbeddedOp` then reuses that same `True` value to decide its *own* representation, even though `EmbeddedOp.state_space` is the much larger *parent* state space (e.g. a 7-qubit model, `state_space.dim == 16384`). This causes `_create_rep_object` to construct a dense $16384 \times 16384$ matrix (`create_dense_superop_rep`) -- about 2.1 GB -- instead of the intended lightweight `'embedded'` representation (`create_embedded_rep`), which only needs memory proportional to the embedded operator's own small subspace.

This most commonly bites custom (often time-dependent) operators, which are typically built by subclassing `DenseOperator`/`LinearOperator` and passing `evotype` as a bare string (e.g. `"densitymx"`) with no explicit `state_space` (so pyGSTi infers a small state space directly from the operator's own matrix), and are then wrapped in an `EmbeddedOp` targeting a larger multi-qubit model -- exactly the pattern shown in pyGSTi's own tutorials/docs for defining custom time-dependent operators. Built-in model-construction helpers like `create_crosstalk_free_model` are unaffected, since they build their operators/evotypes differently.

Bisection shows this was introduced by 5c5b06a6d ("First pass at updating default evotype behavior", 2024-10-21) and is still present on `develop` as of this writing (80e1b1dcd).

## Minimal Working Example

No forward simulation or `set_time()` calls are needed to trigger this -- just constructing a single `EmbeddedOp`:

```python
"""Minimal reproduction of a pyGSTi memory-blowup bug in EmbeddedOp.

Constructing an `EmbeddedOp` that embeds a small (e.g. 1-qubit) custom
operator into a larger (e.g. 7-qubit) model can allocate a dense matrix sized
to the *entire* parent state space, instead of a small representation local
to the embedded operator -- because `EmbeddedOp` inherits the embedded
operator's own `Evotype` (including its dense-representation preference,
which was decided based on the *embedded* operator's own small state space)
rather than re-deciding based on its own (much larger) parent state space.

No forward simulation, `set_time()`, or LoQS is involved -- just constructing
a single `EmbeddedOp`.
"""
import numpy as np
import pygsti
from pygsti.modelmembers.operations import DenseOperator, EmbeddedOp
from pygsti.baseobjs.statespace import QubitSpace

print("pygsti version:", pygsti.__version__)

N_QUBITS = 7
full_space = QubitSpace(N_QUBITS)


class DummyIdle(DenseOperator):
    """A trivial custom 1-qubit operator, built the way pyGSTi/LoQS tutorials
    show: `evotype` passed as a bare string, no explicit `state_space` (so
    it's inferred from `mx`, i.e. just the local 1-qubit space)."""

    def __init__(self):
        super().__init__(np.identity(4, "d"), pygsti.BuiltinBasis("pp", 4), "densitymx")


child = DummyIdle()
print("child's own state_space.dim:", child.state_space.dim)  # 4 (1 qubit)
print("child's own evotype.prefer_dense_reps:", child._evotype.prefer_dense_reps)  # True (dim <= 64)

embedded = EmbeddedOp(full_space, [full_space.sole_tensor_product_block_labels[0]], child)
print("EmbeddedOp.state_space.dim:", embedded.state_space.dim)  # 16384 (7 qubits)
print("EmbeddedOp._rep_type:", embedded._rep_type)  # 'dense' -- should be 'embedded'!
print(
    "EmbeddedOp dense rep size: "
    f"{embedded._rep.base.nbytes / 1e9:.3f} GB "
    f"({embedded._rep.base.shape[0]} x {embedded._rep.base.shape[1]} float64 matrix)"
)
```

Output on current `develop` (80e1b1dcd), before this fix:

```
pygsti version: 0.10.1.post1.dev8+g80e1b1dcd.HEAD.CLEAN
child's own state_space.dim: 4
child's own evotype.prefer_dense_reps: True
EmbeddedOp.state_space.dim: 16384
EmbeddedOp._rep_type: dense
EmbeddedOp dense rep size: 2.147 GB (16384 x 16384 float64 matrix)
```

Output with this fix applied:

```
pygsti version: 0.10.1.post1.dev8+g80e1b1dcd.HEAD.CLEAN
child's own state_space.dim: 4
child's own evotype.prefer_dense_reps: True
EmbeddedOp.state_space.dim: 16384
EmbeddedOp._rep_type: embedded
```

(The last `print` is omitted from the fixed output since `embedded._rep.base` no longer exists for the `'embedded'` rep type -- there is no more multi-GB dense matrix to report the size of.)

Bisection confirms the same script allocates essentially no extra memory (delta of ~0.07 MB for the `EmbeddedOp` construction) at commit f93fd3cd7 (immediately prior to 5c5b06a6d), and the same ~2.1 GB blowup at both the `v0.9.13` release tag and current `develop`.

## Testing

- Added/ran the minimal working example above at `f93fd3cd7`, `v0.9.13`, and current `develop` (`80e1b1dcd`) to confirm the regression window and that the fix (applied on top of `80e1b1dcd`) restores `f93fd3cd7`-level memory behavior (~0.07 MB delta vs. ~2.1 GB).
- Confirmed the fix does not change behavior for:
  - Small embeddings (parent `state_space.dim <= 64`), which still correctly use a dense representation.
  - `create_crosstalk_free_model`-style built-in model construction (7-qubit `LocalNoiseModel`), which was already using the compact `'embedded'` representation before and after this change (~1.2 MB total for all gates, unchanged).
- Ran the existing unit test suite with the fix applied: `test/unit/modelmembers/` and `test/unit/objects/` (1800 passed, 18 skipped, 0 failed), including `test/unit/modelmembers/test_operation.py` and `test/unit/objects/test_localnoisemodel.py` specifically, which exercise `EmbeddedOp`.