### PR TITLE
Fix crash when skipping the initial germ test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Fixed the `is_trace_preserving` utility function for bases whose first element is the identity. The utility function was only used in report generation and the bug did not affect the correctness of its caller.
+* Fixed a crash when the initial germ test is skipped.
 
 ## [0.10.2] - 2026-07-30
 

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -4146,7 +4146,7 @@ def find_germs_breadthfirst_greedy(model_list: list[Model], germs_list: list[_ci
             first_outer_iter_log= True
             printer.log('Initial germ list is not AC, beginning greedy search loop.', 2)
     else:
-        initN=None
+        initN = 1
         first_outer_iter_log= True
     
     while _np.any(weights == 0):

--- a/test/unit/algorithms/test_germselection.py
+++ b/test/unit/algorithms/test_germselection.py
@@ -361,6 +361,15 @@ class GreedyGermSelectionTester(GermSelectionWithNeighbors, BaseCase):
         )
         # TODO assert correctness
 
+    def test_build_up_breadth_skips_initial_germ_set_test(self):
+        germs = germsel.find_germs_breadthfirst_greedy(
+            self.neighbors,
+            self.germ_set,
+            initial_germ_set_test=False,
+            **self.options
+        )
+        self.assertIsNotNone(germs)
+
     def test_build_up_breadth_force_strings(self):
         forceStrs = [Circuit([Label('Gxpi2',0)], line_labels = (0,)),
                     Circuit([Label('Gypi2',0)], line_labels = (0,))]


### PR DESCRIPTION
Skipping the initial germ test set `initN` to `None` and caused a `TypeError`. This change sets `initN` to `1` so germ selection can continue.