### PR TITLE
Sanitize branch names in setuptools_scm local version scheme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,13 @@ def custom_version(version):
         else:
             node = node_and_date
             date = "CLEAN"
-        
-        local_scheme = node + f'.{version.branch}.' + date
+
+        # PEP 440 only allows alphanumerics and periods in the local version segment,
+        # so characters like the "/" in "feature/xyz" branch names must be replaced.
+        import re
+        branch = re.sub(r'[^a-zA-Z0-9]+', '.', str(version.branch or 'unknown')).strip('.') or 'unknown'
+
+        local_scheme = node + f'.{branch}.' + date
 
     return local_scheme
 


### PR DESCRIPTION
Our custom setuptools_scm local version scheme in setup.py embeds the git branch name directly in the version string. PEP 440 only permits alphanumerics and periods inside the local version segment, so branch names like `feature/graphcoloring` produced versions such as `0.0.post1.dev1+g7469a5be5.feature/graphcoloring.CLEAN` that packaging rejects. More generally, building pyGSTi from source on any branch containing a "/" will break.

This PR sanitizes the branch name before it enters the version string: any run of non-alphanumeric characters is collapsed to a single period, so feature/graphcoloring becomes feature.graphcoloring and the resulting version parses cleanly. If the branch name is unavailable (e.g., a detached-HEAD checkout) or sanitizes to nothing, we fall back to unknown.

Claude verified the fix by checking out a branch named tmp/slash-test and computing the version through setuptools_scm with both the old and new schemes. The old scheme's output is rejected by packaging.version.Version with the same InvalidVersion error seen in the CI log; the new scheme yields 0.10.1.post1.dev19+ga400ce929.tmp.slash.test.d20260723, which parses without issue.

Resolves #847.