### PR TITLE
Release 0.10.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+* `matrixtools.eigendecomposition(assume_normal=True)` now still routes Hermitian inputs to `eigh` (Hermitian matrices are normal, but the Hermiticity check was being skipped whenever the caller passed `assume_normal=True`); also fixed a pre-existing bug where `matrixtools.eigenvalues(assume_normal=True)` read off the Schur unitary factor instead of the triangular factor's diagonal (#856).
+
 ## [0.10.1] - 2026-07-06
 
 Bugfix release. The only updates are to pyproject.toml to declare import-time dependencies.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,12 @@
 # CHANGELOG
 
-## [0.10.2] - 2026-07-23
+## [0.10.2] - 2026-07-30
 
 Bugfix release, plus a line search safeguard for the Levenberg-Marquardt optimizer.
 
 ### Added
 * Enumerative line search guard in the (simpler) Levenberg-Marquardt optimizer, triggered when the norm of the search direction is large relative to the current iterate. This prevents the optimizer from jumping to a wrong basin, which matters especially for models with CPTP-parameterized instruments (#852).
+* `tools.jamiolkowski.jamiolkowski_iso_inv` now accepts cvxpy `Expression` inputs, consistent with its type annotations; adds `tools.basistools.is_cvxpy_expression` as an import-cheap helper (#860).
 
 ### Fixed
 * Deserializing models that use a `TensorProdBasis` (and a similar bug in `leakage/gaugeopt.py`) no longer fails by accessing a non-existent `state_space` field (#842).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,18 @@
 # CHANGELOG
 
-## Unreleased
+## [0.10.2] - 2026-07-23
+
+Bugfix release, plus a line search safeguard for the Levenberg-Marquardt optimizer.
+
+### Added
+* Enumerative line search guard in the (simpler) Levenberg-Marquardt optimizer, triggered when the norm of the search direction is large relative to the current iterate. This prevents the optimizer from jumping to a wrong basin, which matters especially for models with CPTP-parameterized instruments (#852).
 
 ### Fixed
+* Deserializing models that use a `TensorProdBasis` (and a similar bug in `leakage/gaugeopt.py`) no longer fails by accessing a non-existent `state_space` field (#842).
+* `EmbeddedOp` no longer inherits a wrong dense-representation preference from the operation it embeds (#841, resolves #543).
+* Processor spec serialization now round-trips non-standard instruments. Previously, plain-string instrument names were exploded character-by-character (e.g., 'Iparity' -> 'I:p:a:r:i:t:y'), integer state-space labels were coerced to strings, and compound names came back as unhashable lists; no non-standard instrument survived a round trip correctly. The old on-disk format is still read, with a best-effort repair (#854).
 * `matrixtools.eigendecomposition(assume_normal=True)` now still routes Hermitian inputs to `eigh` (Hermitian matrices are normal, but the Hermiticity check was being skipped whenever the caller passed `assume_normal=True`); also fixed a pre-existing bug where `matrixtools.eigenvalues(assume_normal=True)` read off the Schur unitary factor instead of the triangular factor's diagonal (#856).
+* Building pyGSTi from source on a branch whose name contains "/" (or other characters that PEP 440 forbids in local version segments) no longer produces an invalid version string; branch names are sanitized in our custom setuptools_scm local version scheme (#857).
 
 ## [0.10.1] - 2026-07-06
 

--- a/docs/markdown/objects/Instruments.md
+++ b/docs/markdown/objects/Instruments.md
@@ -211,7 +211,7 @@ gst = StandardGST(modes=('full TP', 'CPTPLND'), target_model=mdl_ideal, verbosit
 results = gst.run(ProtocolData(edesign, ds))
 ```
 
-Both fits recover the data-generating model about equally well.  We compare each gauge-optimized estimate to the (ideal) target with the Frobenius distance:
+Both fits recover the data-generating model fairly well. We compare each gauge-optimized estimate to the (ideal) target with the Frobenius distance:
 
 ```{code-cell} ipython3
 for mode in ('full TP', 'CPTPLND'):

--- a/pygsti/baseobjs/errorgenbasis.py
+++ b/pygsti/baseobjs/errorgenbasis.py
@@ -63,6 +63,7 @@ def _all_elements_same_type(lst):
             return False
     return True
 
+
 class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
     """
     This basis object contains the information  necessary for building, 
@@ -329,6 +330,7 @@ class ExplicitElementaryErrorgenBasis(ElementaryErrorgenBasis):
         difference_state_space = self.state_space
         return ExplicitElementaryErrorgenBasis(difference_state_space, sorted(difference_labels, key=lambda label: label.__str__()), self._basis_1q)
 
+
 class CompleteElementaryErrorgenBasis(ElementaryErrorgenBasis):
     """
     This basis object contains the information  necessary for building, 
@@ -397,7 +399,6 @@ class CompleteElementaryErrorgenBasis(ElementaryErrorgenBasis):
             cnt += _np.prod(right_lengths) - start_at
 
         return cnt
-
 
     @classmethod
     def _create_ordered_labels(cls, type_str, basis_1q, state_space,

--- a/pygsti/leakage/gaugeopt.py
+++ b/pygsti/leakage/gaugeopt.py
@@ -12,15 +12,16 @@ from __future__ import annotations
 import copy
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
-from pygsti.baseobjs.basis import Basis
+from pygsti.baseobjs.basis import Basis, BuiltinBasis
 
 if TYPE_CHECKING:
     from pygsti.models import ExplicitOpModel
     from pygsti.protocols.gst import GSTGaugeOptSuite, ModelEstimateResults
 
 
-def _direct_sum_unitary_group(subspace_bases, full_basis, triviality_flags=None,
-                              level_partition=None):
+def _direct_sum_unitary_group(subspace_bases: list[BuiltinBasis], full_basis: Basis,
+        triviality_flags=None, level_partition=None
+    ):
     """
     Build a gauge group that acts as an independent unitary on each summand of a
     direct-sum decomposition H = H₀ ⨁ H₁ ⨁ ... of Hilbert space.
@@ -186,7 +187,7 @@ def lagoified_gopparams_dicts(gopparams_dicts: List[Dict]) -> List[Dict]:
         # ^ We use subspace-restricted loss functions that only care about mismatches
         #   between an estimate and a target when restricted to the computational subspace.
         #
-        gg = UnitaryGaugeGroup(tm.basis.state_space, tm.basis)
+        gg = UnitaryGaugeGroup(tm.state_space, tm.basis)
         inner_dict['gauge_group'] = gg
         inner_dict['_gaugeGroupEl'] = gg.compute_element(gg.initial_params)
         # ^ We insist on the unitary gauge group because other common gauge groups

--- a/pygsti/modelmembers/operations/embeddedop.py
+++ b/pygsti/modelmembers/operations/embeddedop.py
@@ -19,6 +19,7 @@ from pygsti.modelmembers.operations.linearop import LinearOperator as _LinearOpe
 from pygsti.modelmembers import modelmember as _modelmember
 from pygsti.baseobjs.statespace import StateSpace as _StateSpace
 from pygsti.baseobjs.errorgenlabel import GlobalElementaryErrorgenLabel as _GlobalElementaryErrorgenLabel, LocalElementaryErrorgenLabel as _LocalElementaryErrorgenLabel
+from pygsti.evotypes.evotype import Evotype as _Evotype
 from pygsti import SpaceT
 
 
@@ -56,7 +57,11 @@ class EmbeddedOp(_LinearOperator):
         assert(len(self.embedded_op.state_space.sole_tensor_product_block_labels) == len(target_labels)), \
             "Embedded operation's state space has a different number of components than the number of target labels!"
 
-        evotype = operation_to_embed._evotype
+        # Re-derive prefer_dense_reps for our own (parent) state_space instead of
+        # inheriting operation_to_embed's, which can be wrong/huge. See issue #543.
+        evotype = _Evotype.cast(
+            operation_to_embed._evotype.name, state_space=_StateSpace.cast(state_space)
+        )
         rep = self._create_rep_object(evotype, state_space)
 
         self._cached_embedded_errorgen_labels_global = None

--- a/pygsti/modelmembers/states/densestate.py
+++ b/pygsti/modelmembers/states/densestate.py
@@ -142,7 +142,10 @@ class DenseState(_DenseCopyMixin, _State):
             if 'Basis object has unexpected dimension' in se and len(serial_memo) > 0:
                 member = list(serial_memo.values())[0]
                 basis = member.parent.basis
-                state_space = basis.state_space
+                # Use the parent model's state_space directly rather than basis.state_space:
+                # composite bases (e.g. TensorProdBasis, DirectSumBasis) don't define state_space,
+                # while every Model is guaranteed to have one.
+                state_space = member.parent.state_space
                 return cls(vec, basis, mm_dict['evotype'], state_space)
             raise e
 

--- a/pygsti/optimize/simplerlm.py
+++ b/pygsti/optimize/simplerlm.py
@@ -120,9 +120,11 @@ class SimplerLMOptimizer(Optimizer):
 
     tol : float or dict, optional
         The tolerance, specified as a single float or as a dict
-        with keys `{'relx', 'relf', 'jac', 'maxdx'}`.  A single
+        with keys `{'relx', 'relf', 'f', 'jac', 'maxdx'}`.  A single
         float sets the `'relf'` and `'jac'` elemments and leaves
-        the others at their default values.
+        the others at their default values.  A dict need not specify
+        all keys; missing keys take the values a float `tol` would
+        have produced with `tol=1e-6`.
 
     fditer : int optional
         Internally compute the Jacobian using a finite-difference method
@@ -169,6 +171,12 @@ class SimplerLMOptimizer(Optimizer):
         by the objective function's `.terms()` and `.lsvec()` methods (`'normal'` mode) or the
         "per-circuit quantities" computed by the objective function's `.percircuit()` and
         `.lsvec_percircuit()` methods (`'percircuit'` mode).
+
+    linesearch : dict, optional
+        Controls the optional backtracking-to-argmin line search performed on a trial
+        LM step when it looks untrusted.  See `simplish_leastsq`'s `linesearch` parameter
+        for the recognized keys (`'mode'`, `'beta'`, `'max_evals'`, `'kappa'`) and their
+        defaults; missing keys (or a `None` dict) take those defaults.
     """
 
     @classmethod
@@ -184,10 +192,20 @@ class SimplerLMOptimizer(Optimizer):
         return cls()
 
     def __init__(self, maxiter=100, maxfev=100, tol=1e-6, fditer=0, first_fditer=0, init_munu="auto", oob_check_interval=0,
-                 oob_action="reject", oob_check_mode=0, serial_solve_proc_threshold=100, lsvec_mode="normal"):
+                 oob_action="reject", oob_check_mode=0, serial_solve_proc_threshold=100, lsvec_mode="normal",
+                 linesearch=None):
 
         super().__init__()
-        if isinstance(tol, float): tol = {'relx': 1e-8, 'relf': tol, 'f': 1.0, 'jac': tol, 'maxdx': 1.0}
+        if isinstance(tol, float):
+            tol = {'relx': 1e-8, 'relf': tol, 'f': 1.0, 'jac': tol, 'maxdx': 1.0}
+        else:
+            default_tol = {'relx': 1e-8, 'relf': 1e-6, 'f': 1.0, 'jac': 1e-6, 'maxdx': 1.0}
+            tol = {**default_tol, **tol}
+        linesearch = dict(linesearch) if linesearch else {}
+        linesearch.setdefault('mode', 'guarded')
+        linesearch.setdefault('beta', 0.25)
+        linesearch.setdefault('max_evals', 6)
+        linesearch.setdefault('kappa', 1.0)
         self.maxiter = maxiter
         self.maxfev = maxfev
         self.tol = tol
@@ -201,6 +219,7 @@ class SimplerLMOptimizer(Optimizer):
         self.called_objective_methods = ('lsvec', 'dlsvec')  # the objective function methods we use (for mem estimate)
         self.serial_solve_proc_threshold = serial_solve_proc_threshold
         self.lsvec_mode = lsvec_mode
+        self.linesearch = linesearch
 
     def _to_nice_serialization(self):
         state = super()._to_nice_serialization()
@@ -217,7 +236,8 @@ class SimplerLMOptimizer(Optimizer):
             'array_types': self.array_types,
             'called_objective_function_methods': self.called_objective_methods,
             'serial_solve_number_of_processors_threshold': self.serial_solve_proc_threshold,
-            'lsvec_mode': self.lsvec_mode
+            'lsvec_mode': self.lsvec_mode,
+            'linesearch': self.linesearch
         })
         return state
 
@@ -233,7 +253,8 @@ class SimplerLMOptimizer(Optimizer):
                    oob_action=state['out_of_bounds_action'],
                    oob_check_mode=state['out_of_bounds_check_mode'],
                    serial_solve_proc_threshold=state['serial_solve_number_of_processors_threshold'],
-                   lsvec_mode=state.get('lsvec_mode', 'normal'))
+                   lsvec_mode=state.get('lsvec_mode', 'normal'),
+                   linesearch=state.get('linesearch', None))
 
     def run(self, objective: TimeIndependentMDCObjectiveFunction, profiler, printer):
 
@@ -283,17 +304,16 @@ class SimplerLMOptimizer(Optimizer):
             objective_func, jacobian, x0,
             max_iter=self.maxiter,
             num_fd_iters=self.fditer,
-            # NOTE: I think the fallback values below will NEVER be triggered. 
-            # Should probably remove them. See __init__ instead.
-            f_norm2_tol=self.tol.get('f', 1.0),
-            jac_norm_tol=self.tol.get('jac', 1e-6),
-            rel_ftol=self.tol.get('relf', 1e-6),
-            rel_xtol=self.tol.get('relx', 1e-8),
-            max_dx_scale=self.tol.get('maxdx', 1.0),
+            f_norm2_tol=self.tol['f'],
+            jac_norm_tol=self.tol['jac'],
+            rel_ftol=self.tol['relf'],
+            rel_xtol=self.tol['relx'],
+            max_dx_scale=self.tol['maxdx'],
             init_munu=self.init_munu,
             oob_check_interval=self.oob_check_interval,
             oob_action=self.oob_action,
             oob_check_mode=self.oob_check_mode,
+            linesearch=self.linesearch,
             resource_alloc=objective.resource_alloc,
             arrays_interface=ari,
             serial_solve_proc_threshold=self.serial_solve_proc_threshold,
@@ -373,7 +393,8 @@ def simplish_leastsq(
     rel_ftol=1e-6, rel_xtol=1e-6, max_iter=100, num_fd_iters=0, max_dx_scale=1.0,
     init_munu="auto", oob_check_interval=0, oob_action="reject", oob_check_mode=0,
     resource_alloc=None, arrays_interface=None, serial_solve_proc_threshold=100,
-    x_limits=None, verbosity=0, profiler=None
+    x_limits=None, verbosity=0, profiler=None,
+    linesearch=None
     ):
     """
     An implementation of the Levenberg-Marquardt least-squares optimization algorithm customized for use within pyGSTi.
@@ -473,6 +494,25 @@ def simplish_leastsq(
     profiler : Profiler, optional
         A profiler object used for to track timing and memory usage.
 
+    linesearch : dict, optional
+        Controls the optional backtracking-to-argmin line search performed on a trial
+        LM step when it looks untrusted.  Recognized keys (missing keys, or an entirely
+        `None` dict, take the defaults shown):
+
+        - `'mode'` (default `'guarded'`) : `{'guarded', 'always', 'none'}`.  `'guarded'`
+          only searches when a trigger fires (the `max_dx_scale` clip activated, the step
+          is large relative to `|x|`, or the trial's objective norm is non-finite).
+          `'always'` searches on every trial step.  `'none'` never searches and is
+          bit-identical to the legacy behavior.  The primary motivation is robustness
+          against a full LM step leaving the good basin, not speed.
+        - `'beta'` (default `0.25`) : geometric shrink factor used by the line search,
+          in (0, 1).  Trial points are evaluated at `t = beta, beta**2, beta**3, ...`
+          along the step ray.
+        - `'max_evals'` (default `6`) : maximum number of trial objective evaluations
+          performed per line search.
+        - `'kappa'` (default `1.0`) : scale factor for the `'guarded'` oversize trigger:
+          a search is triggered when `|dx|^2 > kappa^2 * |x|^2`.
+
     Returns
     -------
     x : numpy.ndarray
@@ -482,6 +522,25 @@ def simplish_leastsq(
     msg : str
         A message indicating why the solution converged (or didn't).
     """
+    linesearch = dict(linesearch) if linesearch else {}
+    linesearch.setdefault('mode', 'guarded')
+    linesearch.setdefault('beta', 0.25)
+    linesearch.setdefault('max_evals', 6)
+    linesearch.setdefault('kappa', 1.0)
+    ls_mode = linesearch['mode']
+    ls_beta = linesearch['beta']
+    ls_max_evals = linesearch['max_evals']
+    ls_kappa = linesearch['kappa']
+
+    if ls_mode not in ('none', 'guarded', 'always'):
+        raise ValueError("Invalid `linesearch['mode']`: %s" % str(ls_mode))
+    if not (0 < ls_beta < 1):
+        raise ValueError("`linesearch['beta']` must satisfy 0 < beta < 1, got %s" % str(ls_beta))
+    if ls_max_evals < 1:
+        raise ValueError("`linesearch['max_evals']` must be >= 1, got %s" % str(ls_max_evals))
+    if ls_kappa <= 0:
+        raise ValueError("`linesearch['kappa']` must be > 0, got %s" % str(ls_kappa))
+
     resource_alloc = _ResourceAllocation.cast(resource_alloc)
     comm = resource_alloc.comm
     printer = _VerbosityPrinter.create_printer(verbosity, comm)
@@ -516,6 +575,9 @@ def simplish_leastsq(
     max_norm_dx = (max_dx_scale**2) * len(global_x) if max_dx_scale else None
     # ^ don't let any component change by more than ~max_dx_scale
 
+    # NOTE: all "norm" variables below (norm_f, norm_dx, norm_x, max_norm_dx, and the
+    # ari.norm2_* helpers) are *squared* 2-norms, not norms. E.g. a log line reading
+    # "norm_dx=96" means ||dx|| ~= 9.8.
 
     f = obj_fn(global_x)  # 'E'-type array
     norm_f = ari.norm2_f(f)
@@ -533,6 +595,52 @@ def simplish_leastsq(
     best_x_state = (mu, nu, norm_f, f.copy())
     # ^ here and elsewhere, need f.copy() b/c f is objfn mem
 
+    def revert_to_best_x(verb):
+        nonlocal oob_check_interval, mu, nu, norm_f
+        printer.log(("** %s with out-of-bounds with check interval=%d, reverting to last know "
+                      "in-bounds point and setting interval=1 **") % (verb, oob_check_interval), 2)
+        oob_check_interval = 1
+        x[:] = best_x[:]
+        mu, nu, norm_f, f[:] = best_x_state
+
+    def eval_candidate(do_oob_check):
+        """Collective. Evaluates obj_fn at global_new_x (caller has filled new_x and allgathered).
+        Returns (new_f, known_inbounds, oob_ok). oob_ok=False means the oob check raised ValueError."""
+        if oob_check_mode == 0 and oob_check_interval > 0:
+            if do_oob_check:
+                try:
+                    new_f = obj_fn(global_new_x, oob_check=True)
+                except ValueError:  # Use this to mean - "not allowed, but don't stop"
+                    return None, False, False
+                return new_f, True, True
+            else:  # don't check this time
+                new_f = obj_fn(global_new_x, oob_check=False)
+                return new_f, False, True
+        else:
+            #Just evaluate objective function normally; never check for in-bounds condition
+            new_f = obj_fn(global_new_x)
+            return new_f, (oob_check_interval == 0), True
+            # ^ assume in bounds if we have no out-of-bounds checks.
+
+    def handle_oob_rejection():
+        """Called when `eval_candidate` reports oob_ok=False. Returns 'continue' or 'break',
+        indicating which the inner-loop call site should do."""
+        nonlocal mu, nu, msg, converged
+        MIN_STOP_ITER = 1  # the minimum iteration where an OOB objective stops the optimization
+        if oob_action == "reject" or k < MIN_STOP_ITER:
+            reject_msg = " (out-of-bounds)"
+            mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
+            return "continue" if len(msg) == 0 else "break"
+        elif oob_action == "stop":
+            if oob_check_interval == 1:
+                msg = "Objective function out-of-bounds! STOP"
+                converged = True
+            else:  # reset to last know in-bounds point and not do oob check every step
+                revert_to_best_x("Hit")
+            return "break"
+        else:
+            raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
+
     try:
 
         for k in range(max_iter):  # outer loop
@@ -547,10 +655,7 @@ def simplish_leastsq(
                     converged = True
                     break
                 else:
-                    printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                    oob_check_interval = 1
-                    x[:] = best_x[:]
-                    mu, nu, norm_f, f[:] = best_x_state
+                    revert_to_best_x("Converged")
                     continue
 
             if profiler: profiler.memory_check("simplish_leastsq: begin outer iter")
@@ -585,10 +690,7 @@ def simplish_leastsq(
                     converged = True
                     break
                 else:
-                    printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                    oob_check_interval = 1
-                    x[:] = best_x[:]
-                    mu, nu, norm_f, f[:] = best_x_state
+                    revert_to_best_x("Converged")
                     continue
 
             if k == 0:
@@ -598,13 +700,12 @@ def simplish_leastsq(
 
             #determining increment using adaptive damping
             while True:  # inner loop
+                step_clipped = False
+                step_shrunk_by_ls = False
                 if profiler: profiler.memory_check("simplish_leastsq: begin inner iter")
 
                 # ok if assume fine-param-proc.size == 1 (otherwise need to sync setting local JTJ)
                 ari.jtj_update_regularization(JTJ, pre_reg_data, mu)
-
-                #assert(_np.isfinite(JTJ).all()), "Non-finite JTJ (inner)!" # NaNs tracking
-                #assert(_np.isfinite(minus_JTf).all()), "Non-finite minus_JTf (inner)!" # NaNs tracking
 
                 try:
                     if profiler: profiler.memory_check("simplish_leastsq: before linsolve")
@@ -630,6 +731,7 @@ def simplish_leastsq(
                     dx *= _np.sqrt(max_norm_dx / norm_dx)
                     new_x[:] = x + dx
                     norm_dx = ari.norm2_x(dx)
+                    step_clipped = True
 
                 #apply x limits (bounds)
                 if x_limits is not None:
@@ -651,64 +753,64 @@ def simplish_leastsq(
                         converged = True
                         break
                     else:
-                        printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                        oob_check_interval = 1
-                        x[:] = best_x[:]
-                        mu, nu, norm_f, f[:] = best_x_state
+                        revert_to_best_x("Converged")
                         break
                 elif (norm_x + rel_xtol) < norm_dx * (_MACH_PRECISION**2):
                     msg = "(near-)singular linear system"
                     break
 
-                if oob_check_mode == 0 and oob_check_interval > 0:
-                    if k % oob_check_interval == 0:
-                        #Check to see if objective function is out of bounds
-
-                        in_bounds = []
-                        ari.allgather_x(new_x, global_new_x)
-                        try:
-                            new_f = obj_fn(global_new_x, oob_check=True)
-                        except ValueError:  # Use this to mean - "not allowed, but don't stop"
-                            in_bounds.append(False)
-                        else:
-                            in_bounds.append(True)
-
-                        if any(in_bounds):  # In adaptive mode, proceed if *any* cases are in-bounds
-                            new_x_is_known_inbounds = True
-                        else:
-                            MIN_STOP_ITER = 1  # the minimum iteration where an OOB objective stops the optimization
-                            if oob_action == "reject" or k < MIN_STOP_ITER:
-                                reject_msg = " (out-of-bounds)"
-                                mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
-                                if len(msg) == 0:
-                                    continue
-                                else:
-                                    break
-                            elif oob_action == "stop":
-                                if oob_check_interval == 1:
-                                    msg = "Objective function out-of-bounds! STOP"
-                                    converged = True
-                                    break
-                                else:  # reset to last know in-bounds point and not do oob check every step
-                                    printer.log(("** Hit out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                                    oob_check_interval = 1
-                                    x[:] = best_x[:]
-                                    mu, nu, norm_f, f[:] = best_x_state
-                                    break  # restart next outer loop
-                            else:
-                                raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
-                    else:  # don't check this time
-                        ari.allgather_x(new_x, global_new_x)
-                        new_f = obj_fn(global_new_x, oob_check=False)
-                        new_x_is_known_inbounds = False
-                else:
-                    #Just evaluate objective function normally; never check for in-bounds condition
-                    ari.allgather_x(new_x, global_new_x)
-                    new_f = obj_fn(global_new_x)
-                    new_x_is_known_inbounds = oob_check_interval == 0
-                    # ^ assume in bounds if we have no out-of-bounds checks.
+                ari.allgather_x(new_x, global_new_x)
+                do_oob_check = (oob_check_mode == 0 and oob_check_interval > 0 and k % oob_check_interval == 0)
+                new_f, new_x_is_known_inbounds, oob_ok = eval_candidate(do_oob_check)
+                if not oob_ok:
+                    if handle_oob_rejection() == "continue":
+                        continue
+                    else:
+                        break
 
                 norm_new_f = ari.norm2_f(new_f)
+
+                if ls_mode == 'always':
+                    do_linesearch = True
+                elif ls_mode == 'guarded':
+                    do_linesearch = step_clipped or norm_dx > (ls_kappa**2) * norm_x or not _np.isfinite(norm_new_f)
+                else:  # 'none'
+                    do_linesearch = False
+
+                if do_linesearch:
+                    best_t = 1.0
+                    best_norm = norm_new_f if _np.isfinite(norm_new_f) else _np.inf
+                    t = ls_beta
+                    for _ in range(ls_max_evals):
+                        new_x[:] = x + t * dx
+                        ari.allgather_x(new_x, global_new_x)
+                        trial_norm = ari.norm2_f(obj_fn(global_new_x))
+                        if _np.isfinite(trial_norm) and trial_norm < best_norm:
+                            best_t, best_norm = t, trial_norm
+                            t *= ls_beta
+                        else:
+                            break  # one past the interior minimum (or trial non-finite)
+
+                    if best_t < 1.0:
+                        dx *= best_t
+                        norm_dx = ari.norm2_x(dx)
+                        step_shrunk_by_ls = True
+
+                    # Re-evaluate at the (possibly rescaled) dx: the trial evals above clobbered
+                    # obj_fn's internally-owned memory, so `new_f`/`norm_new_f` no longer reflect x + dx.
+                    new_x[:] = x + dx
+                    ari.allgather_x(new_x, global_new_x)
+                    new_f, new_x_is_known_inbounds, oob_ok = eval_candidate(do_oob_check)
+                    if not oob_ok:
+                        if handle_oob_rejection() == "continue":
+                            continue
+                        else:
+                            break
+                    norm_new_f = ari.norm2_f(new_f)
+
+                    if step_shrunk_by_ls:
+                        printer.log("      Line search: t=%g, norm_f %g -> %g" % (best_t, best_norm, norm_new_f), 2)
+
                 if not _np.isfinite(norm_new_f):  # avoid infinite loop...
                     msg = "Infinite norm of objective function!"
                     break
@@ -725,14 +827,11 @@ def simplish_leastsq(
                         converged = True
                         break
                     else:
-                        printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                        oob_check_interval = 1
-                        x[:] = best_x[:]
-                        mu, nu, norm_f, f[:] = best_x_state
+                        revert_to_best_x("Converged")
                         break
 
                 if (dL <= 0 or dF <= 0):
-                    reject_msg = " (out-of-bounds)"
+                    reject_msg = " (dL or dF <= 0)"
                     mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
                     if len(msg) == 0:
                         continue
@@ -760,10 +859,7 @@ def simplish_leastsq(
                                 converged = True
                                 break
                             else:  # reset to last know in-bounds point and not do oob check every step
-                                printer.log(("** Hit out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                                oob_check_interval = 1
-                                x[:] = best_x[:]
-                                mu, nu, norm_f, f[:] = best_x_state
+                                revert_to_best_x("Hit")
                                 break  # restart next outer loop
                         else:
                             raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
@@ -773,6 +869,8 @@ def simplish_leastsq(
                 t = 1.0 - (2 * dF / dL - 1.0)**3  # dF/dL == gain ratio
                 # always reduce mu for accepted step when |dx| is small
                 mu_factor = max(t, 1.0 / 3.0) if norm_dx > 1e-8 else 0.3
+                if step_shrunk_by_ls:
+                    mu_factor = max(mu_factor, 1.0)  # the model was untrusted at full step; never loosen damping
                 mu *= mu_factor
                 nu = 2
                 x[:] = new_x[:]
@@ -794,16 +892,9 @@ def simplish_leastsq(
                         best_x[:] = x[:]
                         best_x_state = (mu, nu, norm_f, f.copy())
 
-                #assert(_np.isfinite(x).all()), "Non-finite x!" # NaNs tracking
-                #assert(_np.isfinite(f).all()), "Non-finite f!" # NaNs tracking
-
                 break 
                 # ^ exit inner loop normally ...
             # end of inner loop
-            #
-            # x[:] = best_x[:]
-            # mu, nu, norm_f, f[:] = best_x_state
-            #
         # end of outer loop
         else:
             #if no break stmt hit, then we've exceeded max_iter

--- a/pygsti/processors/processorspec.py
+++ b/pygsti/processors/processorspec.py
@@ -28,6 +28,12 @@ from pygsti.modelmembers.operations import LinearOperator as _LinearOp
 from pygsti.modelmembers.operations import FullArbitraryOp as _FullOp
 
 
+def _tuplize(x):
+    if isinstance(x, (list, tuple)):
+        return tuple((_tuplize(el) for el in x))
+    return x
+
+
 class ProcessorSpec(_NicelySerializable):
     """
     The API presented by a quantum processor, and possible classical control processors.
@@ -309,7 +315,12 @@ class QuditProcessorSpec(ProcessorSpec):
 
         nonstd_preps = {k: _serialize_state(obj) for k, obj in self.nonstd_preps.items()}
         nonstd_povms = {k: _serialize_povm(obj) for k, obj in self.nonstd_povms.items()}
-        nonstd_instruments = {':'.join(map(str, k)): _serialize_instrument(obj) for k, obj in self.nonstd_instruments.items()}
+        # Serialize as a list of [name, spec] pairs so that compound (Label/tuple) names keep
+        # their structure and sslbl types.  The old format was a dict whose keys were flattened
+        # with ':'.join(map(str, k)) -- a lossy transform that exploded plain-string names
+        # character-by-character and coerced integer sslbls to strings.
+        nonstd_instruments = [[k if isinstance(k, str) else list(k), _serialize_instrument(obj)]
+                              for k, obj in self.nonstd_instruments.items()]
 
         state.update({'qudit_labels': list(self.qudit_labels),
                       'qudit_udims': list(self.qudit_udims),
@@ -384,17 +395,31 @@ class QuditProcessorSpec(ProcessorSpec):
 
         nonstd_preps = {k: _unserialize_state(obj) for k, obj in state.get('nonstd_preps', {}).items()}
         nonstd_povms = {k: _unserialize_povm(obj) for k, obj in state.get('nonstd_povms', {}).items()}
-        nonstd_instruments = {tuple(k.split(':')): _unserialize_instrument(obj) for k, obj in state.get('nonstd_instruments', {}).items()}
+
+        # Note: compound (sslbls-qualified) instrument names are reconstructed as plain tuples,
+        # both here and for `instrument_names` in the _from_nice_serialization methods.  This
+        # differs from the symplectic_reps handling in QubitProcessorSpec._from_nice_serialization
+        # and from ModelMemberGraph.load_modelmembers_from_serialization_dict, both of which
+        # rebuild Label objects.
+        serial_instruments = state.get('nonstd_instruments', [])
+        if isinstance(serial_instruments, dict):
+            # Legacy format: keys were flattened to strings with ':'.join(map(str, key)), which
+            # exploded plain-string names character-by-character (e.g. 'Iparity' -> 'I:p:a:r:i:t:y')
+            # and coerced integer sslbls to strings (e.g. ('Iz', 0) -> 'Iz:0').  Repair each key by
+            # finding the instrument name whose flattening reproduces it -- `instrument_names`
+            # round-trips faithfully, so it serves as ground truth.  Unmatched keys fall back to
+            # the old split-on-colon reconstruction.
+            instrument_names = [_tuplize(iname) for iname in state.get('instrument_names', [])]
+            flattened_names = {':'.join(map(str, iname)): iname for iname in instrument_names}
+            nonstd_instruments = {flattened_names.get(k, tuple(k.split(':'))): _unserialize_instrument(obj)
+                                  for k, obj in serial_instruments.items()}
+        else:
+            nonstd_instruments = {_tuplize(k): _unserialize_instrument(obj) for k, obj in serial_instruments}
 
         return nonstd_gate_unitaries, nonstd_preps, nonstd_povms, nonstd_instruments
 
     @classmethod
     def _from_nice_serialization(cls, state):
-        def _tuplize(x):
-            if isinstance(x, (list, tuple)):
-                return tuple((_tuplize(el) for el in x))
-            return x
-
         nonstd_gate_unitaries, nonstd_preps, nonstd_povms, nonstd_instruments = \
             cls._nonstd_elements_from_serialization(state)
 
@@ -403,7 +428,7 @@ class QuditProcessorSpec(ProcessorSpec):
 
         return cls(state['qudit_labels'], state['qudit_udims'], state['gate_names'], nonstd_gate_unitaries,
                    availability, geometry, state['prep_names'], state['povm_names'],
-                   [tuple(iname) for iname in state['instrument_names']],
+                   [_tuplize(iname) for iname in state['instrument_names']],
                    nonstd_preps, nonstd_povms, nonstd_instruments, state['aux_info'])
 
     @property
@@ -1003,11 +1028,6 @@ class QubitProcessorSpec(QuditProcessorSpec):
 
     @classmethod
     def _from_nice_serialization(cls, state):
-        def _tuplize(x):
-            if isinstance(x, (list, tuple)):
-                return tuple((_tuplize(el) for el in x))
-            return x
-
         nonstd_gate_unitaries, nonstd_preps, nonstd_povms, nonstd_instruments = \
             cls._nonstd_elements_from_serialization(state)
 
@@ -1020,9 +1040,10 @@ class QubitProcessorSpec(QuditProcessorSpec):
                             " You should check to make sure you don't want/need to add this information and"
                             " then re-save this processor spec."))
 
+        instrument_names = [_tuplize(iname) for iname in state.get('instrument_names', [])]
         return cls(len(state['qubit_labels']), state['gate_names'], nonstd_gate_unitaries, availability,
                    geometry, state['qubit_labels'], symplectic_reps, state.get('prep_names', []),
-                   state.get('povm_names', []), state.get('instrument_names', []), nonstd_preps, nonstd_povms,
+                   state.get('povm_names', []), instrument_names, nonstd_preps, nonstd_povms,
                    nonstd_instruments, state['aux_info'])
 
     @property

--- a/pygsti/tools/basistools.py
+++ b/pygsti/tools/basistools.py
@@ -10,6 +10,7 @@ Utility functions for working with Basis objects
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+import sys as _sys
 from functools import partial, lru_cache
 
 import numpy as _np
@@ -17,6 +18,27 @@ import numpy as _np
 from pygsti.baseobjs.basisconstructors import _basis_constructor_dict
 from pygsti.baseobjs import basis as _basis
 from pygsti.baseobjs import _compatibility as _compat
+
+
+def is_cvxpy_expression(obj) -> bool:
+    """
+    Whether `obj` is a CVXPY `Expression`.
+
+    Returns False whenever cvxpy is not installed, and -- more usefully -- whenever
+    cvxpy has simply not been imported yet. This check is preferred since cvxpy 
+    imports can be expensive.
+
+    Parameters
+    ----------
+    obj : object
+        The object to test.
+
+    Returns
+    -------
+    bool
+    """
+    cvxpy = _sys.modules.get('cvxpy')
+    return cvxpy is not None and isinstance(obj, cvxpy.Expression)
 
 
 @lru_cache(maxsize=1)
@@ -192,14 +214,20 @@ def change_basis(mx, from_basis, to_basis, expect_real=True):
 
     isMx = len(mx.shape) == 2 and mx.shape[0] == mx.shape[1]
     if isMx:
-        # want ret = toMx.dot( _np.dot(mx, fromMx)) but need to deal
-        # with some/all args being sparse:
         ret = toMx @ (mx @ fromMx)
     else:  # isVec
         ret = toMx @ mx
 
     if not to_basis.real:
         return ret
+
+    if is_cvxpy_expression(ret):
+        # A symbolic expression has no numerically-inspectable imaginary part, so the
+        # `expect_real` check below cannot be performed (and would silently pass, since
+        # `numpy.imag` returns 0 for objects with no `.imag`).  `to_basis.real` says the
+        # result is real for any Hermiticity-preserving input, so project symbolically.
+        import cvxpy as _cp
+        return _cp.real(ret) if ret.is_complex() else ret
 
     if expect_real and _mt.safe_norm(ret, 'imag') > 1e-8:
         raise ValueError("Array has non-zero imaginary part (%g) after basis change (%s to %s)!\n%s" %
@@ -324,18 +352,15 @@ def resize_std_mx(mx, resize, std_basis_1, std_basis_2):
     if std_basis_1.dim == std_basis_2.dim:
         return change_basis(mx, std_basis_1, std_basis_2)  # don't just 'return mx' here
         # - need to change bases if bases are different (e.g. if one is a Tensorprod of std components)
-
-    #print('{}ing {} to {}'.format(resize, std_basis_1, std_basis_2))
-    #print('Dims: ({} to {})'.format(std_basis_1.dim, std_basis_2.dim))
-    #Below: use 'exp' in comments for 'expanded dimension'
+    
     if resize == 'expand':
         assert std_basis_1.dim < std_basis_2.dim
-        right = _np.dot(mx, std_basis_1.from_elementstd_transform_matrix)  # (exp,dim) (dim,dim) (dim,exp) => exp,exp
-        mid = _np.dot(std_basis_1.to_elementstd_transform_matrix, right)  # want Ai st.   Ai * A = I(dim)
+        right = mx @ std_basis_1.from_elementstd_transform_matrix  # (exp,dim) (dim,dim) (dim,exp) => exp,exp
+        mid = std_basis_1.to_elementstd_transform_matrix @ right   # want Ai st. Ai * A = I(dim)
     elif resize == 'contract':
         assert std_basis_1.dim > std_basis_2.dim
-        right = _np.dot(mx, std_basis_2.to_elementstd_transform_matrix)  # (dim,dim) (dim,exp) => dim,exp
-        mid = _np.dot(std_basis_2.from_elementstd_transform_matrix, right)  # (dim, exp) (exp, dim) => expdim, exp
+        right = mx @ std_basis_2.to_elementstd_transform_matrix     # (dim,dim) (dim,exp) => dim,exp
+        mid = std_basis_2.from_elementstd_transform_matrix @ right  # (dim, exp) (exp, dim) => expdim, exp
     return mid
 
 

--- a/pygsti/tools/jamiolkowski.py
+++ b/pygsti/tools/jamiolkowski.py
@@ -100,12 +100,8 @@ def jamiolkowski_iso(operation_mx: Union[_np.ndarray, Expression], op_mx_basis: 
     numpy array or cvxpy Expression
         the Choi matrix, in the desired basis.
     """
-    try:
-        import cvxpy as cp
-        is_cvxpy_expression = isinstance(operation_mx, cp.Expression)
-    except ImportError:
-        is_cvxpy_expression = False
-    
+    is_cvxpy_expression = _bt.is_cvxpy_expression(operation_mx)
+
     if not is_cvxpy_expression:
         operation_mx = _np.asarray(operation_mx)
     op_mx_basis = _bt.create_basis_for_matrix(operation_mx, op_mx_basis)
@@ -153,6 +149,7 @@ def jamiolkowski_iso(operation_mx: Union[_np.ndarray, Expression], op_mx_basis: 
             rows.append(BiBj.conj().ravel())
         choiMx_rows.append( _np.array(rows) @ opMxInStdBasis_vec )
     if is_cvxpy_expression:
+        import cvxpy as cp
         choiMx = cp.vstack(choiMx_rows)
     else:
         choiMx = _np.vstack(choiMx_rows)
@@ -174,7 +171,7 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
 
     Parameters
     ----------
-    choi_mx : numpy array
+    choi_mx : numpy array or cvxpy Expression
         the Choi matrix, normalized to have trace == 1, to compute operation matrix for.
 
     choi_mx_basis : Basis object
@@ -193,10 +190,13 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
 
     Returns
     -------
-    numpy array
+    numpy array or cvxpy Expression
         operation matrix in the desired basis.
     """
-    choi_mx = _np.asarray(choi_mx)  # will have "expanded" dimension even if bases are for reduced...
+    is_cvxpy_expression = _bt.is_cvxpy_expression(choi_mx)
+
+    if not is_cvxpy_expression:
+        choi_mx = _np.asarray(choi_mx)  # will have "expanded" dimension even if bases are for reduced...
     N = choi_mx.shape[0]  # dimension of full-basis (expanded) operation matrix
     if not isinstance(choi_mx_basis, _Basis):  # if we're not given a basis, build
         choi_mx_basis = _Basis.cast(choi_mx_basis, N)  # one with the full dimension
@@ -213,11 +213,29 @@ def jamiolkowski_iso_inv(choi_mx: Union[_np.ndarray, Expression], choi_mx_basis:
     else:
         choiMx_unnorm = choi_mx
 
-    opMxInStdBasis = _np.zeros((N, N), 'complex')  # in matrix unit basis of entire density matrix
-    for i in range(N):
-        for j in range(N):
-            BiBj = _np.kron(BVec[i], _np.conjugate(BVec[j]))
-            opMxInStdBasis += choiMx_unnorm[i, j] * BiBj
+    # Both branches compute the same thing:
+    #     opMxInStdBasis = sum_ij choiMx_unnorm[i, j] * kron(B_i, conj(B_j))
+    # in the matrix unit basis of the entire density matrix.
+    if is_cvxpy_expression:
+        # Accumulate one row of `choiMx_unnorm` at a time as an explicit matrix-vector
+        # product. This is needed because in-place operations with CVXPY Expressions
+        # aren't allowed.
+        import cvxpy as cp
+        opMx_vec = 0
+        for i in range(N):
+            BiBj_cols = _np.empty((N * N, N), dtype=complex)
+            for j in range(N):
+                BiBj_cols[:, j] = _np.kron(BVec[i], _np.conjugate(BVec[j])).ravel()
+            opMx_vec = opMx_vec + BiBj_cols @ choiMx_unnorm[i, :]
+        opMxInStdBasis = cp.reshape(opMx_vec, (N, N), order='C')
+    else:
+        # Don't route ndarrays through the branch above: in-place accumulation is
+        # materially faster.
+        opMxInStdBasis = _np.zeros((N, N), 'complex')
+        for i in range(N):
+            for j in range(N):
+                BiBj = _np.kron(BVec[i], _np.conjugate(BVec[j]))
+                opMxInStdBasis += choiMx_unnorm[i, j] * BiBj
 
     if not isinstance(op_mx_basis, _Basis):
         op_mx_basis = _Basis.cast(op_mx_basis, N)  # make sure op_mx_basis is a Basis; we'd like dimension to be N

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -957,14 +957,54 @@ def eigenvalues(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None, assu
         m /= 2
         return _np.linalg.eigvalsh(m)
     elif assume_normal:
-        temp = _spl.schur(m, output='complex')
-        evals = _np.diag(temp[1])
+        T, _ = _spl.schur(m, output='complex')
+        evals = _np.diag(T)
         return evals
     else:
         return _np.linalg.eigvals(m)
 
 
-def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None):
+def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None,
+                        assume_normal: bool = False, tol: float = 1e-12):
+    """
+    Eigendecompose a square matrix as `m = evecs @ diag(evals) @ inv_evecs`.
+
+    Parameters
+    ----------
+    m : numpy array
+        The matrix to eigendecompose.
+
+    assume_hermitian : bool, optional
+        If True, `m` is (numerically symmetrized and) eigendecomposed with
+        `numpy.linalg.eigh`, which is faster and more numerically stable
+        than the general-purpose path, and guarantees a unitary `evecs`. If
+        None (the default), this is inferred by testing `m` for Hermiticity,
+        regardless of `assume_normal`.
+
+    assume_normal : bool, optional
+        If True, and `m` is not (found or assumed) to be Hermitian, `m` is
+        assumed to be a normal operator and is eigendecomposed via a complex
+        Schur decomposition, whose triangular factor is verified to be
+        diagonal (up to `tol`).
+
+    tol : float, optional
+        Only used when the `assume_normal` path is taken. The off-diagonal
+        norm of the Schur triangular factor is compared against `tol` times
+        the norm of its diagonal; a `ValueError` is raised if the
+        off-diagonal contribution is too large for `m` to be considered
+        normal.
+
+    Returns
+    -------
+    evecs : numpy array
+        The eigenvectors of `m`, as columns.
+
+    evals : numpy array
+        The eigenvalues of `m`.
+
+    inv_evecs : numpy array
+        The matrix inverse of `evecs`
+    """
     if assume_hermitian is None:
         assume_hermitian = is_hermitian(m)
     if assume_hermitian:
@@ -975,6 +1015,17 @@ def eigendecomposition(m: _np.ndarray, *, assume_hermitian: Optional[bool] = Non
         m += m.T.conj()
         m /= 2
         evals, evecs = _np.linalg.eigh(m)
+        inv_evecs = evecs.T.conj()
+    elif assume_normal:
+        T, evecs     = _spl.schur(m, output='complex')  # type: ignore
+        offdiag_norm = _spl.norm(T[_np.triu_indices_from(T, 1)])
+        diag_norm    = _spl.norm(_np.diag(T), ord=_np.inf)
+        if offdiag_norm > tol * diag_norm:
+            raise ValueError(
+                f'Off-diagonal of triangular factor T from Schur decomposition had norm {offdiag_norm}, '
+                f'which exceeds relative tolerance of {tol * diag_norm}.'
+            )
+        evals = _np.diag(T)
         inv_evecs = evecs.T.conj()
     else:
         evals, evecs = _np.linalg.eig(m)

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,13 @@ def custom_version(version):
         else:
             node = node_and_date
             date = "CLEAN"
-        
-        local_scheme = node + f'.{version.branch}.' + date
+
+        # PEP 440 only allows alphanumerics and periods in the local version segment,
+        # so characters like the "/" in "feature/xyz" branch names must be replaced.
+        import re
+        branch = re.sub(r'[^a-zA-Z0-9]+', '.', str(version.branch or 'unknown')).strip('.') or 'unknown'
+
+        local_scheme = node + f'.{branch}.' + date
 
     return local_scheme
 

--- a/test/unit/algorithms/test_gaugeopt_correctness.py
+++ b/test/unit/algorithms/test_gaugeopt_correctness.py
@@ -424,6 +424,36 @@ class LeakageDirectSumGroupTester(BaseCase):
             _leakage_direct_sum_group(basis)
 
 
+class LagoifiedGopparamsDictsTester(BaseCase):
+    """
+    Regression test for pygsti.leakage.gaugeopt.lagoified_gopparams_dicts.
+
+    It used to build its unitary gauge group from `tm.basis.state_space`, which raises
+    AttributeError whenever `tm.basis` is a composite basis (e.g. TensorProdBasis) --
+    the common case for any multi-subsystem model, leakage or not. It should instead use
+    `tm.state_space`, which every Model has regardless of its basis's type.
+    """
+
+    def test_tensor_prod_basis_target_model_does_not_crash(self):
+        from pygsti.baseobjs import ExplicitStateSpace
+        from pygsti.baseobjs.basis import Basis, TensorProdBasis
+        from pygsti.leakage.gaugeopt import lagoified_gopparams_dicts
+        from pygsti.models.gaugegroup import DirectSumUnitaryGroup
+
+        # A qubit tensored with a leaky qutrit: `basis` is a TensorProdBasis, which (unlike
+        # BuiltinBasis) has no `state_space` attribute of its own.
+        basis = TensorProdBasis((Basis.cast('pp', 4), Basis.cast('l2p1', 9)))
+        self.assertFalse(hasattr(basis, 'state_space'))
+        state_space = ExplicitStateSpace(['Q0', 'Q1'], [2, 3])
+        target_model = ExplicitOpModel(state_space, basis)
+
+        gopparams_dicts = lagoified_gopparams_dicts([{'target_model': target_model}])
+
+        self.assertEqual(len(gopparams_dicts), 2)
+        self.assertIsInstance(gopparams_dicts[0]['gauge_group'], UnitaryGaugeGroup)
+        self.assertIsInstance(gopparams_dicts[1]['gauge_group'], DirectSumUnitaryGroup)
+
+
 class FindPerfectGauge_DirectSumGaugeGroup4LevelTester(BaseCase):
     """
     Gauge-recovery test for the generalized direct-sum gauge group on a 4-level

--- a/test/unit/objects/test_processorspec.py
+++ b/test/unit/objects/test_processorspec.py
@@ -3,7 +3,9 @@ import unittest
 import numpy as np
 import scipy
 
+from pygsti.baseobjs.label import Label
 from pygsti.processors import QubitProcessorSpec
+from pygsti.processors import QuditProcessorSpec
 from pygsti.models import modelconstruction as mc
 from pygsti.circuits import Circuit
 from ..util import BaseCase, with_temp_path
@@ -11,7 +13,7 @@ from ..util import BaseCase, with_temp_path
 
 def save_and_load(obj, pth):
     obj.write(pth + ".json")
-    return QubitProcessorSpec.read(pth + '.json')
+    return obj.__class__.read(pth + '.json')
 
 
 class ProcessorSpecTester(BaseCase):

--- a/test/unit/objects/test_processorspec.py
+++ b/test/unit/objects/test_processorspec.py
@@ -40,6 +40,110 @@ class ProcessorSpecTester(BaseCase):
         self.assertAlmostEqual(p2['01'], 0.5)
 
     @with_temp_path
+    def test_instrument_with_sslbls_serialization(self, pth):
+        # Regression test: an instrument whose name carries explicit state-space labels
+        # (as opposed to a bare name like 'Iz' that implicitly acts on all qudits) serializes
+        # its Label to a JSON list. On load, QubitProcessorSpec._from_nice_serialization must
+        # turn each entry of `instrument_names` back into a hashable object; if it doesn't, the
+        # unhashable list survives into `self.instrument_names` and any lookup against
+        # `self.nonstd_instruments` (e.g. via `instrument_specifier`, as called from
+        # `_create_explicit_model`) raises `TypeError: unhashable type: 'list'`.
+        iname = Label('Iz', (0,))
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=(iname,),
+                                   nonstd_instruments={iname: 'Iz'})
+
+        loaded_pspec = save_and_load(pspec, pth)
+
+        # Compound names come back as plain tuples (hash-equal to the original Labels).
+        self.assertEqual(loaded_pspec.instrument_names, (('Iz', 0),))
+        for loaded_iname in loaded_pspec.instrument_names:
+            self.assertEqual(loaded_pspec.instrument_specifier(loaded_iname), 'Iz')
+
+        # Exercise the reported call chain (_create_explicit_model) on a single-qubit spec,
+        # where the instrument's sslbls cover the full state space.  On the two-qubit spec
+        # above this raises NotImplementedError even without serialization, because
+        # instruments cannot be embedded onto a subset of the qudits yet.
+        pspec_1q = QubitProcessorSpec(1, ['Gxpi2', 'Gypi2'],
+                                      instrument_names=(iname,),
+                                      nonstd_instruments={iname: 'Iz'})
+        loaded_pspec_1q = save_and_load(pspec_1q, pth)
+
+        from pygsti.models.modelconstruction import _create_explicit_model
+        mdl = _create_explicit_model(loaded_pspec_1q, None, evotype='default', simulator='auto',
+                                     ideal_gate_type='static', ideal_prep_type='auto', ideal_povm_type='auto',
+                                     embed_gates=False, basis='pp')
+        self.assertEqual(list(mdl.instruments.keys()), [iname])
+
+    @with_temp_path
+    def test_instrument_with_custom_spec_serialization(self, pth):
+        # Regression test: `nonstd_instruments` keys used to be flattened with a lossy colon-join,
+        # which exploded plain-string names character-by-character ('Iparity' -> 'I:p:a:r:i:t:y'),
+        # so a custom instrument spec could never be found by `instrument_specifier` after a
+        # round trip through JSON.
+        spec = {'plus': [('00', '00'), ('11', '11')],
+                'minus': [('10', '10'), ('01', '01')]}
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=('Iparity',),
+                                   nonstd_instruments={'Iparity': spec})
+
+        loaded_pspec = save_and_load(pspec, pth)
+
+        self.assertEqual(loaded_pspec.instrument_names, ('Iparity',))
+        self.assertEqual(loaded_pspec.instrument_specifier('Iparity'), spec)
+
+        from pygsti.models.modelconstruction import create_explicit_model
+        mdl = create_explicit_model(loaded_pspec)
+        self.assertEqual(list(mdl.instruments['Iparity'].keys()), ['plus', 'minus'])
+
+    @with_temp_path
+    def test_qudit_instrument_serialization(self, pth):
+        # Regression test: QuditProcessorSpec._from_nice_serialization applied tuple() to every
+        # loaded instrument name, exploding plain-string names into character tuples
+        # ('Iz' -> ('I', 'z')).
+        iname = Label('Iz', ('Q0',))
+        pspec = QuditProcessorSpec(('Q0', 'Q1'), (2, 2), ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=('Iz', iname),
+                                   nonstd_instruments={iname: 'Iz'})
+
+        loaded_pspec = save_and_load(pspec, pth)
+
+        self.assertEqual(loaded_pspec.instrument_names, ('Iz', ('Iz', 'Q0')))
+        self.assertEqual(loaded_pspec.instrument_specifier('Iz'), 'Iz')
+        self.assertEqual(loaded_pspec.instrument_specifier(('Iz', 'Q0')), 'Iz')
+
+    @with_temp_path
+    def test_legacy_instrument_serialization_format(self, pth):
+        # Files written before the `nonstd_instruments` format change stored a dict whose keys
+        # were flattened with ':'.join(map(str, key)).  Loading must repair those keys by
+        # matching them against `instrument_names`, falling back to a split on ':' for keys it
+        # cannot match.
+        import json
+
+        iname = Label('Iz', (0,))
+        parity_spec = {'plus': [('00', '00'), ('11', '11')],
+                       'minus': [('10', '10'), ('01', '01')]}
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2'], geometry='line',
+                                   instrument_names=('Iparity', iname),
+                                   nonstd_instruments={'Iparity': parity_spec, iname: 'Iz'})
+
+        pspec.write(pth + '.json')
+        with open(pth + '.json') as f:
+            state = json.load(f)
+        state['nonstd_instruments'] = {':'.join(map(str, k)): v for k, v in state['nonstd_instruments']}
+        state['nonstd_instruments']['Ighost:2'] = 'Iz'  # matches no instrument name
+        with open(pth + '.json', 'w') as f:
+            json.dump(state, f)
+
+        loaded_pspec = QubitProcessorSpec.read(pth + '.json')
+
+        self.assertEqual(loaded_pspec.instrument_names, ('Iparity', ('Iz', 0)))
+        self.assertEqual(loaded_pspec.instrument_specifier('Iparity'), parity_spec)
+        self.assertEqual(loaded_pspec.instrument_specifier(('Iz', 0)), 'Iz')
+        # Unmatched legacy keys keep the old best-effort split-on-colon reconstruction.
+        self.assertEqual(loaded_pspec.nonstd_instruments[('Ighost', '2')], 'Iz')
+
+    @with_temp_path
     def test_with_spam(self, pth):
         pspec_defaults = QubitProcessorSpec(4, ['Gxpi2', 'Gypi2'], geometry='line')
 

--- a/test/unit/optimize/test_simplerlm.py
+++ b/test/unit/optimize/test_simplerlm.py
@@ -41,3 +41,98 @@ class LMTester(BaseCase):
         xf, converged, msg, *_ = lm.simplish_leastsq(g, gjac, x0, max_iter=100, arrays_interface=ari,
                                                    x_limits=xlimits)
         self.assertAlmostEqual(xf[0], 1.0)
+
+    def test_linesearch_wrong_basin_witness(self):
+        # r(x) = x + sin(10*x) - 0.5 is oscillatory with many local minima of the sum-of-squares.
+        # From x0=0.8 the full LM step overshoots the nearby true root (x~0.994) into a
+        # neighboring-but-worse local minimum (x~1.718, norm_f~0.05). The line search should
+        # backtrack along the same step ray and land at the good root instead.
+        target = 0.5
+
+        def obj(x, oob_check=False):
+            return np.array([x[0] + np.sin(10 * x[0]) - target])
+
+        def jac(x):
+            return np.array([[1 + 10 * np.cos(10 * x[0])]])
+
+        x0 = np.array([0.8])
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf_none, _, _, _, _, norm_f_none, _ = lm.simplish_leastsq(
+            obj, jac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': 'none'})
+        # This assertion is the witness that the test still captures the pathology: if a future
+        # change makes 'none' converge to the good basin too, this should fail loudly rather than
+        # let the test go vacuous.
+        self.assertGreater(norm_f_none, 0.01)
+
+        for mode in ('guarded', 'always'):
+            ari = _ari.UndistributedArraysInterface(1, 1)
+            xf, _, _, _, _, norm_f, _ = lm.simplish_leastsq(
+                obj, jac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': mode})
+            self.assertLess(norm_f, 1e-6, msg="linesearch mode %s failed to reach the good basin" % mode)
+            self.assertAlmostEqual(xf[0], 0.99416, places=4)
+
+    def test_linesearch_nonfinite_rescue(self):
+        # r(x) = exp(1.5*x) - 2 has a near-zero Jacobian far in the negative tail, so an
+        # undamped full LM step from x0=-3.7 overshoots into positive territory so far that
+        # exp overflows to inf. A shrunk step along the same ray stays finite and converges.
+        k = 1.5
+
+        def obj(x, oob_check=False):
+            with np.errstate(over='ignore'):
+                return np.array([np.exp(k * x[0]) - 2.0])
+
+        def jac(x):
+            with np.errstate(over='ignore'):
+                return np.array([[k * np.exp(k * x[0])]])
+
+        x0 = np.array([-3.7])
+
+        with np.errstate(over='ignore', invalid='ignore'):
+            ari = _ari.UndistributedArraysInterface(1, 1)
+            xf_none, converged_none, msg_none, *_ = lm.simplish_leastsq(
+                obj, jac, x0.copy(), max_iter=20, max_dx_scale=None, arrays_interface=ari,
+                linesearch={'mode': 'none'})
+        self.assertFalse(converged_none)
+        self.assertEqual(msg_none, "Infinite norm of objective function!")
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf, converged, msg, _, _, norm_f, _ = lm.simplish_leastsq(
+            obj, jac, x0.copy(), max_iter=20, max_dx_scale=None, arrays_interface=ari,
+            linesearch={'mode': 'guarded'})
+        self.assertTrue(converged)
+        self.assertLess(norm_f, 1e-6)
+
+    def test_linesearch_guarded_quiet_on_healthy_problem(self):
+        # On a well-conditioned problem the guarded trigger should never fire, so 'guarded'
+        # and 'none' must produce identical results.
+        x0 = np.array([6.0], 'd')
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf_none, _, _, _, _, norm_f_none, _ = lm.simplish_leastsq(
+            g, gjac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': 'none'})
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf_guarded, _, _, _, _, norm_f_guarded, _ = lm.simplish_leastsq(
+            g, gjac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': 'guarded'})
+
+        self.assertEqual(norm_f_none, norm_f_guarded)
+        np.testing.assert_array_equal(xf_none, xf_guarded)
+
+    def test_simplerlm_optimizer_linesearch_serialization_roundtrip(self):
+        opt = lm.SimplerLMOptimizer(linesearch={'mode': 'always', 'beta': 0.5, 'max_evals': 3, 'kappa': 2.0})
+        state = opt._to_nice_serialization()
+        opt2 = lm.SimplerLMOptimizer._from_nice_serialization(state)
+        self.assertEqual(opt2.linesearch, {'mode': 'always', 'beta': 0.5, 'max_evals': 3, 'kappa': 2.0})
+
+        # A state dict without the 'linesearch' key (as produced by code predating this feature)
+        # should deserialize to the defaults rather than raising a KeyError.
+        del state['linesearch']
+        opt3 = lm.SimplerLMOptimizer._from_nice_serialization(state)
+        self.assertEqual(opt3.linesearch, {'mode': 'guarded', 'beta': 0.25, 'max_evals': 6, 'kappa': 1.0})
+
+    def test_tol_normalization(self):
+        # A partial `tol` dict should have its missing keys filled with the values a float
+        # tol=1e-6 would have produced, so that `run()`'s direct indexing never KeyErrors.
+        opt = lm.SimplerLMOptimizer(tol={'relf': 1e-5})
+        self.assertEqual(opt.tol, {'relx': 1e-8, 'relf': 1e-5, 'f': 1.0, 'jac': 1e-6, 'maxdx': 1.0})

--- a/test/unit/tools/test_jamiolkowski.py
+++ b/test/unit/tools/test_jamiolkowski.py
@@ -6,7 +6,7 @@ from pygsti.modelpacks.legacy import std1Q_XYI as std1Q
 from pygsti.baseobjs import statespace
 from pygsti.baseobjs import Basis
 from pygsti.tools import jamiolkowski as j
-from ..util import BaseCase
+from ..util import BaseCase, needs_cvxpy
 
 
 class JamiolkowskiBasisTester(BaseCase):
@@ -177,3 +177,86 @@ class JamiolkowskiOpsTester(BaseCase):
         self.assertArraysAlmostEqual(gatePP, self.mxPP)
         self.assertArraysAlmostEqual(gatePP2, self.mxPP)
         self.assertArraysAlmostEqual(gatePP3, self.mxPP)
+
+
+class JamiolkowskiCVXPYTester(BaseCase):
+    """`jamiolkowski_iso` and `jamiolkowski_iso_inv` are documented to accept and
+    return cvxpy Expressions, so that Choi-matrix constraints can be written directly
+    against a superoperator variable (or vice versa) inside an SDP.  Only the forward
+    map actually implemented it; these tests pin down that both directions do."""
+
+    def setUp(self):
+        self.bases = [Basis.cast(nm, 4) for nm in ('std', 'gm', 'pp')]
+        self.mx = np.array([[1, 0, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, -1, 0, 0],
+                            [0, 0, 0, 1]], 'd')
+
+    @needs_cvxpy
+    def test_iso_inv_accepts_expression(self):
+        """Symbolic and numeric evaluation must agree exactly, in every basis pair."""
+        import cvxpy as cp
+        for op_basis in self.bases:
+            for choi_basis in self.bases:
+                for normalized in (True, False):
+                    mx = bt.change_basis(self.mx, self.bases[1], op_basis)
+                    choi = j.jamiolkowski_iso(mx, op_basis, choi_basis, normalized=normalized)
+
+                    param = cp.Parameter(choi.shape, complex=np.iscomplexobj(choi))
+                    param.value = choi
+                    symbolic = j.jamiolkowski_iso_inv(param, choi_basis, op_basis,
+                                                      normalized=normalized)
+                    numeric = j.jamiolkowski_iso_inv(choi, choi_basis, op_basis,
+                                                     normalized=normalized)
+
+                    self.assertIsInstance(symbolic, cp.Expression)
+                    self.assertEqual(symbolic.shape, numeric.shape)
+                    # a real op basis must give a real Expression, not a complex one
+                    # with a zero imaginary part -- otherwise every downstream
+                    # constraint silently doubles in size.
+                    self.assertEqual(symbolic.is_complex(), not op_basis.real)
+                    self.assertArraysAlmostEqual(symbolic.value, numeric)
+                    self.assertArraysAlmostEqual(numeric, mx)
+
+    @needs_cvxpy
+    def test_iso_inv_composes_with_iso(self):
+        """iso_inv(iso(X)) is the identity map on a symbolic superoperator."""
+        import cvxpy as cp
+        x = cp.Variable((4, 4))
+        roundtrip = j.jamiolkowski_iso_inv(j.jamiolkowski_iso(x, 'pp', 'gm'), 'gm', 'pp')
+        x.value = self.mx
+        self.assertArraysAlmostEqual(roundtrip.value, self.mx)
+
+    @needs_cvxpy
+    def test_iso_inv_in_sdp(self):
+        """End-to-end: optimize over a Choi variable with constraints on the superop."""
+        import cvxpy as cp
+        target = bt.change_basis(self.mx, self.bases[1], self.bases[2])
+        choi = cp.Variable((4, 4), hermitian=True)
+        superop = j.jamiolkowski_iso_inv(choi, 'pp', 'pp')
+        prob = cp.Problem(cp.Minimize(cp.norm(superop - target, 'fro')),
+                          [choi >> 0, cp.trace(choi) == 1, superop[0, :] == np.eye(4)[0]])
+        prob.solve(solver='CLARABEL')
+        self.assertEqual(prob.status, 'optimal')
+        # the recovered superop must be CPTP and its Choi matrix must be the solution
+        self.assertArraysAlmostEqual(superop.value[0, :], np.eye(4)[0])
+        self.assertArraysAlmostEqual(j.jamiolkowski_iso(superop.value, 'pp', 'pp'), choi.value)
+        self.assertGreater(np.linalg.eigvalsh(choi.value).min(), -1e-7)
+
+    @needs_cvxpy
+    def test_iso_inv_block_structured_basis(self):
+        """The 'contract' branch of `resize_std_mx` must stay symbolic too."""
+        import cvxpy as cp
+        kite = Basis.cast('std', [4, 1])
+        mx = np.eye(kite.dim)
+        choi = j.jamiolkowski_iso(mx, kite, 'std')
+        param = cp.Parameter(choi.shape, complex=np.iscomplexobj(choi))
+        param.value = choi
+        symbolic = j.jamiolkowski_iso_inv(param, 'std', kite)
+        self.assertIsInstance(symbolic, cp.Expression)
+        self.assertArraysAlmostEqual(symbolic.value, j.jamiolkowski_iso_inv(choi, 'std', kite))
+
+    def test_is_cvxpy_expression_on_plain_arrays(self):
+        self.assertFalse(bt.is_cvxpy_expression(np.eye(4)))
+        self.assertFalse(bt.is_cvxpy_expression(1.0))
+        self.assertFalse(bt.is_cvxpy_expression(None))

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -97,9 +97,17 @@ class MatrixToolsTester(BaseCase):
             mt.real_matrix_log(M, action_if_imaginary="foobar", tol=1e-6)
 
     def test_matrix_log_raise_on_no_real_log(self):
+        import warnings
         a = np.array([[1, 1], [1, 1]])
         with self.assertRaises(AssertionError):
-            mt.real_matrix_log(a)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(action="ignore", 
+                    message="divide by zero encountered in log", category=RuntimeWarning
+                )
+                warnings.filterwarnings(action='ignore',
+                    message='invalid value encountered in dot', category=RuntimeWarning
+                )
+                mt.real_matrix_log(a)
 
     def test_minweight_match(self):
         a = np.array([1, 2, 3, 4], 'd')
@@ -192,3 +200,53 @@ class MatrixToolsTester(BaseCase):
         self.assertEqual(mt.prime_factors(7), [7])
         self.assertEqual(mt.prime_factors(10), [2, 5])
         self.assertEqual(mt.prime_factors(12), [2, 2, 3])
+
+    def test_eigendecomposition_assume_normal(self):
+        # A non-Hermitian but normal matrix: a unitary conjugate of a diagonal matrix.
+        rng = np.random.default_rng(0)
+        diag = np.array([1 + 2j, 3 - 1j, 0.5j])
+        Q = spl.qr(rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))[0]
+        M = Q @ np.diag(diag) @ Q.conj().T
+        evecs, evals, inv_evecs = mt.eigendecomposition(M, assume_normal=True)
+        self.assertArraysAlmostEqual(evecs @ np.diag(evals) @ inv_evecs, M)
+        self.assertArraysAlmostEqual(evecs @ evecs.conj().T, np.eye(3))
+        self.assertArraysAlmostEqual(inv_evecs, evecs.conj().T)
+
+    def test_eigendecomposition_assume_normal_matches_assume_hermitian_for_hermitian_input(self):
+        rng = np.random.default_rng(0)
+        A = rng.standard_normal((4, 4)) + 1j * rng.standard_normal((4, 4))
+        H = A + A.conj().T
+        evecs_n, evals_n, _ = mt.eigendecomposition(H, assume_normal=True)
+        recon_n = evecs_n @ np.diag(evals_n) @ evecs_n.conj().T
+        self.assertArraysAlmostEqual(recon_n, H)
+
+    def test_eigendecomposition_assume_normal_raises_on_non_normal_input(self):
+        N = np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0.5]], dtype=complex)
+        # N is not normal: N @ N.conj().T != N.conj().T @ N
+        self.assertFalse(np.allclose(N @ N.conj().T, N.conj().T @ N))
+        with self.assertRaises(ValueError):
+            mt.eigendecomposition(N, assume_normal=True)
+
+    def test_eigenvalues_assume_normal_matches_full_eig(self):
+        # Regression test: eigenvalues(assume_normal=True)'s Schur-decomposition path
+        # used to read diag(Z) (the Schur decomposition's unitary factor) instead of
+        # diag(T) (the triangular factor whose diagonal actually holds the
+        # eigenvalues) -- a pre-existing bug on develop, independent of the
+        # assume_hermitian-vs-assume_normal inference fixed in eigendecomposition
+        # above. Use a normal, non-Hermitian matrix so assume_normal=True actually
+        # exercises the Schur path (a Hermitian input would take the eigh path
+        # instead, per eigenvalues' own Hermiticity-first inference).
+        rng = np.random.default_rng(1)
+        diag = np.array([1 + 2j, 3 - 1j, 0.5j])
+        Q = spl.qr(rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))[0]
+        M = Q @ np.diag(diag) @ Q.conj().T
+        self.assertFalse(np.allclose(M, M.conj().T))
+
+        actual = mt.eigenvalues(M, assume_normal=True)
+        expected = np.linalg.eigvals(M)
+
+        def sort_key(z):
+            return (round(z.real, 8), round(z.imag, 8))
+
+        self.assertArraysAlmostEqual(
+            np.array(sorted(actual, key=sort_key)), np.array(sorted(expected, key=sort_key)))


### PR DESCRIPTION
This is a bugfix release, plus a line search safeguard for the Levenberg-Marquardt optimizer.

### Added
* Enumerative line search guard in the (simpler) Levenberg-Marquardt optimizer, triggered when the norm of the search direction is large relative to the current iterate. This prevents the optimizer from jumping to a wrong basin, which matters especially for models with CPTP-parameterized instruments (#852).
* `tools.jamiolkowski.jamiolkowski_iso_inv` now accepts cvxpy `Expression` inputs, consistent with its type annotations; adds `tools.basistools.is_cvxpy_expression` as an import-cheap helper (#860).

### Fixed
* Deserializing models that use a `TensorProdBasis` (and a similar bug in `leakage/gaugeopt.py`) no longer fails by accessing a non-existent `state_space` field (#842).
* `EmbeddedOp` no longer inherits a wrong dense-representation preference from the operation it embeds (#841, resolves #543).
* Processor spec serialization now round-trips non-standard instruments. Previously, plain-string instrument names were exploded character-by-character (e.g., 'Iparity' -> 'I:p:a:r:i:t:y'), integer state-space labels were coerced to strings, and compound names came back as unhashable lists; no non-standard instrument survived a round trip correctly. The old on-disk format is still read, with a best-effort repair (#854).
* `matrixtools.eigendecomposition(assume_normal=True)` now still routes Hermitian inputs to `eigh` (Hermitian matrices are normal, but the Hermiticity check was being skipped whenever the caller passed `assume_normal=True`); also fixed a pre-existing bug where `matrixtools.eigenvalues(assume_normal=True)` read off the Schur unitary factor instead of the triangular factor's diagonal (#856).
* Building pyGSTi from source on a branch whose name contains "/" (or other characters that PEP 440 forbids in local version segments) no longer produces an invalid version string; branch names are sanitized in our custom setuptools_scm local version scheme (#857).
