### PR TITLE
Fix two UnboundLocalError bugs in errgenproptools.py's A-type-generator code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,7 @@
 * Fixed the `is_trace_preserving` utility function for bases whose first element is the identity. The utility function was only used in report generation and the bug did not affect the correctness of its caller.
 * Fixed a crash when the initial germ test is skipped.
 * Fixed germ selection ignoring the user-specified number of non-gauge parameters.
-* Fixed two `UnboundLocalError` bugs in `pygsti.tools.errgenproptools` affecting 'A'-type (active) error generators: `slow_bulk_alpha` assigned its weight-1 anticommuting-Pauli result to the whole return array instead of the per-iteration local (masked whenever the Cython `fasterrgencalc` extension is built, since `bulk_alpha` then aliases the Cython implementation), and `error_generator_commutator`'s 'S'-'A' branch referenced an undefined `ptup` instead of `ptup1`. (#PLACEHOLDER) <!-- TODO: fill in actual PR number before merge -->
+* Fixed two `UnboundLocalError` bugs in `pygsti.tools.errgenproptools` affecting 'A'-type (active) error generators: `slow_bulk_alpha` assigned its weight-1 anticommuting-Pauli result to the whole return array instead of the per-iteration local (masked whenever the Cython `fasterrgencalc` extension is built, since `bulk_alpha` then aliases the Cython implementation), and `error_generator_commutator`'s 'S'-'A' branch referenced an undefined `ptup` instead of `ptup1`. (#876)
 
 ## [0.10.2] - 2026-07-30
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 * Fixed the `is_trace_preserving` utility function for bases whose first element is the identity. The utility function was only used in report generation and the bug did not affect the correctness of its caller.
 * Fixed a crash when the initial germ test is skipped.
 * Fixed germ selection ignoring the user-specified number of non-gauge parameters.
+* Fixed two `UnboundLocalError` bugs in `pygsti.tools.errgenproptools` affecting 'A'-type (active) error generators: `slow_bulk_alpha` assigned its weight-1 anticommuting-Pauli result to the whole return array instead of the per-iteration local (masked whenever the Cython `fasterrgencalc` extension is built, since `bulk_alpha` then aliases the Cython implementation), and `error_generator_commutator`'s 'S'-'A' branch referenced an undefined `ptup` instead of `ptup1`. (#PLACEHOLDER) <!-- TODO: fill in actual PR number before merge -->
 
 ## [0.10.2] - 2026-07-30
 

--- a/pygsti/tools/errgenproptools.py
+++ b/pygsti/tools/errgenproptools.py
@@ -976,7 +976,7 @@ def error_generator_commutator(errorgen_1, errorgen_2, flip_weight=False, weight
                 new_bels = [ptup1[1], ptup2[1]] if stim_pauli_string_less_than(ptup1[1], ptup2[1]) else [ptup2[1], ptup1[1]]
                 errorgens.append((_LSE('C', new_bels), 1j*w*ptup1[0]*ptup2[0]))
         else:
-            if ptup[1] != identity:
+            if ptup1[1] != identity:
                 errorgens.append((_LSE('S', [ptup1[1]]), 2*1j*w*ptup1[0]*ptup2[0]))
 
         ptup1 = pauli_product(errorgen_1_bel_0, errorgen_2_bel_1)
@@ -986,7 +986,7 @@ def error_generator_commutator(errorgen_1, errorgen_2, flip_weight=False, weight
                 new_bels = [ptup1[1], ptup2[1]] if stim_pauli_string_less_than(ptup1[1], ptup2[1]) else [ptup2[1], ptup1[1]]
                 errorgens.append((_LSE('C', new_bels), -1j*w*ptup1[0]*ptup2[0]))
         else:
-            if ptup[1] != identity:
+            if ptup1[1] != identity:
                 errorgens.append((_LSE('S', [ptup1[1]]), -2*1j*w*ptup1[0]*ptup2[0]))
         
         ptup1 = com(errorgen_2_bel_0, errorgen_2_bel_1)
@@ -8024,7 +8024,7 @@ def slow_bulk_alpha(errorgens: Iterable[_LSE], tableau: stim.Tableau, desired_bi
                 sensitivity = 2*phis[running_phi_index].imag
                 running_phi_index+=1
             else: # A1, includes additional term because P and Q anticommuted
-                sensitivities_by_bitstring = 2*(phis[running_phi_index] + phis[running_phi_index+1]).imag
+                sensitivity = 2*(phis[running_phi_index] + phis[running_phi_index+1]).imag
                 running_phi_index+=2
             sensitivities_by_bitstring[i,j] = sensitivity
 

--- a/test/unit/tools/test_errgenproptools.py
+++ b/test/unit/tools/test_errgenproptools.py
@@ -76,7 +76,37 @@ class ErrgenCompositionCommutationTester(BaseCase):
                 print('analytic_commutator_mat=')
                 print_mx(analytic_commutator_mat)
                 raise ValueError()
-                
+
+    def test_errorgen_commutator_S_A_degenerate_case(self):
+        # Regression test for a bug in error_generator_commutator's 'S'-'A' branch: it referenced
+        # an undefined local variable `ptup` (should have been `ptup1`) inside the
+        # `if ptup1[1] == ptup2[1]:` branch (two occurrences), causing an UnboundLocalError. This
+        # branch is only reached when, for single-qubit Paulis P (the S generator's own Pauli) and
+        # the A generator's basis elements Q1,Q2, the (unsigned) products P*Q1 and Q2*P coincide --
+        # which, since unsigned single-qubit Pauli multiplication is abelian and P is invertible,
+        # requires Q1 == Q2. A well-formed A_{Q1,Q2} generator requires Q1 != Q2 (see "A Taxonomy of
+        # Small Errors", Sec. V.D), so this is only reachable for a malformed/degenerate A(Q,Q)
+        # label -- which nothing in LocalStimErrorgenLabel's constructor currently prevents one from
+        # constructing. This test confirms the fix (the typo'd `ptup` -> `ptup1`) so this code path
+        # no longer crashes with an UnboundLocalError.
+        s_label = _LSE('S', [stim.PauliString('Z')])
+        degenerate_a_label = _LSE('A', [stim.PauliString('X'), stim.PauliString('X')])
+        # Should not raise UnboundLocalError.
+        result = _eprop.error_generator_commutator(s_label, degenerate_a_label)
+        self.assertIsInstance(result, list)
+
+        # Also confirm well-formed (non-degenerate) S,A pairs still work correctly (regression
+        # check against the numerical ground truth, since this exact pairing wasn't necessarily
+        # hit by test_errorgen_commutators's 2-qubit complete-basis sweep above).
+        errorgen_basis = CompleteElementaryErrorgenBasis('PP', QubitSpace(2), default_label_type='local')
+        errorgen_lbl_matrix_dict = {lbl: mat for lbl, mat in zip(errorgen_basis.labels, errorgen_basis.elemgen_matrices)}
+        s_lbl = LEEL('S', ('XI',))
+        a_lbl = LEEL('A', ('IX', 'YY'))
+        numeric_commutator = _eprop.error_generator_commutator_numerical(s_lbl, a_lbl, errorgen_lbl_matrix_dict)
+        analytic_commutator = _eprop.error_generator_commutator(_LSE.cast(s_lbl), _LSE.cast(a_lbl))
+        analytic_commutator_mat = _eprop.errorgen_layer_to_matrix(analytic_commutator, 2, errorgen_lbl_matrix_dict)
+        self.assertLess(np.linalg.norm(numeric_commutator - analytic_commutator_mat), 1e-10)
+
     def test_errorgen_composition(self):
         
         #create an error generator basis.
@@ -455,6 +485,39 @@ class ApproxStabilizerMethodTester(BaseCase):
                     print(f'{_eprop.bulk_alpha(errorgen_labels, ckt_tableau, [bitstring])=}')
                     print(f'{_compute_alphas(errorgen_labels, ckt_tableau, bitstring)=}')
                     raise ValueError('Bulk and individually computed alpha values are different.')
+
+    def test_slow_bulk_alpha_weight_1_active_generators(self):
+        # Regression test for a bug in the pure-Python `slow_bulk_alpha` fallback (the function
+        # used whenever the Cython `fasterrgencalc` extension is unavailable -- `bulk_alpha` is
+        # simply aliased to the Cython `fast_bulk_alpha` when it *is* available, which silently
+        # masks this bug in the common case). The "A1" branch (weight-1 'A'-type generators whose
+        # two Paulis anticommute -- i.e. essentially *every* weight-1 A-type generator, since any
+        # two distinct single-qubit Paulis anticommute) assigned to `sensitivities_by_bitstring`
+        # (the function's entire return array) instead of the per-iteration local `sensitivity`,
+        # which was then read on the very next line -- an UnboundLocalError. This test calls
+        # `slow_bulk_alpha` directly (bypassing the Cython alias) to exercise the actual
+        # pure-Python code path, regardless of whether the Cython extension happens to be built
+        # in the current environment.
+        tableau = stim.PauliString('XI').to_tableau()
+        errgen = _LSE('A', [stim.PauliString('X'), stim.PauliString('Y')])
+        bitstrings = ['00', '01', '10', '11']
+        for bitstring in bitstrings:
+            expected = _eprop.alpha(errgen, tableau, bitstring)
+            result = _eprop.slow_bulk_alpha([errgen], tableau, [bitstring])
+            self.assertAlmostEqual(result[0, 0], expected)
+
+        # Also check a weight-2+ random sample from a complete 3-qubit basis, restricted to A-type
+        # generators, for good measure (both anticommuting and commuting P,Q sub-cases).
+        errorgen_basis = CompleteElementaryErrorgenBasis('PP', QubitSpace(3), default_label_type='local',
+                                                          elementary_errorgen_types=('A',))
+        rng = np.random.default_rng(0)
+        random_errorgens = rng.choice(np.fromiter(errorgen_basis.labels, dtype=object), size=20, replace=False)
+        errorgen_labels = [_LSE.cast(lbl) for lbl in random_errorgens]
+        tableau_3q = stim.Tableau.random(3)
+        for bitstring in [''.join(p) for p in product(['0', '1'], repeat=3)]:
+            expected = [_eprop.alpha(eg, tableau_3q, bitstring) for eg in errorgen_labels]
+            result = _eprop.slow_bulk_alpha(errorgen_labels, tableau_3q, [bitstring])
+            np.testing.assert_allclose(result[0, :], expected, atol=1e-10)
 
     def test_alpha_pauli(self):
         from pygsti.modelpacks import smq2Q_XYCPHASE


### PR DESCRIPTION
### Summary

Two independent, pre-existing typo bugs in `pygsti/tools/errgenproptools.py` raise an `UnboundLocalError` for code paths involving 'A' (active) type error generators:

```python
from pygsti.tools import errgenproptools as _eprop
from pygsti.errorgenpropagation.localstimerrorgen import LocalStimErrorgenLabel as _LSE
import stim

tableau = stim.PauliString('XI').to_tableau()
errgen = _LSE('A', [stim.PauliString('X'), stim.PauliString('Y')])
_eprop.slow_bulk_alpha([errgen], tableau, ['00'])
# UnboundLocalError: cannot access local variable 'sensitivity'
```

### Root cause

1. `slow_bulk_alpha`'s "A1" branch (weight-1 'A'-type generators whose two Paulis anticommute -- i.e. *every* weight-1 A-type generator, since any two distinct single-qubit Paulis anticommute) assigned its result to `sensitivities_by_bitstring` -- the function's entire return array -- instead of the per-iteration local `sensitivity`, which is read on the very next line.
2. `error_generator_commutator`'s 'S'-'A' branch referenced an undefined local `ptup` (should be `ptup1`) in two places.

Both are plain variable-name typos, unrelated to each other, both specific to 'A'-type error-generator code paths:

- Bug 1 is masked in most environments because `bulk_alpha` is aliased to the Cython `fast_bulk_alpha` whenever the `fasterrgencalc` extension is built (the common case) -- `slow_bulk_alpha` is only reached as the pure-Python fallback.
- Bug 2 is reachable only for a degenerate `A(Q,Q)` label (two equal Paulis), which nothing in `LocalStimErrorgenLabel`'s constructor currently forbids, even though a well-formed `A_{P,Q}` generator requires P != Q (see "A Taxonomy of Small Errors", Sec. V.D).

### The fix

Two one-token variable-name corrections -- `ptup` -> `ptup1` (x2) and `sensitivities_by_bitstring` -> `sensitivity` -- with no behavioral change beyond these code paths no longer crashing.

### Tests

New tests in `test/unit/tools/test_errgenproptools.py`:

| test | asserts |
|---|---|
| `test_slow_bulk_alpha_weight_1_active_generators` | calls `slow_bulk_alpha` directly (bypassing the Cython alias, so it exercises the actual pure-Python fallback regardless of whether Cython extensions are built) for all 4 bitstrings of a weight-1 A-type generator, matching the single-label `alpha`; also sweeps 20 randomly-sampled 3-qubit A-type generators against a random Clifford tableau |
| `test_errorgen_commutator_S_A_degenerate_case` | constructs the exact degenerate `A(P,P)` label scenario (no longer raises `UnboundLocalError`), plus a well-formed-pair regression check against `error_generator_commutator_numerical` |

Both were confirmed to fail with the exact `UnboundLocalError`s described above against the pre-fix code.

### Verification

```
pytest -q test/unit/tools/test_errgenproptools.py
# 27 passed in 177.05s

pytest -q test/unit/objects/test_errorgenpropagation.py
# 25 passed in 72.14s

pytest -q test/unit/tools/test_lindbladtools.py
# 13 passed in 0.30s

flake8 pygsti/tools/errgenproptools.py test/unit/tools/test_errgenproptools.py --config=.flake8-critical
# clean
```

### Context

Found while adding 'C'/'A' error-generator support to `pygsti.extras.ml` (#835) -- not on that subpackage's own call paths (it only ever calls the singular `errgenproptools.alpha`, never `bulk_alpha`/`slow_bulk_alpha`/`error_generator_commutator`), but hit while cross-validating `alpha()` against `bulk_alpha()` and exercising the wider A-type-generator surface during that work. Per @rileyjmurray's request on #835 ("please split them off into a dedicated PR that we can land before this one"), this is extracted the same way `0bdbb2830` was extracted to #865: a small, independently-reviewable core fix rather than incidental scope inside a large feature PR. #835 has a follow-up commit removing this change from its own diff.
