### PR TITLE
matrixtools.py: normal operators in eigendecomposition(), plus a bug fix in eigenvalues()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+* `matrixtools.eigendecomposition(assume_normal=True)` now still routes Hermitian inputs to `eigh` (Hermitian matrices are normal, but the Hermiticity check was being skipped whenever the caller passed `assume_normal=True`); also fixed a pre-existing bug where `matrixtools.eigenvalues(assume_normal=True)` read off the Schur unitary factor instead of the triangular factor's diagonal (#856).
+
 ## [0.10.1] - 2026-07-06
 
 Bugfix release. The only updates are to pyproject.toml to declare import-time dependencies.

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -979,21 +979,13 @@ def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = Non
         `numpy.linalg.eigh`, which is faster and more numerically stable
         than the general-purpose path, and guarantees a unitary `evecs`. If
         None (the default), this is inferred by testing `m` for Hermiticity,
-        regardless of `assume_normal`: Hermitian matrices are a special case
-        of normal matrices, and the Hermiticity test is much cheaper than the
-        Schur decomposition `assume_normal` would otherwise trigger, so a
-        Hermitian `m` always takes the `eigh` path.
+        regardless of `assume_normal`.
 
     assume_normal : bool, optional
         If True, and `m` is not (found or assumed) to be Hermitian, `m` is
         assumed to be a normal operator and is eigendecomposed via a complex
         Schur decomposition, whose triangular factor is verified to be
-        diagonal (up to `tol`) -- i.e., the same approach used by this
-        module's `eign` function. This also guarantees a unitary `evecs`, and
-        is a reasonable middle ground between `assume_hermitian=True` and the
-        fully general (non-unitary `evecs`) path used when neither
-        `assume_hermitian` (whether passed or inferred) nor `assume_normal`
-        holds.
+        diagonal (up to `tol`).
 
     tol : float, optional
         Only used when the `assume_normal` path is taken. The off-diagonal
@@ -1011,9 +1003,7 @@ def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = Non
         The eigenvalues of `m`.
 
     inv_evecs : numpy array
-        The inverse of `evecs` (equal to `evecs.T.conj()` whenever `evecs`
-        is unitary, i.e. whenever the `assume_hermitian` or `assume_normal`
-        path was taken).
+        The matrix inverse of `evecs`
     """
     if assume_hermitian is None:
         assume_hermitian = is_hermitian(m)
@@ -1027,11 +1017,9 @@ def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = Non
         evals, evecs = _np.linalg.eigh(m)
         inv_evecs = evecs.T.conj()
     elif assume_normal:
-        # Same approach as this module's eign(): a complex Schur decomposition,
-        # with the triangular factor checked (rather than assumed) to be diagonal.
-        T, evecs = _spl.schur(m, output='complex')
+        T, evecs     = _spl.schur(m, output='complex')  # type: ignore
         offdiag_norm = _spl.norm(T[_np.triu_indices_from(T, 1)])
-        diag_norm = _spl.norm(_np.diag(T), ord=_np.inf)
+        diag_norm    = _spl.norm(_np.diag(T), ord=_np.inf)
         if offdiag_norm > tol * diag_norm:
             raise ValueError(
                 f'Off-diagonal of triangular factor T from Schur decomposition had norm {offdiag_norm}, '

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -957,14 +957,64 @@ def eigenvalues(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None, assu
         m /= 2
         return _np.linalg.eigvalsh(m)
     elif assume_normal:
-        temp = _spl.schur(m, output='complex')
-        evals = _np.diag(temp[1])
+        T, _ = _spl.schur(m, output='complex')
+        evals = _np.diag(T)
         return evals
     else:
         return _np.linalg.eigvals(m)
 
 
-def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None):
+def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None,
+                        assume_normal: bool = False, tol: float = 1e-12):
+    """
+    Eigendecompose a square matrix as `m = evecs @ diag(evals) @ inv_evecs`.
+
+    Parameters
+    ----------
+    m : numpy array
+        The matrix to eigendecompose.
+
+    assume_hermitian : bool, optional
+        If True, `m` is (numerically symmetrized and) eigendecomposed with
+        `numpy.linalg.eigh`, which is faster and more numerically stable
+        than the general-purpose path, and guarantees a unitary `evecs`. If
+        None (the default), this is inferred by testing `m` for Hermiticity,
+        regardless of `assume_normal`: Hermitian matrices are a special case
+        of normal matrices, and the Hermiticity test is much cheaper than the
+        Schur decomposition `assume_normal` would otherwise trigger, so a
+        Hermitian `m` always takes the `eigh` path.
+
+    assume_normal : bool, optional
+        If True, and `m` is not (found or assumed) to be Hermitian, `m` is
+        assumed to be a normal operator and is eigendecomposed via a complex
+        Schur decomposition, whose triangular factor is verified to be
+        diagonal (up to `tol`) -- i.e., the same approach used by this
+        module's `eign` function. This also guarantees a unitary `evecs`, and
+        is a reasonable middle ground between `assume_hermitian=True` and the
+        fully general (non-unitary `evecs`) path used when neither
+        `assume_hermitian` (whether passed or inferred) nor `assume_normal`
+        holds.
+
+    tol : float, optional
+        Only used when the `assume_normal` path is taken. The off-diagonal
+        norm of the Schur triangular factor is compared against `tol` times
+        the norm of its diagonal; a `ValueError` is raised if the
+        off-diagonal contribution is too large for `m` to be considered
+        normal.
+
+    Returns
+    -------
+    evecs : numpy array
+        The eigenvectors of `m`, as columns.
+
+    evals : numpy array
+        The eigenvalues of `m`.
+
+    inv_evecs : numpy array
+        The inverse of `evecs` (equal to `evecs.T.conj()` whenever `evecs`
+        is unitary, i.e. whenever the `assume_hermitian` or `assume_normal`
+        path was taken).
+    """
     if assume_hermitian is None:
         assume_hermitian = is_hermitian(m)
     if assume_hermitian:
@@ -975,6 +1025,19 @@ def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = Non
         m += m.T.conj()
         m /= 2
         evals, evecs = _np.linalg.eigh(m)
+        inv_evecs = evecs.T.conj()
+    elif assume_normal:
+        # Same approach as this module's eign(): a complex Schur decomposition,
+        # with the triangular factor checked (rather than assumed) to be diagonal.
+        T, evecs = _spl.schur(m, output='complex')
+        offdiag_norm = _spl.norm(T[_np.triu_indices_from(T, 1)])
+        diag_norm = _spl.norm(_np.diag(T), ord=_np.inf)
+        if offdiag_norm > tol * diag_norm:
+            raise ValueError(
+                f'Off-diagonal of triangular factor T from Schur decomposition had norm {offdiag_norm}, '
+                f'which exceeds relative tolerance of {tol * diag_norm}.'
+            )
+        evals = _np.diag(T)
         inv_evecs = evecs.T.conj()
     else:
         evals, evecs = _np.linalg.eig(m)

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -192,3 +192,53 @@ class MatrixToolsTester(BaseCase):
         self.assertEqual(mt.prime_factors(7), [7])
         self.assertEqual(mt.prime_factors(10), [2, 5])
         self.assertEqual(mt.prime_factors(12), [2, 2, 3])
+
+    def test_eigendecomposition_assume_normal(self):
+        # A non-Hermitian but normal matrix: a unitary conjugate of a diagonal matrix.
+        rng = np.random.default_rng(0)
+        diag = np.array([1 + 2j, 3 - 1j, 0.5j])
+        Q = spl.qr(rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))[0]
+        M = Q @ np.diag(diag) @ Q.conj().T
+        evecs, evals, inv_evecs = mt.eigendecomposition(M, assume_normal=True)
+        self.assertArraysAlmostEqual(evecs @ np.diag(evals) @ inv_evecs, M)
+        self.assertArraysAlmostEqual(evecs @ evecs.conj().T, np.eye(3))
+        self.assertArraysAlmostEqual(inv_evecs, evecs.conj().T)
+
+    def test_eigendecomposition_assume_normal_matches_assume_hermitian_for_hermitian_input(self):
+        rng = np.random.default_rng(0)
+        A = rng.standard_normal((4, 4)) + 1j * rng.standard_normal((4, 4))
+        H = A + A.conj().T
+        evecs_n, evals_n, _ = mt.eigendecomposition(H, assume_normal=True)
+        recon_n = evecs_n @ np.diag(evals_n) @ evecs_n.conj().T
+        self.assertArraysAlmostEqual(recon_n, H)
+
+    def test_eigendecomposition_assume_normal_raises_on_non_normal_input(self):
+        N = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0.5]], dtype=complex)
+        # N is not normal: N @ N.conj().T != N.conj().T @ N
+        self.assertFalse(np.allclose(N @ N.conj().T, N.conj().T @ N))
+        with self.assertRaises(ValueError):
+            mt.eigendecomposition(N, assume_normal=True)
+
+    def test_eigenvalues_assume_normal_matches_full_eig(self):
+        # Regression test: eigenvalues(assume_normal=True)'s Schur-decomposition path
+        # used to read diag(Z) (the Schur decomposition's unitary factor) instead of
+        # diag(T) (the triangular factor whose diagonal actually holds the
+        # eigenvalues) -- a pre-existing bug on develop, independent of the
+        # assume_hermitian-vs-assume_normal inference fixed in eigendecomposition
+        # above. Use a normal, non-Hermitian matrix so assume_normal=True actually
+        # exercises the Schur path (a Hermitian input would take the eigh path
+        # instead, per eigenvalues' own Hermiticity-first inference).
+        rng = np.random.default_rng(1)
+        diag = np.array([1 + 2j, 3 - 1j, 0.5j])
+        Q = spl.qr(rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))[0]
+        M = Q @ np.diag(diag) @ Q.conj().T
+        self.assertFalse(np.allclose(M, M.conj().T))
+
+        actual = mt.eigenvalues(M, assume_normal=True)
+        expected = np.linalg.eigvals(M)
+
+        def sort_key(z):
+            return (round(z.real, 8), round(z.imag, 8))
+
+        self.assertArraysAlmostEqual(
+            np.array(sorted(actual, key=sort_key)), np.array(sorted(expected, key=sort_key)))

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -97,9 +97,17 @@ class MatrixToolsTester(BaseCase):
             mt.real_matrix_log(M, action_if_imaginary="foobar", tol=1e-6)
 
     def test_matrix_log_raise_on_no_real_log(self):
+        import warnings
         a = np.array([[1, 1], [1, 1]])
         with self.assertRaises(AssertionError):
-            mt.real_matrix_log(a)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(action="ignore", 
+                    message="divide by zero encountered in log", category=RuntimeWarning
+                )
+                warnings.filterwarnings(action='ignore',
+                    message='invalid value encountered in dot', category=RuntimeWarning
+                )
+                mt.real_matrix_log(a)
 
     def test_minweight_match(self):
         a = np.array([1, 2, 3, 4], 'd')


### PR DESCRIPTION
This PR extends eigendecomposition in matrixtools.py with an assume_normal keyword argument. When set, and when the input isn't (found or assumed to be) Hermitian, the matrix is eigendecomposed via a complex Schur decomposition whose triangular factor is verified to be diagonal up to a relative tolerance. This path guarantees unitary eigenvectors, giving a middle ground between the Hermitian eigh path and the fully general eig path. Hermitian inputs still take the eigh path regardless of assume_normal, since the Hermiticity test is much cheaper than a Schur decomposition. I also added a proper docstring documenting all of this.

This PR also fixes a bug in eigenvalues: its assume_normal path read the diagonal of the Schur decomposition's unitary factor rather than the triangular factor, so it returned garbage instead of eigenvalues. A regression test exercises this path with a normal, non-Hermitian matrix (a Hermitian one would be routed to eigh and miss the bug).

Unit tests cover the new assume_normal decomposition path: reconstruction and unitarity for a normal non-Hermitian matrix, agreement with the Hermitian path on Hermitian input, and a ValueError on non-normal input.