### PR TITLE
cvxpy support in jamiolkowski_iso_inv

### DIFF
--- a/pygsti/tools/basistools.py
+++ b/pygsti/tools/basistools.py
@@ -25,11 +25,8 @@ def is_cvxpy_expression(obj) -> bool:
     Whether `obj` is a CVXPY `Expression`.
 
     Returns False whenever cvxpy is not installed, and -- more usefully -- whenever
-    cvxpy has simply not been imported yet.  That shortcut is exact rather than
-    heuristic: an `Expression` instance cannot exist unless `cvxpy` is already in
-    `sys.modules`.  It matters because cvxpy is an optional dependency with a
-    multi-second import time, and this predicate is called from hot paths such as
-    :func:`change_basis`.
+    cvxpy has simply not been imported yet. This check is preferred since cvxpy 
+    imports can be expensive.
 
     Parameters
     ----------
@@ -217,8 +214,6 @@ def change_basis(mx, from_basis, to_basis, expect_real=True):
 
     isMx = len(mx.shape) == 2 and mx.shape[0] == mx.shape[1]
     if isMx:
-        # want ret = toMx.dot( _np.dot(mx, fromMx)) but need to deal
-        # with some/all args being sparse:
         ret = toMx @ (mx @ fromMx)
     else:  # isVec
         ret = toMx @ mx
@@ -357,20 +352,14 @@ def resize_std_mx(mx, resize, std_basis_1, std_basis_2):
     if std_basis_1.dim == std_basis_2.dim:
         return change_basis(mx, std_basis_1, std_basis_2)  # don't just 'return mx' here
         # - need to change bases if bases are different (e.g. if one is a Tensorprod of std components)
-
-    #print('{}ing {} to {}'.format(resize, std_basis_1, std_basis_2))
-    #print('Dims: ({} to {})'.format(std_basis_1.dim, std_basis_2.dim))
-    #Below: use 'exp' in comments for 'expanded dimension'
-    # Note: use `@` rather than `_np.dot` throughout -- `_np.dot` silently produces an
-    # object-dtype array when either operand is a CVXPY Expression (or a scipy sparse
-    # matrix), whereas `@` dispatches to the operand's own `__matmul__`/`__rmatmul__`.
+    
     if resize == 'expand':
         assert std_basis_1.dim < std_basis_2.dim
         right = mx @ std_basis_1.from_elementstd_transform_matrix  # (exp,dim) (dim,dim) (dim,exp) => exp,exp
-        mid = std_basis_1.to_elementstd_transform_matrix @ right  # want Ai st.   Ai * A = I(dim)
+        mid = std_basis_1.to_elementstd_transform_matrix @ right   # want Ai st. Ai * A = I(dim)
     elif resize == 'contract':
         assert std_basis_1.dim > std_basis_2.dim
-        right = mx @ std_basis_2.to_elementstd_transform_matrix  # (dim,dim) (dim,exp) => dim,exp
+        right = mx @ std_basis_2.to_elementstd_transform_matrix     # (dim,dim) (dim,exp) => dim,exp
         mid = std_basis_2.from_elementstd_transform_matrix @ right  # (dim, exp) (exp, dim) => expdim, exp
     return mid
 

--- a/pygsti/tools/basistools.py
+++ b/pygsti/tools/basistools.py
@@ -10,6 +10,7 @@ Utility functions for working with Basis objects
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+import sys as _sys
 from functools import partial, lru_cache
 
 import numpy as _np
@@ -17,6 +18,30 @@ import numpy as _np
 from pygsti.baseobjs.basisconstructors import _basis_constructor_dict
 from pygsti.baseobjs import basis as _basis
 from pygsti.baseobjs import _compatibility as _compat
+
+
+def is_cvxpy_expression(obj) -> bool:
+    """
+    Whether `obj` is a CVXPY `Expression`.
+
+    Returns False whenever cvxpy is not installed, and -- more usefully -- whenever
+    cvxpy has simply not been imported yet.  That shortcut is exact rather than
+    heuristic: an `Expression` instance cannot exist unless `cvxpy` is already in
+    `sys.modules`.  It matters because cvxpy is an optional dependency with a
+    multi-second import time, and this predicate is called from hot paths such as
+    :func:`change_basis`.
+
+    Parameters
+    ----------
+    obj : object
+        The object to test.
+
+    Returns
+    -------
+    bool
+    """
+    cvxpy = _sys.modules.get('cvxpy')
+    return cvxpy is not None and isinstance(obj, cvxpy.Expression)
 
 
 @lru_cache(maxsize=1)
@@ -201,6 +226,14 @@ def change_basis(mx, from_basis, to_basis, expect_real=True):
     if not to_basis.real:
         return ret
 
+    if is_cvxpy_expression(ret):
+        # A symbolic expression has no numerically-inspectable imaginary part, so the
+        # `expect_real` check below cannot be performed (and would silently pass, since
+        # `numpy.imag` returns 0 for objects with no `.imag`).  `to_basis.real` says the
+        # result is real for any Hermiticity-preserving input, so project symbolically.
+        import cvxpy as _cp
+        return _cp.real(ret) if ret.is_complex() else ret
+
     if expect_real and _mt.safe_norm(ret, 'imag') > 1e-8:
         raise ValueError("Array has non-zero imaginary part (%g) after basis change (%s to %s)!\n%s" %
                          (_mt.safe_norm(ret, 'imag'), from_basis, to_basis, ret))
@@ -328,14 +361,17 @@ def resize_std_mx(mx, resize, std_basis_1, std_basis_2):
     #print('{}ing {} to {}'.format(resize, std_basis_1, std_basis_2))
     #print('Dims: ({} to {})'.format(std_basis_1.dim, std_basis_2.dim))
     #Below: use 'exp' in comments for 'expanded dimension'
+    # Note: use `@` rather than `_np.dot` throughout -- `_np.dot` silently produces an
+    # object-dtype array when either operand is a CVXPY Expression (or a scipy sparse
+    # matrix), whereas `@` dispatches to the operand's own `__matmul__`/`__rmatmul__`.
     if resize == 'expand':
         assert std_basis_1.dim < std_basis_2.dim
-        right = _np.dot(mx, std_basis_1.from_elementstd_transform_matrix)  # (exp,dim) (dim,dim) (dim,exp) => exp,exp
-        mid = _np.dot(std_basis_1.to_elementstd_transform_matrix, right)  # want Ai st.   Ai * A = I(dim)
+        right = mx @ std_basis_1.from_elementstd_transform_matrix  # (exp,dim) (dim,dim) (dim,exp) => exp,exp
+        mid = std_basis_1.to_elementstd_transform_matrix @ right  # want Ai st.   Ai * A = I(dim)
     elif resize == 'contract':
         assert std_basis_1.dim > std_basis_2.dim
-        right = _np.dot(mx, std_basis_2.to_elementstd_transform_matrix)  # (dim,dim) (dim,exp) => dim,exp
-        mid = _np.dot(std_basis_2.from_elementstd_transform_matrix, right)  # (dim, exp) (exp, dim) => expdim, exp
+        right = mx @ std_basis_2.to_elementstd_transform_matrix  # (dim,dim) (dim,exp) => dim,exp
+        mid = std_basis_2.from_elementstd_transform_matrix @ right  # (dim, exp) (exp, dim) => expdim, exp
     return mid
 
 

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -100,12 +100,8 @@ def jamiolkowski_iso(operation_mx: Union[_np.ndarray, Expression], op_mx_basis: 
     numpy array or cvxpy Expression
         the Choi matrix, in the desired basis.
     """
-    try:
-        import cvxpy as cp
-        is_cvxpy_expression = isinstance(operation_mx, cp.Expression)
-    except ImportError:
-        is_cvxpy_expression = False
-    
+    is_cvxpy_expression = _bt.is_cvxpy_expression(operation_mx)
+
     if not is_cvxpy_expression:
         operation_mx = _np.asarray(operation_mx)
     op_mx_basis = _bt.create_basis_for_matrix(operation_mx, op_mx_basis)
@@ -153,6 +149,7 @@ def jamiolkowski_iso(operation_mx: Union[_np.ndarray, Expression], op_mx_basis: 
             rows.append(BiBj.conj().ravel())
         choiMx_rows.append( _np.array(rows) @ opMxInStdBasis_vec )
     if is_cvxpy_expression:
+        import cvxpy as cp
         choiMx = cp.vstack(choiMx_rows)
     else:
         choiMx = _np.vstack(choiMx_rows)
@@ -174,7 +171,7 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
 
     Parameters
     ----------
-    choi_mx : numpy array
+    choi_mx : numpy array or cvxpy Expression
         the Choi matrix, normalized to have trace == 1, to compute operation matrix for.
 
     choi_mx_basis : Basis object
@@ -193,10 +190,13 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
 
     Returns
     -------
-    numpy array
+    numpy array or cvxpy Expression
         operation matrix in the desired basis.
     """
-    choi_mx = _np.asarray(choi_mx)  # will have "expanded" dimension even if bases are for reduced...
+    is_cvxpy_expression = _bt.is_cvxpy_expression(choi_mx)
+
+    if not is_cvxpy_expression:
+        choi_mx = _np.asarray(choi_mx)  # will have "expanded" dimension even if bases are for reduced...
     N = choi_mx.shape[0]  # dimension of full-basis (expanded) operation matrix
     if not isinstance(choi_mx_basis, _Basis):  # if we're not given a basis, build
         choi_mx_basis = _Basis.cast(choi_mx_basis, N)  # one with the full dimension
@@ -213,11 +213,34 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
     else:
         choiMx_unnorm = choi_mx
 
-    opMxInStdBasis = _np.zeros((N, N), 'complex')  # in matrix unit basis of entire density matrix
-    for i in range(N):
-        for j in range(N):
-            BiBj = _np.kron(BVec[i], _np.conjugate(BVec[j]))
-            opMxInStdBasis += choiMx_unnorm[i, j] * BiBj
+    # Both branches compute the same thing:
+    #     opMxInStdBasis = sum_ij choiMx_unnorm[i, j] * kron(B_i, conj(B_j))
+    # in the matrix unit basis of the entire density matrix.  They are kept separate
+    # because neither formulation is acceptable in the other's role -- see below.
+    if is_cvxpy_expression:
+        # Accumulate one row of `choiMx_unnorm` at a time as an explicit matrix-vector
+        # product.  This keeps the whole computation affine in `choi_mx`, so a CVXPY
+        # Expression flows through it unevaluated (cf. `jamiolkowski_iso`); scaling and
+        # adding `BiBj` in place, as the numeric branch does, cannot work symbolically.
+        # The peak temporary is N**3, the same as the equivalent loop in
+        # `jamiolkowski_iso`.
+        import cvxpy as cp
+        opMx_vec = 0
+        for i in range(N):
+            BiBj_cols = _np.empty((N * N, N), dtype=complex)
+            for j in range(N):
+                BiBj_cols[:, j] = _np.kron(BVec[i], _np.conjugate(BVec[j])).ravel()
+            opMx_vec = opMx_vec + BiBj_cols @ choiMx_unnorm[i, :]
+        opMxInStdBasis = cp.reshape(opMx_vec, (N, N), order='C')
+    else:
+        # Don't route ndarrays through the branch above: its inner product is a BLAS
+        # matvec on operands small enough that thread startup dominates (measured ~9 ms
+        # for a single 256x16 complex matvec, i.e. ~30x slower overall at N=16).
+        opMxInStdBasis = _np.zeros((N, N), 'complex')
+        for i in range(N):
+            for j in range(N):
+                BiBj = _np.kron(BVec[i], _np.conjugate(BVec[j]))
+                opMxInStdBasis += choiMx_unnorm[i, j] * BiBj
 
     if not isinstance(op_mx_basis, _Basis):
         op_mx_basis = _Basis.cast(op_mx_basis, N)  # make sure op_mx_basis is a Basis; we'd like dimension to be N

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -215,15 +215,11 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
 
     # Both branches compute the same thing:
     #     opMxInStdBasis = sum_ij choiMx_unnorm[i, j] * kron(B_i, conj(B_j))
-    # in the matrix unit basis of the entire density matrix.  They are kept separate
-    # because neither formulation is acceptable in the other's role -- see below.
+    # in the matrix unit basis of the entire density matrix.
     if is_cvxpy_expression:
         # Accumulate one row of `choiMx_unnorm` at a time as an explicit matrix-vector
-        # product.  This keeps the whole computation affine in `choi_mx`, so a CVXPY
-        # Expression flows through it unevaluated (cf. `jamiolkowski_iso`); scaling and
-        # adding `BiBj` in place, as the numeric branch does, cannot work symbolically.
-        # The peak temporary is N**3, the same as the equivalent loop in
-        # `jamiolkowski_iso`.
+        # product. This is needed because in-place operations with CVXPY Expressions
+        # aren't allowed.
         import cvxpy as cp
         opMx_vec = 0
         for i in range(N):
@@ -233,9 +229,8 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
             opMx_vec = opMx_vec + BiBj_cols @ choiMx_unnorm[i, :]
         opMxInStdBasis = cp.reshape(opMx_vec, (N, N), order='C')
     else:
-        # Don't route ndarrays through the branch above: its inner product is a BLAS
-        # matvec on operands small enough that thread startup dominates (measured ~9 ms
-        # for a single 256x16 complex matvec, i.e. ~30x slower overall at N=16).
+        # Don't route ndarrays through the branch above: in-place accumulation is
+        # materially faster.
         opMxInStdBasis = _np.zeros((N, N), 'complex')
         for i in range(N):
             for j in range(N):

--- a/test/unit/tools/test_jamiolkowski.py
+++ b/test/unit/tools/test_jamiolkowski.py
@@ -6,7 +6,7 @@ from pygsti.modelpacks.legacy import std1Q_XYI as std1Q
 from pygsti.baseobjs import statespace
 from pygsti.baseobjs import Basis
 from pygsti.tools import jamiolkowski as j
-from ..util import BaseCase
+from ..util import BaseCase, needs_cvxpy
 
 
 class JamiolkowskiBasisTester(BaseCase):
@@ -177,3 +177,86 @@ class JamiolkowskiOpsTester(BaseCase):
         self.assertArraysAlmostEqual(gatePP, self.mxPP)
         self.assertArraysAlmostEqual(gatePP2, self.mxPP)
         self.assertArraysAlmostEqual(gatePP3, self.mxPP)
+
+
+class JamiolkowskiCVXPYTester(BaseCase):
+    """`jamiolkowski_iso` and `jamiolkowski_iso_inv` are documented to accept and
+    return cvxpy Expressions, so that Choi-matrix constraints can be written directly
+    against a superoperator variable (or vice versa) inside an SDP.  Only the forward
+    map actually implemented it; these tests pin down that both directions do."""
+
+    def setUp(self):
+        self.bases = [Basis.cast(nm, 4) for nm in ('std', 'gm', 'pp')]
+        self.mx = np.array([[1, 0, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, -1, 0, 0],
+                            [0, 0, 0, 1]], 'd')
+
+    @needs_cvxpy
+    def test_iso_inv_accepts_expression(self):
+        """Symbolic and numeric evaluation must agree exactly, in every basis pair."""
+        import cvxpy as cp
+        for op_basis in self.bases:
+            for choi_basis in self.bases:
+                for normalized in (True, False):
+                    mx = bt.change_basis(self.mx, self.bases[1], op_basis)
+                    choi = j.jamiolkowski_iso(mx, op_basis, choi_basis, normalized=normalized)
+
+                    param = cp.Parameter(choi.shape, complex=np.iscomplexobj(choi))
+                    param.value = choi
+                    symbolic = j.jamiolkowski_iso_inv(param, choi_basis, op_basis,
+                                                      normalized=normalized)
+                    numeric = j.jamiolkowski_iso_inv(choi, choi_basis, op_basis,
+                                                     normalized=normalized)
+
+                    self.assertIsInstance(symbolic, cp.Expression)
+                    self.assertEqual(symbolic.shape, numeric.shape)
+                    # a real op basis must give a real Expression, not a complex one
+                    # with a zero imaginary part -- otherwise every downstream
+                    # constraint silently doubles in size.
+                    self.assertEqual(symbolic.is_complex(), not op_basis.real)
+                    self.assertArraysAlmostEqual(symbolic.value, numeric)
+                    self.assertArraysAlmostEqual(numeric, mx)
+
+    @needs_cvxpy
+    def test_iso_inv_composes_with_iso(self):
+        """iso_inv(iso(X)) is the identity map on a symbolic superoperator."""
+        import cvxpy as cp
+        x = cp.Variable((4, 4))
+        roundtrip = j.jamiolkowski_iso_inv(j.jamiolkowski_iso(x, 'pp', 'gm'), 'gm', 'pp')
+        x.value = self.mx
+        self.assertArraysAlmostEqual(roundtrip.value, self.mx)
+
+    @needs_cvxpy
+    def test_iso_inv_in_sdp(self):
+        """End-to-end: optimize over a Choi variable with constraints on the superop."""
+        import cvxpy as cp
+        target = bt.change_basis(self.mx, self.bases[1], self.bases[2])
+        choi = cp.Variable((4, 4), hermitian=True)
+        superop = j.jamiolkowski_iso_inv(choi, 'pp', 'pp')
+        prob = cp.Problem(cp.Minimize(cp.norm(superop - target, 'fro')),
+                          [choi >> 0, cp.trace(choi) == 1, superop[0, :] == np.eye(4)[0]])
+        prob.solve(solver='CLARABEL')
+        self.assertEqual(prob.status, 'optimal')
+        # the recovered superop must be CPTP and its Choi matrix must be the solution
+        self.assertArraysAlmostEqual(superop.value[0, :], np.eye(4)[0])
+        self.assertArraysAlmostEqual(j.jamiolkowski_iso(superop.value, 'pp', 'pp'), choi.value)
+        self.assertGreater(np.linalg.eigvalsh(choi.value).min(), -1e-7)
+
+    @needs_cvxpy
+    def test_iso_inv_block_structured_basis(self):
+        """The 'contract' branch of `resize_std_mx` must stay symbolic too."""
+        import cvxpy as cp
+        kite = Basis.cast('std', [4, 1])
+        mx = np.eye(kite.dim)
+        choi = j.jamiolkowski_iso(mx, kite, 'std')
+        param = cp.Parameter(choi.shape, complex=np.iscomplexobj(choi))
+        param.value = choi
+        symbolic = j.jamiolkowski_iso_inv(param, 'std', kite)
+        self.assertIsInstance(symbolic, cp.Expression)
+        self.assertArraysAlmostEqual(symbolic.value, j.jamiolkowski_iso_inv(choi, 'std', kite))
+
+    def test_is_cvxpy_expression_on_plain_arrays(self):
+        self.assertFalse(bt.is_cvxpy_expression(np.eye(4)))
+        self.assertFalse(bt.is_cvxpy_expression(1.0))
+        self.assertFalse(bt.is_cvxpy_expression(None))


### PR DESCRIPTION
This PR enables cvxpy support in jamiolkowski_iso_inv, which is needed to be consistent with its type annotations. It also adds import helpers and tests.