### PR TITLE
Fix EmbeddedOp local labels for non-trivial qubit labels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Fixed a crash when the initial germ test is skipped.
 * Fixed germ selection ignoring the user-specified number of non-gauge parameters.
 * Fixed two `UnboundLocalError` bugs in `pygsti.tools.errgenproptools` affecting 'A'-type (active) error generators: `slow_bulk_alpha` assigned its weight-1 anticommuting-Pauli result to the whole return array instead of the per-iteration local (masked whenever the Cython `fasterrgencalc` extension is built, since `bulk_alpha` then aliases the Cython implementation), and `error_generator_commutator`'s 'S'-'A' branch referenced an undefined `ptup` instead of `ptup1`. (#876)
+* Fixed `EmbeddedOp`/`EmbeddedErrorgen` local error-generator-label embedding (`label_type='local'`) for string or permuted-integer qubit labels, which previously raised `TypeError` or silently mis-embedded. (#878)
 
 ## [0.10.2] - 2026-07-30
 

--- a/pygsti/modelmembers/operations/embeddedop.py
+++ b/pygsti/modelmembers/operations/embeddedop.py
@@ -712,7 +712,7 @@ class EmbeddedOp(_LinearOperator, _Torchable):
                     new_bels = []
                     for bel in lbl.basis_element_labels:
                         base_label = [identity_label for _ in range(self.state_space.num_qudits)]
-                        for pos, pauli in zip(target_positions, bel):
+                        for pos, pauli in zip(target_positions, bel, strict=True):
                             base_label[pos] = pauli
                         new_bels.append(''.join(base_label))
                     embedded_labels.append(_LocalElementaryErrorgenLabel(lbl.errorgen_type, tuple(new_bels)))

--- a/pygsti/modelmembers/operations/embeddedop.py
+++ b/pygsti/modelmembers/operations/embeddedop.py
@@ -701,14 +701,19 @@ class EmbeddedOp(_LinearOperator, _Torchable):
                 self._cached_embedded_errorgen_labels_global = embedded_labels
             elif isinstance(labels_to_embed[0], _LocalElementaryErrorgenLabel):
                 #use different embedding scheme for local labels
+                #target_labels are this EmbeddedOp's target qubit *labels*, which may not be
+                #integer positions (e.g. string qubit labels, or permuted integer labels), so
+                #resolve each to its integer position in state_space.qubit_labels before using it
+                #to index the (plain-list) base_label.
+                target_positions = [self.state_space.qubit_labels.index(t) for t in self.target_labels]
                 embedded_labels = []
                 base_label = [identity_label for _ in range(self.state_space.num_qudits)]
                 for lbl in labels_to_embed:
                     new_bels = []
                     for bel in lbl.basis_element_labels:
                         base_label = [identity_label for _ in range(self.state_space.num_qudits)]
-                        for target, pauli in zip(self.target_labels, bel):
-                            base_label[target] = pauli
+                        for pos, pauli in zip(target_positions, bel):
+                            base_label[pos] = pauli
                         new_bels.append(''.join(base_label))
                     embedded_labels.append(_LocalElementaryErrorgenLabel(lbl.errorgen_type, tuple(new_bels)))
                 embedded_labels = tuple(embedded_labels)

--- a/test/unit/modelmembers/test_embeddedop.py
+++ b/test/unit/modelmembers/test_embeddedop.py
@@ -30,7 +30,7 @@ def test_errorgen_coefficient_labels_local_integer_qubit_labels_control():
     ss = QubitSpace(3)
     embedded = EmbeddedOp(ss, [1], _h_errorgen_op('X'))
     labels = embedded.errorgen_coefficient_labels(label_type='local')
-    assert labels == (LEEL('H', ('IXI',)),)
+    assert labels == (LEEL('H', ('IXI',)),), f'Expected IXI-embedded label, got {labels}'
 
 
 def test_errorgen_coefficient_labels_local_string_qubit_labels():
@@ -40,7 +40,7 @@ def test_errorgen_coefficient_labels_local_string_qubit_labels():
     ss = QubitSpace(['q2', 'q16', 'q22'])
     embedded = EmbeddedOp(ss, ['q16'], _h_errorgen_op('X'))
     labels = embedded.errorgen_coefficient_labels(label_type='local')
-    assert labels == (LEEL('H', ('IXI',)),)
+    assert labels == (LEEL('H', ('IXI',)),), f'Expected IXI-embedded label, got {labels}'
 
 
 def test_errorgen_coefficient_labels_local_permuted_integer_qubit_labels():
@@ -51,7 +51,7 @@ def test_errorgen_coefficient_labels_local_permuted_integer_qubit_labels():
     ss = QubitSpace([2, 0, 1])
     embedded = EmbeddedOp(ss, [2], _h_errorgen_op('X'))  # qubit label 2 is at position 0
     labels = embedded.errorgen_coefficient_labels(label_type='local')
-    assert labels == (LEEL('H', ('XII',)),)
+    assert labels == (LEEL('H', ('XII',)),), f'Expected XII-embedded label, got {labels}'
 
 
 def test_errorgen_coefficient_labels_local_two_qubit_target_out_of_order():
@@ -65,7 +65,7 @@ def test_errorgen_coefficient_labels_local_two_qubit_target_out_of_order():
     embedded = EmbeddedOp(ss, ['q5', 'q2'], ExpErrorgenOp(eg))
     labels = embedded.errorgen_coefficient_labels(label_type='local')
     # 'q5' ('X') is at position 2; 'q2' ('Y') is at position 0; 'q16' untouched.
-    assert labels == (LEEL('H', ('YIX',)),)
+    assert labels == (LEEL('H', ('YIX',)),), f'Expected YIX-embedded label, got {labels}'
 
 
 def test_errorgen_coefficients_local_string_qubit_labels_end_to_end():
@@ -76,8 +76,8 @@ def test_errorgen_coefficients_local_string_qubit_labels_end_to_end():
     ss = QubitSpace(['q2', 'q16', 'q22'])
     embedded = EmbeddedOp(ss, ['q16'], _h_errorgen_op('X', rate=0.15))
     coeffs = embedded.errorgen_coefficients(label_type='local')
-    assert set(coeffs.keys()) == {LEEL('H', ('IXI',))}
-    assert np.isclose(coeffs[LEEL('H', ('IXI',))], 0.15)
+    assert set(coeffs.keys()) == {LEEL('H', ('IXI',))}, f'Expected only IXI-embedded label, got {coeffs.keys()}'
+    assert np.isclose(coeffs[LEEL('H', ('IXI',))], 0.15), f'Expected rate 0.15, got {coeffs[LEEL("H", ("IXI",))]}'
 
 
 def test_embeddederrorgen_coefficient_labels_local_string_qubit_labels():
@@ -89,4 +89,4 @@ def test_embeddederrorgen_coefficient_labels_local_string_qubit_labels():
     ss = QubitSpace(['q2', 'q16', 'q22'])
     embedded = EmbeddedErrorgen(ss, ['q16'], eg)
     labels = embedded.coefficient_labels(label_type='local')
-    assert labels == (LEEL('H', ('IXI',)),)
+    assert labels == (LEEL('H', ('IXI',)),), f'Expected IXI-embedded label, got {labels}'

--- a/test/unit/modelmembers/test_embeddedop.py
+++ b/test/unit/modelmembers/test_embeddedop.py
@@ -1,0 +1,92 @@
+"""
+Regression tests for `EmbeddedOp.errorgen_coefficient_labels`/`errorgen_coefficients` with
+`label_type='local'`.
+
+`_embed_labels`'s local-label branch indexes a plain Python list (`base_label`) directly with
+entries of `self.target_labels`, which are the `EmbeddedOp`'s *target qubit labels* rather than
+their integer positions within `self.state_space`. This works by coincidence for state spaces
+with unpermuted integer qubit labels (where a label equals its own position), but raises
+`TypeError` for any state space with string qubit labels, and would silently mis-embed for a
+state space with permuted integer labels. These tests exercise both a string-labeled space (where
+the bug currently raises) and a permuted-integer-labeled space (where the bug would currently
+mis-embed silently), alongside an unpermuted-integer control that already passes today.
+"""
+import numpy as np
+
+from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as LEEL
+from pygsti.baseobjs.statespace import QubitSpace
+from pygsti.modelmembers.operations import EmbeddedErrorgen, EmbeddedOp, ExpErrorgenOp, LindbladErrorgen
+
+
+def _h_errorgen_op(pauli, rate=0.15, num_qubits=1):
+    """A single-qubit-or-more ExpErrorgenOp with one Hamiltonian-type local coefficient."""
+    eg = LindbladErrorgen.from_elementary_errorgens(
+        {LEEL('H', (pauli,)): rate}, parameterization='H', state_space=num_qubits)
+    return ExpErrorgenOp(eg)
+
+
+def test_errorgen_coefficient_labels_local_integer_qubit_labels_control():
+    """Control case: an unpermuted integer-labeled space, where the bug is a no-op today."""
+    ss = QubitSpace(3)
+    embedded = EmbeddedOp(ss, [1], _h_errorgen_op('X'))
+    labels = embedded.errorgen_coefficient_labels(label_type='local')
+    assert labels == (LEEL('H', ('IXI',)),)
+
+
+def test_errorgen_coefficient_labels_local_string_qubit_labels():
+    """String qubit labels: `_embed_labels` must resolve each target label to its integer
+    position in `state_space.qubit_labels` before indexing, not use the label itself as an index.
+    """
+    ss = QubitSpace(['q2', 'q16', 'q22'])
+    embedded = EmbeddedOp(ss, ['q16'], _h_errorgen_op('X'))
+    labels = embedded.errorgen_coefficient_labels(label_type='local')
+    assert labels == (LEEL('H', ('IXI',)),)
+
+
+def test_errorgen_coefficient_labels_local_permuted_integer_qubit_labels():
+    """Permuted integer qubit labels: a target label equal to a valid index, but not its own
+    position, would currently be silently mis-embedded (rather than raising) since `list`
+    indexing with an out-of-place-but-still-integer label doesn't error.
+    """
+    ss = QubitSpace([2, 0, 1])
+    embedded = EmbeddedOp(ss, [2], _h_errorgen_op('X'))  # qubit label 2 is at position 0
+    labels = embedded.errorgen_coefficient_labels(label_type='local')
+    assert labels == (LEEL('H', ('XII',)),)
+
+
+def test_errorgen_coefficient_labels_local_two_qubit_target_out_of_order():
+    """Two-qubit target whose labels appear out of order relative to `state_space.qubit_labels`,
+    to confirm each basis-element-string character is paired with its own target's resolved
+    position (not, e.g., accidentally paired via enumeration order).
+    """
+    ss = QubitSpace(['q2', 'q16', 'q5'])
+    eg = LindbladErrorgen.from_elementary_errorgens(
+        {LEEL('H', ('XY',)): 0.05}, parameterization='H', state_space=2)
+    embedded = EmbeddedOp(ss, ['q5', 'q2'], ExpErrorgenOp(eg))
+    labels = embedded.errorgen_coefficient_labels(label_type='local')
+    # 'q5' ('X') is at position 2; 'q2' ('Y') is at position 0; 'q16' untouched.
+    assert labels == (LEEL('H', ('YIX',)),)
+
+
+def test_errorgen_coefficients_local_string_qubit_labels_end_to_end():
+    """The full `errorgen_coefficients(label_type='local')` call chain (as used by
+    `pygsti.errorgenpropagation.errorpropagator.ErrorGeneratorPropagator`), not just the
+    label-construction helper in isolation.
+    """
+    ss = QubitSpace(['q2', 'q16', 'q22'])
+    embedded = EmbeddedOp(ss, ['q16'], _h_errorgen_op('X', rate=0.15))
+    coeffs = embedded.errorgen_coefficients(label_type='local')
+    assert set(coeffs.keys()) == {LEEL('H', ('IXI',))}
+    assert np.isclose(coeffs[LEEL('H', ('IXI',))], 0.15)
+
+
+def test_embeddederrorgen_coefficient_labels_local_string_qubit_labels():
+    """`EmbeddedErrorgen` overrides `coefficient_labels` (not `errorgen_coefficient_labels`) but
+    shares the same `_embed_labels` helper with `EmbeddedOp`, so it hits the identical bug.
+    """
+    eg = LindbladErrorgen.from_elementary_errorgens(
+        {LEEL('H', ('X',)): 0.15}, parameterization='H', state_space=1)
+    ss = QubitSpace(['q2', 'q16', 'q22'])
+    embedded = EmbeddedErrorgen(ss, ['q16'], eg)
+    labels = embedded.coefficient_labels(label_type='local')
+    assert labels == (LEEL('H', ('IXI',)),)


### PR DESCRIPTION
## Summary

`EmbeddedOp._embed_labels`'s local-label branch (the code behind `errorgen_coefficient_labels`/
`errorgen_coefficients`/`error_rates` with `label_type='local'`, also inherited by `EmbeddedErrorgen`)
raises `TypeError` for any state space with string qubit labels, and would silently mis-embed for a
state space with permuted integer qubit labels:

```python
import pygsti
from pygsti.modelmembers.operations import EmbeddedOp, LindbladErrorgen, ExpErrorgenOp
from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as LEEL

eg = LindbladErrorgen.from_elementary_errorgens({LEEL('H', ('X',)): 0.15}, parameterization='H', state_space=1)
ss = pygsti.baseobjs.QubitSpace(['q2', 'q16', 'q22'])
embedded = EmbeddedOp(ss, ['q16'], ExpErrorgenOp(eg))
embedded.errorgen_coefficient_labels(label_type='local')  # TypeError: list indices must be integers or slices, not str
```

This is hit unconditionally by `pygsti.errorgenpropagation.errorpropagator.ErrorGeneratorPropagator.
construct_errorgen_layers`, which always requests `label_type='local'` -- so any use of error-generator
propagation on a model with string qubit labels hits this.

### Root cause

```python
elif isinstance(labels_to_embed[0], _LocalElementaryErrorgenLabel):
    embedded_labels = []
    base_label = [identity_label for _ in range(self.state_space.num_qudits)]
    for lbl in labels_to_embed:
        new_bels = []
        for bel in lbl.basis_element_labels:
            base_label = [identity_label for _ in range(self.state_space.num_qudits)]
            for target, pauli in zip(self.target_labels, bel):
                base_label[target] = pauli   # `target` is a raw entry of self.target_labels
            new_bels.append(''.join(base_label))
        ...
```

`self.target_labels` are this `EmbeddedOp`'s target *qubit labels* (e.g. `("q16",)`), never resolved to
integer positions before indexing `base_label` (a plain Python `list`). This works by coincidence for
state spaces with unpermuted integer qubit labels (a label equals its own position), but is otherwise
wrong. The neighboring *global*-label branch a few lines above already does the analogous
label-to-position mapping correctly, so this looks like an oversight specific to the local-label branch
rather than a fundamental design constraint. Introduced in `9dcd6ae24` ("Fix bugs introduced by new
local label handling"); confirmed present, unchanged, in every version checked (`v0.10`, `v0.10.1`,
`v0.10.2`, `develop`).

## The fix

Resolve each target label to its integer position in `self.state_space.qubit_labels` before indexing,
mirroring the mapping the global-label branch already does:

```python
target_positions = [self.state_space.qubit_labels.index(t) for t in self.target_labels]
...
for pos, pauli in zip(target_positions, bel):
    base_label[pos] = pauli
```

A no-op for state spaces with unpermuted integer qubit labels (`qubit_labels.index(t) == t`), so no
existing behavior changes.

## Tests

New `test/unit/modelmembers/test_embeddedop.py` (no prior file/coverage existed for `EmbeddedOp`'s
error-generator-label logic):

| test | covers |
|---|---|
| `test_errorgen_coefficient_labels_local_integer_qubit_labels_control` | unpermuted integer labels (already correct pre-fix; control) |
| `test_errorgen_coefficient_labels_local_string_qubit_labels` | string qubit labels (raises `TypeError` pre-fix) |
| `test_errorgen_coefficient_labels_local_permuted_integer_qubit_labels` | permuted integer labels (silently wrong answer pre-fix, doesn't raise) |
| `test_errorgen_coefficient_labels_local_two_qubit_target_out_of_order` | 2-qubit target, out-of-order relative to `qubit_labels`, positional pairing |
| `test_errorgen_coefficients_local_string_qubit_labels_end_to_end` | full `errorgen_coefficients(label_type='local')` chain, not just label construction |
| `test_embeddederrorgen_coefficient_labels_local_string_qubit_labels` | `EmbeddedErrorgen.coefficient_labels`, which shares `_embed_labels` via inheritance |

Each of the 5 non-control tests confirmed to fail against the unfixed code (4 with the exact `TypeError`
above, 1 with a silent wrong-value assertion failure) before the fix was applied.

## Verification

```
pytest -q test/unit/modelmembers/test_embeddedop.py
# 6 passed

pytest -q test/unit/modelmembers/
# 757 passed, 6 skipped (identical to pre-fix baseline)

pytest -q test/unit/objects/test_errorgenpropagation.py test/unit/objects/test_localnoisemodel.py \
          test/unit/objects/test_errorgenbasis.py test/unit/objects/test_model_updates_after_creation.py \
          test/unit/objects/test_forwardsim.py test/unit/tools/test_errgenproptools.py \
          test/unit/tools/test_errgenpolytools.py test/unit/tools/test_optools.py \
          test/unit/tools/test_lindbladtools.py
# 204 passed, 4 skipped

pytest -q test/test_packages/objects/test_advancedgatesetparameterization.py
# 4 passed
```

## Context

Found while generalizing LoQS use of `ErrorGeneratorPropagator` on models
with string (device-native, e.g. `"q2"`) qubit labels.
