### PR TITLE
Fix nongauge parameter override in initial greedy germ-set test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Fixed the `is_trace_preserving` utility function for bases whose first element is the identity. The utility function was only used in report generation and the bug did not affect the correctness of its caller.
+* Fixed germ selection ignoring the user-specified number of non-gauge parameters.
 
 ## [0.10.2] - 2026-07-30
 

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -4132,6 +4132,7 @@ def find_germs_breadthfirst_greedy(model_list: list[Model], germs_list: list[_ci
         printer.log('Testing initial germ list for AC.', 2)
         initial_germ_set_completeness = test_germs_list_completeness(model_list, goodGerms,
                                                                      score_func, threshold,
+                                                                     num_gauge_params=numGaugeParams,
                                                                      float_type=float_type,
                                                                      comm=comm)
         if initial_germ_set_completeness == -1:


### PR DESCRIPTION
Hi PyGSTi team,

The initial germ-set completeness check ignored `num_nongauge_params`, which could terminate germ selection early. This fix forwards the corresponding gauge-parameter count to the check.

I hope this fix is helpful.