### PR TITLE
WIP: Have ExplicitOpModel respect target qubit order for whole-state-space gates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 * Rank-1 (Legendre-weighted) synthetic-SPAM randomized benchmarking (R1RB) of "Randomized Benchmarking with Synthetic Quantum Circuits" for arbitrary-spin SU(2)/qudit systems: `SU2QuditRBDesign`, `SU2QuditRBSimulator`, `SU2QuditRB`, and the underlying SU(2) representation-theory tools (`pygsti.tools.su2tools.SpinJ`; exact, stdlib-only Clebsch-Gordan/Wigner 6-j symbols in `pygsti.tools.wignersymbols`) (#853)
 
 ### Fixed
+* `create_explicit_model` now respects the order of a gate's target qudits when the gate spans the model's entire state space. Previously, on an n-qudit model, an n-qudit gate placed on a permuted target ordering (e.g. `Gcnot:1:0` under `availability={'Gcnot': 'all-permutations'}`) was built without applying the permutation, so it came out identical to `Gcnot:0:1`. Affects every release since v0.9.10.
+* `operations.create_from_unitary_mx` no longer discards its `unitary_mx` argument when `stdname` names a standard gate that the unitary doesn't match. The `'static standard'` branch builds a `StaticStandardOp` from the name alone, and is now taken only when the name and the unitary agree.
 * Fixed the `is_trace_preserving` utility function for bases whose first element is the identity. The utility function was only used in report generation and the bug did not affect the correctness of its caller.
 
 ## [0.10.2] - 2026-07-30

--- a/pygsti/modelmembers/operations/__init__.py
+++ b/pygsti/modelmembers/operations/__init__.py
@@ -10,6 +10,7 @@ Sub-package holding model operation objects.
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+import functools as _functools
 import numpy as _np
 import warnings as _warnings
 
@@ -42,8 +43,36 @@ from .affineshiftop import AffineShiftOp
 from .cptrop import RootConjOperator, SummedOperator
 from pygsti.baseobjs import statespace as _statespace
 from pygsti.tools import basistools as _bt
+from pygsti.tools import internalgates as _itgs
 from pygsti.tools import optools as _ot
 from pygsti import SpaceT
+
+
+@_functools.lru_cache(maxsize=1)
+def _standard_gatename_unitaries_readonly():
+    """
+    Cached copy of :func:`standard_gatename_unitaries`, which rebuilds its dict (~3ms) on each call.
+
+    Private, and never handed out, so the usual caveat about mutating a cached mutable doesn't apply.
+    """
+    return _itgs.standard_gatename_unitaries()
+
+
+def _standard_name_matches_unitary(stdname, unitary_mx):
+    """
+    Whether `stdname` names a standard gate whose unitary is (numerically) `unitary_mx`.
+
+    `StaticStandardOp` is built from the gate *name* alone and ignores any unitary it's handed,
+    so it may only be used when the two agree.  Returns `False` for unrecognized names and for
+    continuously-parameterized standard gates (e.g. `'Gzr'`), whose entries in
+    :func:`standard_gatename_unitaries` are functions rather than matrices.
+    """
+    if stdname is None:
+        return False
+    std_unitary = _standard_gatename_unitaries_readonly().get(stdname, None)
+    if std_unitary is None or callable(std_unitary):
+        return False
+    return std_unitary.shape == unitary_mx.shape and _np.allclose(std_unitary, unitary_mx)
 
 
 def create_from_unitary_mx(unitary_mx, op_type, basis='pp', stdname=None, evotype='default', state_space=None):
@@ -54,6 +83,14 @@ def create_from_unitary_mx(unitary_mx, op_type, basis='pp', stdname=None, evotyp
     U = unitary_mx
     if state_space is None:
         state_space = _statespace.default_space_for_udim(U.shape[0])
+
+    # A `stdname` that disagrees with `unitary_mx` cannot be honored: the 'static standard' branch below
+    # builds the operation from the name alone and would silently discard `unitary_mx`.  This happens, for
+    # instance, when a standard gate is embedded into a permuted ordering of the model's qudits -- the
+    # name is still "Gcnot" but the unitary is not the standard CNOT.  Drop the name in that case and let
+    # the remaining (unitary-respecting) preferences handle it.
+    if stdname is not None and not _standard_name_matches_unitary(stdname, U):
+        stdname = None
 
     for typ in op_type_preferences:
         try:

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -232,6 +232,13 @@ class ExplicitOpModel(_mdl.OpModel):
         if self.state_space is None:
             raise ValueError("Must set model state space before adding auto-embedded gates.")
 
+        # Note: a full-state-space `op_val` is taken to be *already embedded*, regardless of what
+        # `op_target_labels` says.  This is a contract, not an oversight: `ExplicitOpModel` stores
+        # every operation on its full state space, so `__setitem__`, `update` and `copy` all re-insert
+        # already-embedded operations under their original (partial or permuted) keys.  Embedding them
+        # a second time would corrupt the model on every copy and serialization round trip.  Callers
+        # that hold a *local* operation acting on `op_target_labels` must therefore either supply it on
+        # the corresponding subspace or pass `force=True`.
         if op_val.state_space == self.state_space and not force:
             return op_val  # if gate operates on full dimension, no need to embed.
 

--- a/pygsti/models/modelconstruction.py
+++ b/pygsti/models/modelconstruction.py
@@ -883,10 +883,11 @@ def _create_explicit_model(processor_spec, modelnoise, custom_gates=None, evotyp
                         else:
                             if isinstance(gate_unitary, (int, _np.int64)):  # interpret gate_unitary as identity
                                 gate_unitary = _np.identity(2**gate_unitary, 'd')  # turn into explicit identity op
-                            if gate_unitary.shape[0] == state_space.udim:  # no need to embed!
-                                embedded_unitary = gate_unitary
-                            else:
-                                embedded_unitary = _embed_unitary(state_space, inds, gate_unitary)
+                            # Note: we're in the `else` of `inds is None or inds == tuple(qudit_labels)`, so
+                            # `inds` is guaranteed to be a *non-trivial* ordering of target qudits.  Embedding
+                            # is therefore required even when the gate already spans the entire state space,
+                            # since in that case the embedding is a (nonidentity) permutation of the qudits.
+                            embedded_unitary = _embed_unitary(state_space, inds, gate_unitary)
                             ideal_gate = _op.create_from_unitary_mx(embedded_unitary, ideal_gate_type, basis,
                                                                     stdname, evotype, state_space)
 

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -11,6 +11,8 @@ import pygsti.models.modelconstruction as mc
 import pygsti.modelmembers.operations as op
 import pygsti.modelmembers.states as st
 import pygsti.tools.basistools as bt
+import pygsti.tools.optools as ot
+from pygsti.tools.internalgates import standard_gatename_unitaries as std_unitaries
 from pygsti.processors.processorspec import QubitProcessorSpec as _ProcessorSpec
 from pygsti.baseobjs.errorgenlabel import GlobalElementaryErrorgenLabel as GEEL
 from ..util import BaseCase
@@ -609,6 +611,161 @@ class ModelConstructionTester(BaseCase):
         self.assertArraysAlmostEqual(mdl_default_explicit3.instruments['Iparity']['minus'].to_dense(), Iminus)
 
 
+def _embed_unitary_by_hand(num_qubits, unitary, target_qubits):
+    """
+    A reference implementation of unitary embedding that shares no code with pyGSTi.
+
+    `unitary` acts on `len(target_qubits)` qubits; `target_qubits[i]` names the qubit that the
+    `i`-th factor of `unitary` acts on.  Qubit 0 is the leftmost (most significant) tensor factor.
+    Built by summing over matrix units so that the qubit-ordering logic is written out explicitly
+    rather than delegated to a permutation routine.
+    """
+    k = len(target_qubits)
+    assert unitary.shape == (2 ** k, 2 ** k)
+    spectators = [q for q in range(num_qubits) if q not in target_qubits]
+    embedded = np.zeros((2 ** num_qubits, 2 ** num_qubits), dtype=complex)
+
+    def flat_index(bits):
+        return int(''.join(str(b) for b in bits), 2) if num_qubits > 0 else 0
+
+    for spectator_bits in itertools.product((0, 1), repeat=len(spectators)):
+        for row in range(2 ** k):
+            for col in range(2 ** k):
+                row_bits = [0] * num_qubits
+                col_bits = [0] * num_qubits
+                for q, b in zip(spectators, spectator_bits):
+                    row_bits[q] = col_bits[q] = b
+                for i, q in enumerate(target_qubits):
+                    row_bits[q] = (row >> (k - 1 - i)) & 1
+                    col_bits[q] = (col >> (k - 1 - i)) & 1
+                embedded[flat_index(row_bits), flat_index(col_bits)] += unitary[row, col]
+    return embedded
+
+
+class TargetQubitOrderingTester(BaseCase):
+    """
+    Regression tests for gates whose target qubits are listed in a non-default order.
+
+    A gate placed on target qubits ``(1, 0)`` must be the ``(0, 1)`` gate conjugated by a SWAP.
+    Historically this was silently skipped whenever the gate happened to span the model's whole
+    state space -- the "no need to embed" shortcut in ``_create_explicit_model`` tested only total
+    dimension, and ``create_from_unitary_mx`` then rebuilt standard-named gates from their name,
+    discarding the (correctly permuted) unitary it had been handed.
+    """
+
+    # 'auto' -- the default -- is ('static standard', 'static clifford', 'static unitary'), and is
+    # the only sweep entry that actually reaches the StaticStandardOp branch.  A bare
+    # 'static clifford' is omitted: it requires the stabilizer evotype and doesn't build here.
+    GATE_TYPES = ('auto', 'static', 'static unitary', 'full', 'full TP', 'CPTPLND', 'H+S')
+
+    # 'CPTPLND' is dropped from the 3-qubit sweep only because a 3-qubit CPTPLND explicit model
+    # takes ~40s to build; 'H+S' covers the same Lindblad code path in well under a second.
+    GATE_TYPES_3Q = ('auto', 'static', 'static unitary', 'full', 'full TP', 'H+S')
+
+    _model_cache = {}
+
+    def setUp(self):
+        pygsti.models.ExplicitOpModel._strict = False
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._model_cache.clear()
+
+    def _model(self, num_qubits, gate_name, gate_type, nonstd_gate_unitaries=None):
+        # Models are built once and shared: nothing below mutates them, and a 2-qubit CPTPLND
+        # model isn't free.
+        key = (num_qubits, gate_name, gate_type,
+               None if nonstd_gate_unitaries is None else tuple(sorted(nonstd_gate_unitaries)))
+        if key not in self._model_cache:
+            pspec = _ProcessorSpec(num_qubits, ('Gxpi2', 'Gypi2', gate_name),
+                                   availability={gate_name: 'all-permutations'},
+                                   nonstd_gate_unitaries=nonstd_gate_unitaries)
+            self._model_cache[key] = mc.create_explicit_model(pspec, ideal_gate_type=gate_type,
+                                                              ideal_spam_type='static')
+        return self._model_cache[key]
+
+    def _assert_matches_reference(self, model, num_qubits, gate_name, unitary, targets):
+        expected = ot.unitary_to_superop(_embed_unitary_by_hand(num_qubits, unitary, targets), 'pp')
+        actual = model.operations[(gate_name,) + tuple(targets)].to_dense('HilbertSchmidt')
+        self.assertArraysAlmostEqual(actual, expected)
+
+    def test_two_qubit_gate_on_two_qubit_model_respects_target_order(self):
+        # The motivating case: the gate spans the *entire* model, so every ordering of the target
+        # qubits has the right total dimension and the dimension-only shortcut fired for all of them.
+        for gate_name in ('Gcnot', 'Gecr'):
+            unitary = std_unitaries()[gate_name]
+            for gate_type in self.GATE_TYPES:
+                with self.subTest(gate=gate_name, gate_type=gate_type):
+                    model = self._model(2, gate_name, gate_type)
+                    self._assert_matches_reference(model, 2, gate_name, unitary, (0, 1))
+                    self._assert_matches_reference(model, 2, gate_name, unitary, (1, 0))
+
+    def test_two_qubit_gate_orderings_differ(self):
+        # A weaker but more legible statement of the same thing, and the exact symptom that was
+        # reported: the two orderings used to come out bit-identical.
+        for gate_type in self.GATE_TYPES:
+            with self.subTest(gate_type=gate_type):
+                model = self._model(2, 'Gcnot', gate_type)
+                forward = model.operations[('Gcnot', 0, 1)].to_dense('HilbertSchmidt')
+                reverse = model.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt')
+                self.assertGreater(np.linalg.norm(forward - reverse), 1e-6)
+
+    def test_symmetric_gate_orderings_agree(self):
+        # The flip side, and a large part of why this went unnoticed: SWAP *is* invariant under
+        # exchanging its targets, so it looks correct no matter what the embedding code does.
+        model = self._model(2, 'Gswap', 'static')
+        self.assertArraysAlmostEqual(model.operations[('Gswap', 0, 1)].to_dense('HilbertSchmidt'),
+                                     model.operations[('Gswap', 1, 0)].to_dense('HilbertSchmidt'))
+
+    def test_three_qubit_model_respects_target_order(self):
+        # The control case: with a spectator qubit present the dimensions no longer coincide, so
+        # this path was always correct.  Kept so that a future "simplification" can't break it.
+        unitary = std_unitaries()['Gcnot']
+        for gate_type in self.GATE_TYPES_3Q:
+            model = self._model(3, 'Gcnot', gate_type)
+            for targets in ((0, 1), (1, 0), (0, 2), (2, 0), (1, 2), (2, 1)):
+                with self.subTest(gate_type=gate_type, targets=targets):
+                    self._assert_matches_reference(model, 3, 'Gcnot', unitary, targets)
+
+    def test_nonstandard_gate_respects_target_order(self):
+        # Exercises the `stdname is None` path through create_from_unitary_mx: an asymmetric
+        # two-qubit unitary that isn't in the standard gate table at all.
+        unitary = np.array([[1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 1],
+                            [0, 0, 1j, 0]], dtype=complex)
+        for gate_type in self.GATE_TYPES:
+            with self.subTest(gate_type=gate_type):
+                model = self._model(2, 'Gtest', gate_type, nonstd_gate_unitaries={'Gtest': unitary})
+                self._assert_matches_reference(model, 2, 'Gtest', unitary, (0, 1))
+                self._assert_matches_reference(model, 2, 'Gtest', unitary, (1, 0))
+
+    def test_permuted_gate_survives_copy_and_serialization(self):
+        # `ExplicitOpModel` stores fully-embedded operations under partial/permuted keys, and both
+        # copy() and load-from-serialization re-insert them through OrderedMemberDict.__setitem__.
+        # Re-embedding them there would permute the gate again on every round trip.
+        for gate_type in ('static', 'CPTPLND'):
+            with self.subTest(gate_type=gate_type):
+                model = self._model(2, 'Gcnot', gate_type)
+                original = model.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt').copy()
+                self.assertArraysAlmostEqual(
+                    model.copy().operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt'), original)
+                reloaded = pygsti.models.ExplicitOpModel.loads(model.dumps())
+                self.assertArraysAlmostEqual(
+                    reloaded.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt'), original)
+
+    def test_permuted_gate_simulates_correctly(self):
+        # End-to-end: probabilities computed through the forward simulator, not just to_dense().
+        # Starting from |01>, Gcnot:1:0 (control = qubit 1) flips qubit 0 and gives |11>, while
+        # Gcnot:0:1 (control = qubit 0) leaves the state alone.  Before the fix both gave |01>.
+        model = self._model(2, 'Gcnot', 'static')
+        prep_01 = [('Gxpi2', 1), ('Gxpi2', 1)]  # |00> -> |01>
+        probs_reversed = model.probabilities(
+            pygsti.circuits.Circuit(prep_01 + [('Gcnot', 1, 0)], line_labels=(0, 1)))
+        self.assertAlmostEqual(probs_reversed['11'], 1.0, places=6)
+        probs_forward = model.probabilities(
+            pygsti.circuits.Circuit(prep_01 + [('Gcnot', 0, 1)], line_labels=(0, 1)))
+        self.assertAlmostEqual(probs_forward['01'], 1.0, places=6)
 
 
 

--- a/test/unit/modelmembers/test_operation.py
+++ b/test/unit/modelmembers/test_operation.py
@@ -237,6 +237,63 @@ class StaticStdOpTester(BaseCase):
             op.StaticStandardOp('Gi', 'pp', 'not_an_evotype')
 
 
+class CreateFromUnitaryMxStdnameTester(BaseCase):
+    """
+    `create_from_unitary_mx`'s 'static standard' branch builds a `StaticStandardOp` from `stdname`
+    alone and never looks at `unitary_mx`.  It may therefore only be taken when the two agree --
+    otherwise the caller's unitary is silently thrown away.
+    """
+
+    #: CNOT with the roles of the two qubits exchanged; still "a CNOT", but not *the* standard one.
+    REVERSED_CNOT = np.array([[1, 0, 0, 0],
+                              [0, 0, 0, 1],
+                              [0, 0, 1, 0],
+                              [0, 1, 0, 0]], dtype=complex)
+
+    PREFS = ('static standard', 'static unitary')
+
+    def test_matching_stdname_yields_static_standard_op(self):
+        U = itgs.standard_gatename_unitaries()['Gcnot']
+        created = op.create_from_unitary_mx(U, self.PREFS, 'pp', 'Gcnot')
+        self.assertIsInstance(created, op.StaticStandardOp)
+        self.assertArraysAlmostEqual(created.to_dense('HilbertSchmidt'), gt.unitary_to_pauligate(U))
+
+    def test_mismatched_stdname_is_ignored(self):
+        created = op.create_from_unitary_mx(self.REVERSED_CNOT, self.PREFS, 'pp', 'Gcnot')
+        self.assertNotIsInstance(created, op.StaticStandardOp)
+        self.assertArraysAlmostEqual(created.to_dense('HilbertSchmidt'),
+                                     gt.unitary_to_pauligate(self.REVERSED_CNOT))
+
+    def test_mismatched_stdname_is_ignored_for_lindblad_postfactor(self):
+        # The Lindblad types build a static unitary postfactor by recursing into
+        # create_from_unitary_mx with the same stdname, so the check has to hold there too.
+        created = op.create_from_unitary_mx(self.REVERSED_CNOT, 'CPTPLND', 'pp', 'Gcnot')
+        self.assertArraysAlmostEqual(created.to_dense('HilbertSchmidt'),
+                                     gt.unitary_to_pauligate(self.REVERSED_CNOT))
+
+    def test_stdname_of_wrong_dimension_is_ignored(self):
+        U = itgs.standard_gatename_unitaries()['Gxpi2']  # 1-qubit name, 2-qubit unitary
+        created = op.create_from_unitary_mx(self.REVERSED_CNOT, self.PREFS, 'pp', 'Gxpi2')
+        self.assertNotIsInstance(created, op.StaticStandardOp)
+        self.assertArraysAlmostEqual(created.to_dense('HilbertSchmidt'),
+                                     gt.unitary_to_pauligate(self.REVERSED_CNOT))
+
+    def test_unknown_stdname_is_ignored(self):
+        U = itgs.standard_gatename_unitaries()['Gxpi2']
+        created = op.create_from_unitary_mx(U, self.PREFS, 'pp', 'ThisIsNotAGateName')
+        self.assertNotIsInstance(created, op.StaticStandardOp)
+        self.assertArraysAlmostEqual(created.to_dense('HilbertSchmidt'), gt.unitary_to_pauligate(U))
+
+    def test_parameterized_stdname_is_ignored(self):
+        # 'Gzr' and friends map to *functions* in the standard gate table, so there is no matrix to
+        # compare against -- and StaticStandardOp raises a TypeError (which create_from_unitary_mx
+        # does not catch) if one tries anyway.
+        U = itgs.standard_gatename_unitaries()['Gzpi2']
+        created = op.create_from_unitary_mx(U, self.PREFS, 'pp', 'Gzr')
+        self.assertNotIsInstance(created, op.StaticStandardOp)
+        self.assertArraysAlmostEqual(created.to_dense('HilbertSchmidt'), gt.unitary_to_pauligate(U))
+
+
 class FullOpTester(MutableDenseOpBase, BaseCase):
     n_params = 16
 

--- a/test/unit/objects/test_explicitmodel.py
+++ b/test/unit/objects/test_explicitmodel.py
@@ -4,13 +4,14 @@ import numpy.testing as npt
 import scipy.linalg as la
 import pytest
 
+import pygsti
 import pygsti.models.explicitmodel as mdl
 from pygsti.baseobjs import ExplicitStateSpace
 from pygsti.models.modelconstruction import create_explicit_model_from_expressions, create_operation
 from pygsti.models.explicitmodel import transform_composed_model
 from pygsti.models.gaugegroup import UnitaryGaugeGroupElement
 from pygsti.modelmembers.instruments import Instrument, TPInstrument
-from pygsti.modelmembers.operations import ComposedOp
+from pygsti.modelmembers.operations import ComposedOp, EmbeddedOp, StaticArbitraryOp
 from pygsti.modelpacks.legacy import std1Q_XYI as std
 import pygsti.modelpacks.smq1Q_XYI as smq1Q_XYI
 from pygsti.tools.optools import unitary_to_pauligate
@@ -288,3 +289,60 @@ class Test_TransformComposedModelInstrument(BaseCase):
             expected = invU @ orig_op @ U_mx
             npt.assert_allclose(result.instruments['Itp'][ek].to_dense(), expected,
                                 atol=1e-12, err_msg=f'TPInstrument member {ek!r}')
+
+
+class AutoEmbedTester(BaseCase):
+    """
+    Tests for `ExplicitOpModel._embed_operation`, i.e. the auto-embedding that
+    `OrderedMemberDict.__setitem__` performs when a key carries state-space labels.
+    """
+
+    CNOT_01 = unitary_to_pauligate(np.array([[1, 0, 0, 0],
+                                             [0, 1, 0, 0],
+                                             [0, 0, 0, 1],
+                                             [0, 0, 1, 0]], dtype=complex))
+    CNOT_10 = unitary_to_pauligate(np.array([[1, 0, 0, 0],
+                                             [0, 0, 0, 1],
+                                             [0, 0, 1, 0],
+                                             [0, 1, 0, 0]], dtype=complex))
+
+    def setUp(self):
+        pspec = pygsti.processors.QubitProcessorSpec(2, ('Gxpi2', 'Gypi2', 'Gcnot'),
+                                                     availability={'Gcnot': 'all-permutations'})
+        self.model = pygsti.models.modelconstruction.create_explicit_model(
+            pspec, ideal_gate_type='static', ideal_spam_type='static')
+
+    def test_subsystem_operation_is_embedded(self):
+        # A one-qubit operation assigned under a two-qubit model's ('Gy', 1) key gets embedded
+        # onto qubit 1, leaving qubit 0 alone.
+        one_qubit_y = unitary_to_pauligate(la.expm(-1j * (np.pi / 4) * np.array([[0, -1j], [1j, 0]])))
+        # Note the operation has to be handed over as a one-qubit ModelMember: a bare numpy array is
+        # cast onto the *parent's* state space by OrderedMemberDict.cast_to_model_member.
+        self.model.operations[('Gtest', 1)] = StaticArbitraryOp(
+            one_qubit_y, 'pp', 'default', ExplicitStateSpace([1], [2]))
+        stored = self.model.operations[('Gtest', 1)]
+        self.assertIsInstance(stored, EmbeddedOp)
+        npt.assert_allclose(stored.to_dense('HilbertSchmidt'),
+                            np.kron(np.eye(4), one_qubit_y), atol=1e-12)
+
+    def test_full_state_space_operation_is_stored_verbatim(self):
+        # An operation that already spans the model's full state space is taken to be *already*
+        # embedded, whatever the key's state-space labels say.  This is what lets an
+        # ExplicitOpModel round-trip through copy() and serialization: both re-insert every
+        # (already-embedded) operation under its original, possibly permuted, key.  Re-embedding
+        # here would apply the permutation a second time on each round trip.
+        self.model.operations[('Gcnot', 1, 0)] = self.CNOT_01
+        npt.assert_allclose(self.model.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt'),
+                            self.CNOT_01, atol=1e-12)
+
+    def test_construction_and_round_trips_agree(self):
+        # The corollary that actually matters to users: the value `create_explicit_model` puts
+        # under a permuted key is the correctly permuted gate, and it stays that way.
+        npt.assert_allclose(self.model.operations[('Gcnot', 0, 1)].to_dense('HilbertSchmidt'),
+                            self.CNOT_01, atol=1e-12)
+        npt.assert_allclose(self.model.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt'),
+                            self.CNOT_10, atol=1e-12)
+        for round_tripped in (self.model.copy(),
+                              pygsti.models.ExplicitOpModel.loads(self.model.dumps())):
+            npt.assert_allclose(round_tripped.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt'),
+                                self.CNOT_10, atol=1e-12)

--- a/test/unit/objects/test_model_updates_after_creation.py
+++ b/test/unit/objects/test_model_updates_after_creation.py
@@ -13,6 +13,7 @@ from pygsti.tools import slicetools as _slct
 from pygsti.modelmembers.operations import ComposedOp, EmbeddedOp
 from pygsti.algorithms import BuiltinBasis
 from pygsti.modelmembers.operations import create_from_unitary_mx
+from pygsti.tools.internalgates import standard_gatename_unitaries
 
 from ..util import BaseCase
 
@@ -111,8 +112,10 @@ class TestRebuildParamVec(BaseCase):
                                                                         state_space=QubitSpace(1),
                                                                         evotype='densitymx')
 
-            comp = ComposedOp([create_from_unitary_mx(np.eye(2), "static standard",
-                                                      stdname=gate_name),
+            # Note: the unitary and `stdname` have to agree -- create_from_unitary_mx's
+            # 'static standard' branch is only taken when they do.
+            comp = ComposedOp([create_from_unitary_mx(standard_gatename_unitaries()[gate_name],
+                                                      "static standard", stdname=gate_name),
                                ExpErrorgenOp(my_lindbladian)])
             comp1 = comp.copy()
 


### PR DESCRIPTION
*The following was written by a robot. I've done some preliminary validation. I'm keeping this disclaimer up until I can do a more thorough inspection. Thanks to @omaupin for reporting this bug.*

*Ping @sserita and @coreyostrove. My 4x10 schedule will have me not working tomorrow. I'd welcome independent review by either of you. I think this will warrant a quick turn-around bugfix release.*

------------------------------------------------

On an *n*-qubit `ExplicitOpModel`, an *n*-qubit gate placed on a permuted target ordering was built without applying the permutation. The two-qubit case is the one that bites:

```python
pspec = QubitProcessorSpec(2, ['Gh', 'Gp', 'Gcnot'], availability={'Gcnot': 'all-permutations'})
model = create_explicit_model(pspec, ideal_gate_type='CPTPLND', ideal_spam_type='CPTPLND')
np.linalg.norm(model['Gcnot:0:1'].to_dense() - model['Gcnot:1:0'].to_dense())  # 0.0
```

Both labels return the *same* superoperator — the standard CNOT — so `Gcnot:1:0` silently has its control and target exchanged. Every simulated probability, every fit, and every reported error rate involving such a gate is wrong. Symmetric gates (`Gswap`, `Gcphase`) are unaffected in practice, which is probably a good part of why this survived so long.

The symptom is not specific to `CPTPLND`: `ideal_gate_type='static'` is equally wrong, as are `'full'`, `'full TP'`, `'static unitary'`, and the rest. Nor does it depend on the gate being a CNOT — any order-sensitive gate on a model it exactly fills is affected, including non-standard ones supplied through `nonstd_gate_unitaries`.

`git blame` puts the introducing commit at `5277b1a3f` (August 2021), so this has been present in **every release from v0.9.10 (2021-10-03) through v0.10.2**. A companion write-up of the release archaeology is stored locally on Riley's machine.

## Two independent causes

Both are "no need to embed" fast paths, and both have to go.

**1. `models/modelconstruction.py` — the dimension-only shortcut.** In `_create_explicit_model`:

```python
if gate_unitary.shape[0] == state_space.udim:  # no need to embed!
    embedded_unitary = gate_unitary
else:
    embedded_unitary = _embed_unitary(state_space, inds, gate_unitary)
```

This tests total dimension, but the thing that decides whether embedding is needed is whether `inds` matches the model's own qudit ordering. When the gate fills the model, the dimensions agree for *every* permutation of `inds`, so `_embed_unitary` — which is the code that actually applies the permutation — never runs.

The correct, order-sensitive test was already sitting one scope up: this whole block is the `else` of `if inds is None or inds == tuple(qudit_labels)`. So by the time control reaches the shortcut, `inds` is *known* to be a non-trivial ordering and the shortcut can only ever fire on a case that needs permuting. It is now deleted and `_embed_unitary` is called unconditionally.

**2. `modelmembers/operations/__init__.py` — `create_from_unitary_mx` discarding its unitary.** The `'static standard'` branch:

```python
if typ == 'static standard' and stdname is not None:
    op = StaticStandardOp(stdname, basis, evotype, state_space)
```

`StaticStandardOp` reconstructs the gate from the name via `standard_gatename_unitaries()` and never looks at `unitary_mx`. So a caller that passes a correctly permuted CNOT along with `stdname='Gcnot'` gets the *unpermuted* CNOT back. The branch is now taken only when the name and the unitary agree, and otherwise falls through to the unitary-respecting preferences (`'static clifford'` / `'static unitary'`).

Validating in the callee rather than at the one call site seemed clearly right here: `create_from_unitary_mx` is shared, and silently ignoring an argument is a trap for every future caller. The check skips continuously-parameterized standard gates (`Gzr`, `Gczr`, `Gu3`), whose table entries are functions rather than matrices; incidentally that also removes an uncaught `TypeError` that `StaticStandardOp` would otherwise raise on those names.

It's a trap we'd already walked into, in fact: `test/unit/objects/test_model_updates_after_creation.py` called `create_from_unitary_mx(np.eye(2), "static standard", stdname="Gypi2")` and got a `Gypi2` back, the identity argument being a placeholder for a value it knew would be ignored. That call now passes the actual `Gypi2` unitary. It's the only such caller in the tree.

**The two fixes have to land together.** Fixing only `#1` doesn't produce a subtly wrong model — it produces a hard failure. With the permutation restored, `create_from_unitary_mx` hands the permuted unitary to `StaticStandardOp`, gets the unpermuted standard gate back as the Lindblad postfactor, and then trips the consistency assertion a few lines later:

```
ValueError: Could not create an operator of type(s) CPTPLND from the given unitary op:
{'CPTPLND': "Failure to create Lindblad operation (maybe due the complex log's branch cut?)"}
```

Worth knowing if anyone bisects this.

## What I deliberately did *not* change

`ExplicitOpModel._embed_operation` looks like a third instance of the same mistake, and I originally intended to fix it:

```python
if op_val.state_space == self.state_space and not force:
    return op_val  # if gate operates on full dimension, no need to embed.
```

The user-visible consequence is real: `model.operations[('Gcnot', 1, 0)] = <4x4 superop>` stores the operator verbatim on a 2-qubit model, but embeds (correctly, with the permutation) on a 3-qubit one — identical code, different answer depending on how many spectator qubits exist.

But the shortcut turns out to be load-bearing, and not only for the constructor. `ExplicitOpModel` stores every operation on its full state space, under keys that may name a subset of qudits or a permutation of them. `OrderedMemberDict.__setitem__` — and therefore `update`, `copy`, and `_from_nice_serialization` — re-inserts those already-embedded operations under their original keys. Removing the shortcut makes `create_explicit_model` fail outright (a 1-qubit gate's key has fewer target labels than the model has qudits, so `EmbeddedOp`'s constructor asserts), and would re-apply the permutation on every copy and every save/load round trip for the full-span case.

The ambiguity is genuine and can't be resolved at this layer: given a full-state-space operation and a target-label list, nothing distinguishes "already embedded" from "local, needs embedding." Resolving it properly needs an insertion API that says which one the caller means, threaded through the constructor, `update`, `copy`, and deserialization — a bigger change than this bug fix, and one I'd rather not smuggle in. For now the contract is spelled out in a comment at the call site, and pinned by tests (`AutoEmbedTester`) so a future reader doesn't "fix" it and break every round trip.

## Tests

- `test/unit/construction/test_modelconstruction.py::TargetQubitOrderingTester` — the main regression coverage. Every constructed gate is checked against a hand-written reference embedding (`_embed_unitary_by_hand`, built by summing over matrix units; it shares no code with pyGSTi), swept over `{'auto', 'static', 'static unitary', 'full', 'full TP', 'CPTPLND', 'H+S'}`. `'auto'` is both the default and the only entry that reaches the `StaticStandardOp` branch at all. Covers: 2-qubit models with `Gcnot` and `Gecr`; the non-standard-gate path; the 3-qubit control case that always worked; `Gswap` as the permutation-invariant foil; a forward-simulated probability rather than just `to_dense()`; and copy/serialization round trips.
- `test/unit/modelmembers/test_operation.py::CreateFromUnitaryMxStdnameTester` — unit coverage for the `stdname` check: matching name, mismatched name, mismatched name through the Lindblad postfactor recursion, wrong dimension, unknown name, and a parameterized (callable) name.
- `test/unit/objects/test_explicitmodel.py::AutoEmbedTester` — pins the auto-embed contract discussed above.

Against unfixed `develop` these produce 33 failures; all pass with the fix. Total added runtime is about 4 seconds. (3-qubit `CPTPLND` is excluded from the sweep purely on cost — that one model takes ~40s to build — with `H+S` covering the same Lindblad path.)

## Testing

Full `test/unit` suite, py313:

```
python -m pytest test/unit -q
# 3272 passed, 96 skipped, 2 xfailed, 82 warnings, 212 subtests passed in 296.19s (0:04:56)
```
