### PR TITLE
Fix bugs in processor spec serialization: handling non-standard instrument labels

### DIFF
--- a/pygsti/processors/processorspec.py
+++ b/pygsti/processors/processorspec.py
@@ -29,6 +29,12 @@ from pygsti.modelmembers.operations import LinearOperator as _LinearOp
 from pygsti.modelmembers.operations import FullArbitraryOp as _FullOp
 
 
+def _tuplize(x):
+    if isinstance(x, (list, tuple)):
+        return tuple((_tuplize(el) for el in x))
+    return x
+
+
 class ProcessorSpec(_NicelySerializable):
     """
     The API presented by a quantum processor, and possible classical control processors.
@@ -331,7 +337,12 @@ class QuditProcessorSpec(ProcessorSpec):
 
         nonstd_preps = {k: _serialize_state(obj) for k, obj in self.nonstd_preps.items()}
         nonstd_povms = {k: _serialize_povm(obj) for k, obj in self.nonstd_povms.items()}
-        nonstd_instruments = {':'.join(map(str, k)): _serialize_instrument(obj) for k, obj in self.nonstd_instruments.items()}
+        # Serialize as a list of [name, spec] pairs so that compound (Label/tuple) names keep
+        # their structure and sslbl types.  The old format was a dict whose keys were flattened
+        # with ':'.join(map(str, k)) -- a lossy transform that exploded plain-string names
+        # character-by-character and coerced integer sslbls to strings.
+        nonstd_instruments = [[k if isinstance(k, str) else list(k), _serialize_instrument(obj)]
+                              for k, obj in self.nonstd_instruments.items()]
 
         state.update({'qudit_labels': list(self.qudit_labels),
                       'qudit_udims': list(self.qudit_udims),
@@ -407,17 +418,31 @@ class QuditProcessorSpec(ProcessorSpec):
 
         nonstd_preps = {k: _unserialize_state(obj) for k, obj in state.get('nonstd_preps', {}).items()}
         nonstd_povms = {k: _unserialize_povm(obj) for k, obj in state.get('nonstd_povms', {}).items()}
-        nonstd_instruments = {tuple(k.split(':')): _unserialize_instrument(obj) for k, obj in state.get('nonstd_instruments', {}).items()}
+
+        # Note: compound (sslbls-qualified) instrument names are reconstructed as plain tuples,
+        # both here and for `instrument_names` in the _from_nice_serialization methods.  This
+        # differs from the symplectic_reps handling in QubitProcessorSpec._from_nice_serialization
+        # and from ModelMemberGraph.load_modelmembers_from_serialization_dict, both of which
+        # rebuild Label objects.
+        serial_instruments = state.get('nonstd_instruments', [])
+        if isinstance(serial_instruments, dict):
+            # Legacy format: keys were flattened to strings with ':'.join(map(str, key)), which
+            # exploded plain-string names character-by-character (e.g. 'Iparity' -> 'I:p:a:r:i:t:y')
+            # and coerced integer sslbls to strings (e.g. ('Iz', 0) -> 'Iz:0').  Repair each key by
+            # finding the instrument name whose flattening reproduces it -- `instrument_names`
+            # round-trips faithfully, so it serves as ground truth.  Unmatched keys fall back to
+            # the old split-on-colon reconstruction.
+            instrument_names = [_tuplize(iname) for iname in state.get('instrument_names', [])]
+            flattened_names = {':'.join(map(str, iname)): iname for iname in instrument_names}
+            nonstd_instruments = {flattened_names.get(k, tuple(k.split(':'))): _unserialize_instrument(obj)
+                                  for k, obj in serial_instruments.items()}
+        else:
+            nonstd_instruments = {_tuplize(k): _unserialize_instrument(obj) for k, obj in serial_instruments}
 
         return nonstd_gate_unitaries, nonstd_preps, nonstd_povms, nonstd_instruments
 
     @classmethod
     def _from_nice_serialization(cls, state):
-        def _tuplize(x):
-            if isinstance(x, (list, tuple)):
-                return tuple((_tuplize(el) for el in x))
-            return x
-
         nonstd_gate_unitaries, nonstd_preps, nonstd_povms, nonstd_instruments = \
             cls._nonstd_elements_from_serialization(state)
 
@@ -426,7 +451,7 @@ class QuditProcessorSpec(ProcessorSpec):
 
         return cls(state['qudit_labels'], state['qudit_udims'], state['gate_names'], nonstd_gate_unitaries,
                    availability, geometry, state['prep_names'], state['povm_names'],
-                   [tuple(iname) for iname in state['instrument_names']],
+                   [_tuplize(iname) for iname in state['instrument_names']],
                    nonstd_preps, nonstd_povms, nonstd_instruments, state['aux_info'],
                    nonstd_gate_num_qudits=state.get('nonstd_gate_num_qudits', {}))
 
@@ -1088,11 +1113,6 @@ class QubitProcessorSpec(QuditProcessorSpec):
 
     @classmethod
     def _from_nice_serialization(cls, state):
-        def _tuplize(x):
-            if isinstance(x, (list, tuple)):
-                return tuple((_tuplize(el) for el in x))
-            return x
-
         nonstd_gate_unitaries, nonstd_preps, nonstd_povms, nonstd_instruments = \
             cls._nonstd_elements_from_serialization(state)
 
@@ -1113,9 +1133,10 @@ class QubitProcessorSpec(QuditProcessorSpec):
                             " You should check to make sure you don't want/need to add this information and"
                             " then re-save this processor spec."))
 
+        instrument_names = [_tuplize(iname) for iname in state.get('instrument_names', [])]
         return cls(len(state['qubit_labels']), state['gate_names'], nonstd_gate_unitaries, availability,
                    geometry, state['qubit_labels'], symplectic_reps, state.get('prep_names', []),
-                   state.get('povm_names', []), state.get('instrument_names', []), nonstd_preps, nonstd_povms,
+                   state.get('povm_names', []), instrument_names, nonstd_preps, nonstd_povms,
                    nonstd_instruments, state['aux_info'],
                    gate_arg_label_indices=state.get('gate_arg_label_indices', {}),
                    nonstd_gate_num_qubits=state.get('nonstd_gate_num_qubits',

--- a/test/unit/objects/test_processorspec.py
+++ b/test/unit/objects/test_processorspec.py
@@ -144,6 +144,110 @@ class ProcessorSpecTester(BaseCase):
             QubitProcessorSpec(1, ['Gbad'], nonstd_gate_num_qubits={'Gbad': 0})
 
     @with_temp_path
+    def test_instrument_with_sslbls_serialization(self, pth):
+        # Regression test: an instrument whose name carries explicit state-space labels
+        # (as opposed to a bare name like 'Iz' that implicitly acts on all qudits) serializes
+        # its Label to a JSON list. On load, QubitProcessorSpec._from_nice_serialization must
+        # turn each entry of `instrument_names` back into a hashable object; if it doesn't, the
+        # unhashable list survives into `self.instrument_names` and any lookup against
+        # `self.nonstd_instruments` (e.g. via `instrument_specifier`, as called from
+        # `_create_explicit_model`) raises `TypeError: unhashable type: 'list'`.
+        iname = Label('Iz', (0,))
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=(iname,),
+                                   nonstd_instruments={iname: 'Iz'})
+
+        loaded_pspec = save_and_load(pspec, pth)
+
+        # Compound names come back as plain tuples (hash-equal to the original Labels).
+        self.assertEqual(loaded_pspec.instrument_names, (('Iz', 0),))
+        for loaded_iname in loaded_pspec.instrument_names:
+            self.assertEqual(loaded_pspec.instrument_specifier(loaded_iname), 'Iz')
+
+        # Exercise the reported call chain (_create_explicit_model) on a single-qubit spec,
+        # where the instrument's sslbls cover the full state space.  On the two-qubit spec
+        # above this raises NotImplementedError even without serialization, because
+        # instruments cannot be embedded onto a subset of the qudits yet.
+        pspec_1q = QubitProcessorSpec(1, ['Gxpi2', 'Gypi2'],
+                                      instrument_names=(iname,),
+                                      nonstd_instruments={iname: 'Iz'})
+        loaded_pspec_1q = save_and_load(pspec_1q, pth)
+
+        from pygsti.models.modelconstruction import _create_explicit_model
+        mdl = _create_explicit_model(loaded_pspec_1q, None, evotype='default', simulator='auto',
+                                     ideal_gate_type='static', ideal_prep_type='auto', ideal_povm_type='auto',
+                                     embed_gates=False, basis='pp')
+        self.assertEqual(list(mdl.instruments.keys()), [iname])
+
+    @with_temp_path
+    def test_instrument_with_custom_spec_serialization(self, pth):
+        # Regression test: `nonstd_instruments` keys used to be flattened with a lossy colon-join,
+        # which exploded plain-string names character-by-character ('Iparity' -> 'I:p:a:r:i:t:y'),
+        # so a custom instrument spec could never be found by `instrument_specifier` after a
+        # round trip through JSON.
+        spec = {'plus': [('00', '00'), ('11', '11')],
+                'minus': [('10', '10'), ('01', '01')]}
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=('Iparity',),
+                                   nonstd_instruments={'Iparity': spec})
+
+        loaded_pspec = save_and_load(pspec, pth)
+
+        self.assertEqual(loaded_pspec.instrument_names, ('Iparity',))
+        self.assertEqual(loaded_pspec.instrument_specifier('Iparity'), spec)
+
+        from pygsti.models.modelconstruction import create_explicit_model
+        mdl = create_explicit_model(loaded_pspec)
+        self.assertEqual(list(mdl.instruments['Iparity'].keys()), ['plus', 'minus'])
+
+    @with_temp_path
+    def test_qudit_instrument_serialization(self, pth):
+        # Regression test: QuditProcessorSpec._from_nice_serialization applied tuple() to every
+        # loaded instrument name, exploding plain-string names into character tuples
+        # ('Iz' -> ('I', 'z')).
+        iname = Label('Iz', ('Q0',))
+        pspec = QuditProcessorSpec(('Q0', 'Q1'), (2, 2), ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=('Iz', iname),
+                                   nonstd_instruments={iname: 'Iz'})
+
+        loaded_pspec = save_and_load(pspec, pth)
+
+        self.assertEqual(loaded_pspec.instrument_names, ('Iz', ('Iz', 'Q0')))
+        self.assertEqual(loaded_pspec.instrument_specifier('Iz'), 'Iz')
+        self.assertEqual(loaded_pspec.instrument_specifier(('Iz', 'Q0')), 'Iz')
+
+    @with_temp_path
+    def test_legacy_instrument_serialization_format(self, pth):
+        # Files written before the `nonstd_instruments` format change stored a dict whose keys
+        # were flattened with ':'.join(map(str, key)).  Loading must repair those keys by
+        # matching them against `instrument_names`, falling back to a split on ':' for keys it
+        # cannot match.
+        import json
+
+        iname = Label('Iz', (0,))
+        parity_spec = {'plus': [('00', '00'), ('11', '11')],
+                       'minus': [('10', '10'), ('01', '01')]}
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=('Iparity', iname),
+                                   nonstd_instruments={'Iparity': parity_spec, iname: 'Iz'})
+
+        pspec.write(pth + '.json')
+        with open(pth + '.json') as f:
+            state = json.load(f)
+        state['nonstd_instruments'] = {':'.join(map(str, k)): v for k, v in state['nonstd_instruments']}
+        state['nonstd_instruments']['Ighost:2'] = 'Iz'  # matches no instrument name
+        with open(pth + '.json', 'w') as f:
+            json.dump(state, f)
+
+        loaded_pspec = QubitProcessorSpec.read(pth + '.json')
+
+        self.assertEqual(loaded_pspec.instrument_names, ('Iparity', ('Iz', 0)))
+        self.assertEqual(loaded_pspec.instrument_specifier('Iparity'), parity_spec)
+        self.assertEqual(loaded_pspec.instrument_specifier(('Iz', 0)), 'Iz')
+        # Unmatched legacy keys keep the old best-effort split-on-colon reconstruction.
+        self.assertEqual(loaded_pspec.nonstd_instruments[('Ighost', '2')], 'Iz')
+
+    @with_temp_path
     def test_with_spam(self, pth):
         pspec_defaults = QubitProcessorSpec(4, ['Gxpi2', 'Gypi2'], geometry='line')
 


### PR DESCRIPTION
*In what follows, "we" refers to "Fable and I."*

-------------------------

JSON serialization of a QubitProcessorSpec or QuditProcessorSpec object can lead to a corrupted nonstd_instruments dict.

Currently, keys of the nonstd_instruments dict are flattened with ':'.join(map(str, key)), which explodes plain-string names character-by-character ('Iparity' → 'I:p:a:r:i:t:y') and coerces integer sslbls to strings, while compound instrument names came back from JSON as (unhashable) lists. A round-tripped spec with instrument names then crashed in instrument_specifier with TypeError: unhashable type: 'list' (encountered via StandardGST.run). In fact no non-standard instrument survived a round trip correctly — outcomes ranged from crashes to silently substituting a standard instrument for the user's custom spec.

This PR:
  - serializes nonstd_instruments as a list of [name, spec] pairs, preserving name structure and sslbl types;
  - keeps reading the old dict format, with a best-effort repair that matches each legacy flattened key against the faithfully round-tripped instrument_names;
  - reconstructs compound instrument names consistently (as tuples) in both _from_nice_serialization implementations.

The existing regression test now asserts round-tripped values end to end, and new tests cover string-keyed custom specs, the qudit path, and the legacy on-disk format.

While working on this we found a separate latent bug in nearby code (_unserialize_instrument_member misparses instrument members that aren't exactly two rank-1 pairs). It's orthogonal to this fix; we'll open an issue for it shortly.