### PR TITLE
Unit tests for MatrixGroup

### DIFF
--- a/pygsti/tools/group.py
+++ b/pygsti/tools/group.py
@@ -11,11 +11,14 @@ Encapsulates a group in terms of matrices and relations
 #***************************************************************************************************
 
 from functools import reduce as _reduce
+import numbers as _numbers
 
 import numpy as _np
 
+from pygsti.tools.legacytools import deprecate as _deprecated_fn
 
-def is_integer(x):
+
+def _isint(x):
     """
     Check if `x` is an integer type.
 
@@ -28,8 +31,27 @@ def is_integer(x):
     -------
     bool
     """
-    #TODO: combine with compattools.isint(x) ??
-    return bool(isinstance(x, int) or isinstance(x, _np.int_))
+    return isinstance(x, _numbers.Integral)
+
+
+@_deprecated_fn('isinstance(x, numbers.Integral)')
+def is_integer(x):
+    """
+    Check if `x` is an integer type.
+
+    .. deprecated:: 0.10.2
+        Use `isinstance(x, numbers.Integral)` instead.
+
+    Parameters
+    ----------
+    x : object
+        Object to test.
+
+    Returns
+    -------
+    bool
+    """
+    return _isint(x)
 
 
 def construct_1q_clifford_group():
@@ -121,7 +143,7 @@ class MatrixGroup(object):
         -------
         numpy array
         """
-        if not is_integer(i): i = self.label_indices[i]
+        if not _isint(i): i = self.label_indices[i]
         return self.mxs[i]
 
     def inverse_matrix(self, i):
@@ -137,7 +159,7 @@ class MatrixGroup(object):
         -------
         numpy array
         """
-        if not is_integer(i): i = self.label_indices[i]
+        if not _isint(i): i = self.label_indices[i]
         return self.mxs[self.inverse_table[i]]
 
     def inverse_index(self, i):
@@ -155,7 +177,7 @@ class MatrixGroup(object):
             If `i` is an integer, returns the element's index.  Otherwise
             returns the element's label.
         """
-        if is_integer(i):
+        if _isint(i):
             return self.inverse_table[i]
         else:
             i = self.label_indices[i]
@@ -181,7 +203,7 @@ class MatrixGroup(object):
             index.  Otherwise returns the resulting element's label.
         """
         if len(indices) == 0: return None
-        if is_integer(indices[0]):
+        if _isint(indices[0]):
             return _reduce(lambda i, j: self.product_table[i, j], indices)
         else:
             indices = [self.label_indices[i] for i in indices]

--- a/pygsti/tools/group.py
+++ b/pygsti/tools/group.py
@@ -94,7 +94,8 @@ class MatrixGroup(object):
         labels : list, optional
             A label corresponding to each group element.
         """
-        self.mxs = list(list_of_matrices)
+        self.mxs = [m.to_dense() if hasattr(m, 'to_dense') else _np.asarray(m)
+                    for m in list_of_matrices]
         self.labels = list(labels) if (labels is not None) else None
         assert(labels is None or len(labels) == len(list_of_matrices))
         if labels is not None:
@@ -111,23 +112,39 @@ class MatrixGroup(object):
 
         #Construct group table
         self.product_table = -1 * _np.ones([N, N], dtype=int)
-        for i in range(N):
-            for j in range(N):
-                ij_product = _np.dot(self.mxs[j], self.mxs[i])
-                #Dot in reverse order here for multiplication here because
-                #gates are applied left to right.
+        if N > 0:
+            A = _np.asarray(self.mxs)
 
-                for k in range(N):
-                    if _np.isclose(_np.linalg.norm(ij_product - self.mxs[k]), 0):
-                        self.product_table[i, j] = k; break
+            def make_key(m):
+                # Round to 9 decimals and add 0.0 to normalize -0.0
+                return (_np.round(m, 9) + 0.0).tobytes()
+
+            lookup = {make_key(A[k]): k for k in range(N)}
+
+            for i in range(N):
+                # Batched product of all matrices in A with matrix i: (N, d, d)
+                # Gates applied left-to-right means product sequence g_j * g_i
+                row_products = _np.matmul(A, A[i])
+
+                for j in range(N):
+                    product_key = make_key(row_products[j])
+                    k = lookup.get(product_key, -1)
+
+                    if k < 0:
+                        # Fallback to tolerant linear scan on hash boundary miss
+                        diffs = _np.abs(A - row_products[j]).reshape(N, -1).max(axis=1)
+                        best_k = int(_np.argmin(diffs))
+                        if _np.isclose(_np.linalg.norm(row_products[j] - self.mxs[best_k]), 0):
+                            k = best_k
+
+                    self.product_table[i, j] = k
         assert (-1 not in self.product_table), "Cannot construct group table"
 
         #Construct inverse table
         self.inverse_table = -1 * _np.ones(N, dtype=int)
-        for i in range(N):
-            for j in range(N):
-                if self.product_table[i, j] == 0:  # the identity
-                    self.inverse_table[i] = j; break
+        if N > 0:
+            rows, cols = _np.nonzero(self.product_table == 0)
+            self.inverse_table[rows] = cols
         assert (-1 not in self.inverse_table), "Cannot construct inv table"
 
     def matrix(self, i):

--- a/pygsti/tools/group.py
+++ b/pygsti/tools/group.py
@@ -18,22 +18,6 @@ import numpy as _np
 from pygsti.tools.legacytools import deprecate as _deprecated_fn
 
 
-def _isint(x):
-    """
-    Check if `x` is an integer type.
-
-    Parameters
-    ----------
-    x : object
-        Object to test.
-
-    Returns
-    -------
-    bool
-    """
-    return isinstance(x, _numbers.Integral)
-
-
 @_deprecated_fn('isinstance(x, numbers.Integral)')
 def is_integer(x):
     """
@@ -51,7 +35,7 @@ def is_integer(x):
     -------
     bool
     """
-    return _isint(x)
+    return isinstance(x, _numbers.Integral)
 
 
 def construct_1q_clifford_group():
@@ -160,7 +144,7 @@ class MatrixGroup(object):
         -------
         numpy array
         """
-        if not _isint(i): i = self.label_indices[i]
+        if not isinstance(i, _numbers.Integral): i = self.label_indices[i]
         return self.mxs[i]
 
     def inverse_matrix(self, i):
@@ -176,7 +160,7 @@ class MatrixGroup(object):
         -------
         numpy array
         """
-        if not _isint(i): i = self.label_indices[i]
+        if not isinstance(i, _numbers.Integral): i = self.label_indices[i]
         return self.mxs[self.inverse_table[i]]
 
     def inverse_index(self, i):
@@ -194,7 +178,7 @@ class MatrixGroup(object):
             If `i` is an integer, returns the element's index.  Otherwise
             returns the element's label.
         """
-        if _isint(i):
+        if isinstance(i, _numbers.Integral):
             return self.inverse_table[i]
         else:
             i = self.label_indices[i]
@@ -220,7 +204,7 @@ class MatrixGroup(object):
             index.  Otherwise returns the resulting element's label.
         """
         if len(indices) == 0: return None
-        if _isint(indices[0]):
+        if isinstance(indices[0], _numbers.Integral):
             return _reduce(lambda i, j: self.product_table[i, j], indices)
         else:
             indices = [self.label_indices[i] for i in indices]

--- a/pygsti/tools/group.py
+++ b/pygsti/tools/group.py
@@ -96,39 +96,23 @@ class MatrixGroup(object):
 
         #Construct group table
         self.product_table = -1 * _np.ones([N, N], dtype=int)
-        if N > 0:
-            A = _np.asarray(self.mxs)
+        for i in range(N):
+            for j in range(N):
+                ij_product = _np.dot(self.mxs[j], self.mxs[i])
+                #Dot in reverse order here for multiplication here because
+                #gates are applied left to right.
 
-            def make_key(m):
-                # Round to 9 decimals and add 0.0 to normalize -0.0
-                return (_np.round(m, 9) + 0.0).tobytes()
-
-            lookup = {make_key(A[k]): k for k in range(N)}
-
-            for i in range(N):
-                # Batched product of all matrices in A with matrix i: (N, d, d)
-                # Gates applied left-to-right means product sequence g_j * g_i
-                row_products = _np.matmul(A, A[i])
-
-                for j in range(N):
-                    product_key = make_key(row_products[j])
-                    k = lookup.get(product_key, -1)
-
-                    if k < 0:
-                        # Fallback to tolerant linear scan on hash boundary miss
-                        diffs = _np.abs(A - row_products[j]).reshape(N, -1).max(axis=1)
-                        best_k = int(_np.argmin(diffs))
-                        if _np.isclose(_np.linalg.norm(row_products[j] - self.mxs[best_k]), 0):
-                            k = best_k
-
-                    self.product_table[i, j] = k
+                for k in range(N):
+                    if _np.isclose(_np.linalg.norm(ij_product - self.mxs[k]), 0):
+                        self.product_table[i, j] = k; break
         assert (-1 not in self.product_table), "Cannot construct group table"
 
         #Construct inverse table
         self.inverse_table = -1 * _np.ones(N, dtype=int)
-        if N > 0:
-            rows, cols = _np.nonzero(self.product_table == 0)
-            self.inverse_table[rows] = cols
+        for i in range(N):
+            for j in range(N):
+                if self.product_table[i, j] == 0:  # the identity
+                    self.inverse_table[i] = j; break
         assert (-1 not in self.inverse_table), "Cannot construct inv table"
 
     def matrix(self, i):

--- a/test/unit/tools/test_group.py
+++ b/test/unit/tools/test_group.py
@@ -1,0 +1,125 @@
+import numpy as np
+import warnings
+from pygsti.tools import group
+from pygsti.tools.exceptions import pyGSTiDeprecationWarning
+from ..util import BaseCase
+
+
+class MatrixGroupTester(BaseCase):
+
+    def test_construct_1q_clifford_group(self):
+        g = group.construct_1q_clifford_group()
+        self.assertEqual(len(g), 24)
+        self.assertFalse(-1 in g.product_table)
+        self.assertFalse(-1 in g.inverse_table)
+
+        # Latin square property: each row and column contains each element exactly once
+        N = len(g)
+        for i in range(N):
+            self.assertEqual(len(set(g.product_table[i])), N)
+            self.assertEqual(len(set(g.product_table[:, i])), N)
+
+        # Inverses property: g * g^-1 = identity
+        for i in range(N):
+            self.assertEqual(g.product_table[i, g.inverse_table[i]], 0)
+
+    def test_is_integer_deprecated(self):
+        # Call directly under catch_warnings to ensure pyGSTiDeprecationWarning is raised
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            res_int = group.is_integer(5)
+            res_np_int = group.is_integer(np.int32(5))
+            res_float = group.is_integer(5.5)
+
+            self.assertTrue(res_int)
+            self.assertTrue(res_np_int)
+            self.assertFalse(res_float)
+
+            # Assert at least one warning was emitted and it is pyGSTiDeprecationWarning
+            dep_warnings = [warning for warning in w if issubclass(warning.category, pyGSTiDeprecationWarning)]
+            self.assertGreaterEqual(len(dep_warnings), 1)
+
+    def test_matrix_group_arguments(self):
+        # Test that labels and integer indices both work for accessors
+        g = group.construct_1q_clifford_group()
+        self.assertIsNotNone(g.labels)
+        assert g.labels is not None  # for mypy
+
+        # Try np.int32 and check it works with matrix() without raising KeyError
+        idx_np = np.int32(1)
+        m1 = g.matrix(idx_np)
+        m2 = g.matrix(1)
+        self.assertArraysEqual(m1, m2)
+
+        lbl = g.labels[1]
+        m3 = g.matrix(lbl)
+        self.assertArraysEqual(m1, m3)
+
+        # Check inverse accessors
+        inv_idx1 = g.inverse_index(idx_np)
+        assert isinstance(inv_idx1, (int, np.integer))
+        inv_idx2 = g.inverse_index(1)
+        self.assertEqual(inv_idx1, inv_idx2)
+
+        inv_lbl = g.inverse_index(lbl)
+        self.assertEqual(inv_lbl, g.labels[inv_idx1])
+
+        # Check product
+        prod_idx = g.product([1, 2])
+        assert isinstance(prod_idx, (int, np.integer))
+        prod_lbl = g.product([g.labels[1], g.labels[2]])
+        self.assertEqual(prod_lbl, g.labels[prod_idx])
+
+    def test_matrix_group_coercion_and_asserts(self):
+        class MockOp:
+            def __init__(self, arr):
+                self._arr = arr
+            @property
+            def shape(self):
+                return self._arr.shape
+            def to_dense(self):
+                return self._arr
+
+        id2 = np.identity(2)
+        # Mock operations as objects with to_dense()
+        mock_ops = [MockOp(id2)]
+        g = group.MatrixGroup(mock_ops)
+        self.assertEqual(len(g), 1)
+        self.assertArraysEqual(g.matrix(0), id2)
+
+        # Non-identity first should assert failure
+        non_id = np.array([[0.0, 1.0], [1.0, 0.0]])
+        with self.assertRaises(AssertionError):
+            group.MatrixGroup([non_id])
+
+    def test_equivalence_guard(self):
+        # Build cyclic rotation group Z_16 (irrational entries)
+        n = 16
+        th = 2 * np.pi / n
+        mxs = [np.array([[np.cos(k * th), -np.sin(k * th)],
+                          [np.sin(k * th), np.cos(k * th)]]) for k in range(n)]
+        
+        # Build reference tables using the exact brute force O(N^3) logic from pre-optimization
+        N = len(mxs)
+        ref_product_table = -1 * np.ones([N, N], dtype=int)
+        for i in range(N):
+            for j in range(N):
+                ij_product = np.dot(mxs[j], mxs[i])
+                for k in range(N):
+                    if np.isclose(np.linalg.norm(ij_product - mxs[k]), 0):
+                        ref_product_table[i, j] = k
+                        break
+                        
+        ref_inverse_table = -1 * np.ones(N, dtype=int)
+        for i in range(N):
+            for j in range(N):
+                if ref_product_table[i, j] == 0:
+                    ref_inverse_table[i] = j
+                    break
+
+        # Now build using optimized MatrixGroup
+        g = group.MatrixGroup(mxs)
+        
+        # Assert exact agreement
+        self.assertArraysEqual(g.product_table, ref_product_table)
+        self.assertArraysEqual(g.inverse_table, ref_inverse_table)

--- a/test/unit/tools/test_group.py
+++ b/test/unit/tools/test_group.py
@@ -23,22 +23,6 @@ class MatrixGroupTester(BaseCase):
         for i in range(N):
             self.assertEqual(g.product_table[i, g.inverse_table[i]], 0)
 
-    def test_is_integer_deprecated(self):
-        # Call directly under catch_warnings to ensure pyGSTiDeprecationWarning is raised
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            res_int = group.is_integer(5)
-            res_np_int = group.is_integer(np.int32(5))
-            res_float = group.is_integer(5.5)
-
-            self.assertTrue(res_int)
-            self.assertTrue(res_np_int)
-            self.assertFalse(res_float)
-
-            # Assert at least one warning was emitted and it is pyGSTiDeprecationWarning
-            dep_warnings = [warning for warning in w if issubclass(warning.category, pyGSTiDeprecationWarning)]
-            self.assertGreaterEqual(len(dep_warnings), 1)
-
     def test_matrix_group_arguments(self):
         # Test that labels and integer indices both work for accessors
         g = group.construct_1q_clifford_group()

--- a/test/unit/tools/test_internalgates.py
+++ b/test/unit/tools/test_internalgates.py
@@ -1,24 +1,19 @@
 import numpy as np
 
-# from pygsti.extras import rb
-from pygsti.tools import internalgates, optools as ot, basistools as bt
+from pygsti.tools import internalgates, optools as ot, basistools as bt, group
 from ..util import BaseCase
 
 
 class InternalGatesTester(BaseCase):
 
     def test_internalgate_definitions(self):
-        # TODO is this test needed?
-        self.skipTest("RB analysis is known to be broken.  Skip tests until it gets fixed.")
-        std_unitaries = internalgates.standard_gatename_unitaries()
-        std_quil = internalgates.standard_gatenames_quil_conversions()
-        std_quil = internalgates.standard_gatenames_openqasm_conversions()
-
         # Checks the standard Clifford gate unitaries agree with the Clifford group unitaries.
-        group = rb.group.construct_1q_clifford_group()
-        for key in group.labels:
-            self.assertLess(np.sum(abs(np.array(group.matrix(key))
-                                       - ot.unitary_to_pauligate(std_unitaries[key]))), 10**-10)
+        std_unitaries = internalgates.standard_gatename_unitaries()
+        g = group.construct_1q_clifford_group()
+        assert g.labels is not None
+        for key in g.labels:
+            self.assertLess(np.sum(abs(np.array(g.matrix(key))
+                                       - ot.unitary_to_pauligate(std_unitaries[str(key)]))), 10**-10)
 
     def test_u3_unitary_generator(self):
         # Checks the u3 unitary generator runs


### PR DESCRIPTION
Added unit tests for the MatrixGroup and removed a custom is integer function in favor of using `isintance(x, _numbers.Integral)`.