### PR TITLE
Keep protocol checkpoints out of the source tree during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,137 @@
+"""Repo-wide pytest configuration.
+
+Keeps protocol checkpoints out of the source tree during test runs.
+
+``GateSetTomography``, ``StandardGST``, ``ModelTest`` and ``IBMQExperiment``
+each default their checkpoint location to a directory *relative to the current
+working directory* (``./gst_checkpoints/``, ``./standard_gst_checkpoints/``,
+``./model_test_checkpoints/``, ``./ibmqexperiment_checkpoint/``). That's a
+reasonable default for someone running a fit interactively, but under pytest it
+means ~50 tests deposit checkpoint JSON wherever pytest happened to be invoked
+from — normally the repo root — and a full notebook run scatters ~150 MB across
+the ``docs/markdown`` source directories.
+
+This plugin redirects only the *default*: when a caller passes
+``checkpoint_path=None`` (i.e. expresses no opinion) and hasn't disabled
+checkpointing, the path is rewritten into a throwaway directory outside the
+source tree. Callers that pass an explicit ``checkpoint_path`` are untouched, so
+the tests that deliberately exercise checkpoint write/resume — notably
+``test/test_packages/drivers/test_drivers.py`` — keep testing exactly what they
+tested before. Checkpointing itself still runs; only the destination changes.
+
+Disable with ``--checkpoint-redirect=off``. Set
+``PYGSTI_TEST_KEEP_CHECKPOINTS=1`` to leave the directory behind for inspection
+instead of deleting it at session end.
+
+Note that this cannot reach the notebook suite: nbval executes each notebook in
+a separate kernel subprocess, which this process's monkeypatching never sees.
+Notebook checkpoints stay under ``docs/`` and are gitignored.
+"""
+import functools
+import inspect
+import itertools
+import pathlib
+import shutil
+import tempfile
+
+_root = []            # [pathlib.Path] once configured
+_cleanup = [False]
+_counter = itertools.count()
+
+
+def _sanitize(name):
+    """Make `name` safe as a path stem.
+
+    Dots matter: the protocols run the path through ``Path(...).with_suffix('')``,
+    which would silently truncate a stem containing one.
+    """
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(name)) or "checkpoint"
+
+
+def _fresh_path(kind, name=None, as_directory=False):
+    """A unique checkpoint destination under the throwaway root.
+
+    The protocols expect ``{dir}/{stem}`` and create ``{dir}`` themselves, so we
+    don't create anything here. ``IBMQExperiment`` instead wants a directory that
+    does *not* yet exist (it refuses to clobber an existing checkpoint), hence
+    ``as_directory``.
+    """
+    n = next(_counter)
+    if as_directory:
+        return str(_root[0] / f"{kind}_{n}")
+    return str(_root[0] / f"{kind}_{n}" / _sanitize(name or kind))
+
+
+def _redirect(owner, attrname, kind, as_directory=False):
+    """Wrap ``owner.attrname`` so a ``checkpoint_path`` of None becomes a temp path."""
+    fn = getattr(owner, attrname, None)
+    if fn is None or getattr(fn, "_pygsti_checkpoint_redirected", False):
+        return
+    sig = inspect.signature(fn)
+    if "checkpoint_path" not in sig.parameters:
+        return
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        arguments = bound.arguments
+        if (arguments.get("checkpoint_path") is None
+                and not arguments.get("disable_checkpointing", False)):
+            # `self` carries the protocol name, which makes the temp tree readable.
+            name = getattr(args[0], "name", None) if args else None
+            arguments["checkpoint_path"] = _fresh_path(kind, name, as_directory)
+        return fn(*bound.args, **bound.kwargs)
+
+    wrapper._pygsti_checkpoint_redirected = True
+    setattr(owner, attrname, wrapper)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--checkpoint-redirect", action="store", default="on", choices=["on", "off"],
+        help="Redirect default protocol checkpoint paths out of the source tree "
+             "(default: on).")
+
+
+def pytest_configure(config):
+    if config.getoption("--checkpoint-redirect") == "off":
+        return
+
+    # Prefer pytest's own basetemp when the user asked for one, so checkpoints
+    # follow the same lifecycle as everything else pytest writes. Otherwise use a
+    # private temp dir we clean up ourselves. Either way each xdist worker runs
+    # this hook separately and gets its own directory, so there's no contention.
+    basetemp = config.getoption("basetemp", None)
+    if basetemp:
+        _root.append(pathlib.Path(basetemp) / "pygsti_checkpoints")
+        _root[0].mkdir(parents=True, exist_ok=True)
+    else:
+        _root.append(pathlib.Path(tempfile.mkdtemp(prefix="pygsti-test-checkpoints-")))
+        _cleanup[0] = True
+
+    from pygsti.protocols.gst import GateSetTomography, StandardGST
+    from pygsti.protocols.modeltest import ModelTest
+
+    _redirect(GateSetTomography, "run", "gst")
+    _redirect(StandardGST, "run", "standard_gst")
+    _redirect(ModelTest, "run", "model_test")
+
+    try:  # optional dependency: only present when qiskit is installed
+        from pygsti.extras.ibmq.ibmqexperiment import IBMQExperiment
+    except ImportError:
+        pass
+    else:
+        _redirect(IBMQExperiment, "__init__", "ibmqexperiment", as_directory=True)
+
+
+def pytest_report_header(config):
+    if _root:
+        return f"protocol checkpoints redirected to: {_root[0]}"
+    return None
+
+
+def pytest_unconfigure(config):
+    import os
+    if _root and _cleanup[0] and not os.environ.get("PYGSTI_TEST_KEEP_CHECKPOINTS"):
+        shutil.rmtree(_root[0], ignore_errors=True)

--- a/conftest.py
+++ b/conftest.py
@@ -1,137 +1,228 @@
 """Repo-wide pytest configuration.
 
-Keeps protocol checkpoints out of the source tree during test runs.
+This file is the rootdir-level hook point for the whole repository: anything
+that has to apply to every suite at once belongs here. At the moment it carries
+exactly one such concern — keeping protocol checkpoints out of the source tree —
+which lives in the ``CheckpointRedirect`` namespace below.
 
-``GateSetTomography``, ``StandardGST``, ``ModelTest`` and ``IBMQExperiment``
-each default their checkpoint location to a directory *relative to the current
-working directory* (``./gst_checkpoints/``, ``./standard_gst_checkpoints/``,
-``./model_test_checkpoints/``, ``./ibmqexperiment_checkpoint/``). That's a
-reasonable default for someone running a fit interactively, but under pytest it
-means ~50 tests deposit checkpoint JSON wherever pytest happened to be invoked
-from — normally the repo root — and a full notebook run scatters ~150 MB across
-the ``docs/markdown`` source directories.
-
-This plugin redirects only the *default*: when a caller passes
-``checkpoint_path=None`` (i.e. expresses no opinion) and hasn't disabled
-checkpointing, the path is rewritten into a throwaway directory outside the
-source tree. Callers that pass an explicit ``checkpoint_path`` are untouched, so
-the tests that deliberately exercise checkpoint write/resume — notably
-``test/test_packages/drivers/test_drivers.py`` — keep testing exactly what they
-tested before. Checkpointing itself still runs; only the destination changes.
-
-Disable with ``--checkpoint-redirect=off``. Set
-``PYGSTI_TEST_KEEP_CHECKPOINTS=1`` to leave the directory behind for inspection
-instead of deleting it at session end.
-
-Note that this cannot reach the notebook suite: nbval executes each notebook in
-a separate kernel subprocess, which this process's monkeypatching never sees.
-Notebook checkpoints stay under ``docs/`` and are gitignored.
+New concerns should get their own namespace class rather than adding free
+functions here, so the pytest hooks at the bottom of the file stay a short,
+readable index of everything this conftest does.
 """
 import functools
 import inspect
 import itertools
+import os
 import pathlib
 import shutil
 import tempfile
 
-_root = []            # [pathlib.Path] once configured
-_cleanup = [False]
-_counter = itertools.count()
 
+class CheckpointRedirect:
+    """Keeps protocol checkpoints out of the source tree during test runs.
 
-def _sanitize(name):
-    """Make `name` safe as a path stem.
+    ``GateSetTomography``, ``StandardGST``, ``ModelTest`` and ``IBMQExperiment``
+    each default their checkpoint location to a directory *relative to the
+    current working directory* (``./gst_checkpoints/``,
+    ``./standard_gst_checkpoints/``, ``./model_test_checkpoints/``,
+    ``./ibmqexperiment_checkpoint/``). That's a reasonable default for someone
+    running a fit interactively, but under pytest it means ~50 tests deposit
+    checkpoint JSON wherever pytest happened to be invoked from — normally the
+    repo root — and a full notebook run scatters ~150 MB across the
+    ``docs/markdown`` source directories.
 
-    Dots matter: the protocols run the path through ``Path(...).with_suffix('')``,
-    which would silently truncate a stem containing one.
+    This redirects only the *default*: when a caller passes
+    ``checkpoint_path=None`` (i.e. expresses no opinion) and hasn't disabled
+    checkpointing, the path is rewritten into a throwaway directory outside the
+    source tree. Callers that pass an explicit ``checkpoint_path`` are untouched,
+    so the tests that deliberately exercise checkpoint write/resume — notably
+    ``test/test_packages/drivers/test_drivers.py`` — keep testing exactly what
+    they tested before. Checkpointing itself still runs; only the destination
+    changes.
+
+    Disable with ``--checkpoint-redirect=off``. Set
+    ``PYGSTI_TEST_KEEP_CHECKPOINTS=1`` to leave the directory behind for
+    inspection instead of deleting it at session end.
+
+    Note that this cannot reach the notebook suite: nbval executes each notebook
+    in a separate kernel subprocess, which this process's monkeypatching never
+    sees. Notebook checkpoints stay under ``docs/`` and are gitignored.
     """
-    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(name)) or "checkpoint"
 
+    OPTION = "--checkpoint-redirect"
+    KEEP_ENVIRONMENT_VARIABLE = "PYGSTI_TEST_KEEP_CHECKPOINTS"
+    WRAPPED_MARKER = "_pygsti_checkpoint_redirected"
+    SAFE_PUNCTUATION = "-_"
 
-def _fresh_path(kind, name=None, as_directory=False):
-    """A unique checkpoint destination under the throwaway root.
+    root = None         # pathlib.Path, once `choose_root` has run
+    owns_root = False   # True when we created the root and must delete it again
+    counter = itertools.count()
 
-    The protocols expect ``{dir}/{stem}`` and create ``{dir}`` themselves, so we
-    don't create anything here. ``IBMQExperiment`` instead wants a directory that
-    does *not* yet exist (it refuses to clobber an existing checkpoint), hence
-    ``as_directory``.
-    """
-    n = next(_counter)
-    if as_directory:
-        return str(_root[0] / f"{kind}_{n}")
-    return str(_root[0] / f"{kind}_{n}" / _sanitize(name or kind))
+    @staticmethod
+    def add_option(parser):
+        parser.addoption(
+            CheckpointRedirect.OPTION, action="store", default="on", choices=["on", "off"],
+            help="Redirect default protocol checkpoint paths out of the source tree "
+                 "(default: on).")
 
+    @staticmethod
+    def enabled(config):
+        return config.getoption(CheckpointRedirect.OPTION) == "on"
 
-def _redirect(owner, attrname, kind, as_directory=False):
-    """Wrap ``owner.attrname`` so a ``checkpoint_path`` of None becomes a temp path."""
-    fn = getattr(owner, attrname, None)
-    if fn is None or getattr(fn, "_pygsti_checkpoint_redirected", False):
-        return
-    sig = inspect.signature(fn)
-    if "checkpoint_path" not in sig.parameters:
-        return
+    @staticmethod
+    def choose_root(config):
+        """Pick the throwaway directory that all redirected checkpoints go under.
 
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        bound = sig.bind(*args, **kwargs)
-        bound.apply_defaults()
-        arguments = bound.arguments
-        if (arguments.get("checkpoint_path") is None
-                and not arguments.get("disable_checkpointing", False)):
+        Prefer pytest's own basetemp when the user asked for one, so checkpoints
+        follow the same lifecycle as everything else pytest writes. Otherwise use
+        a private temp dir we clean up ourselves. Either way each xdist worker
+        runs the configure hook separately and gets its own directory, so there
+        is no contention.
+        """
+        basetemp = config.getoption("basetemp", None)
+        if basetemp:
+            CheckpointRedirect.root = pathlib.Path(basetemp) / "pygsti_checkpoints"
+            CheckpointRedirect.root.mkdir(parents=True, exist_ok=True)
+            CheckpointRedirect.owns_root = False
+            return
+
+        private_directory = tempfile.mkdtemp(prefix="pygsti-test-checkpoints-")
+        CheckpointRedirect.root = pathlib.Path(private_directory)
+        CheckpointRedirect.owns_root = True
+
+    @staticmethod
+    def sanitize(name):
+        """Make `name` safe as a path stem.
+
+        Dots matter: the protocols run the path through
+        ``Path(...).with_suffix('')``, which would silently truncate a stem
+        containing one.
+        """
+        def safe(character):
+            keep = character.isalnum() or character in CheckpointRedirect.SAFE_PUNCTUATION
+            return character if keep else "_"
+
+        sanitized = "".join(safe(character) for character in str(name))
+        return sanitized or "checkpoint"
+
+    @staticmethod
+    def fresh_path(kind, name, as_directory):
+        """A unique checkpoint destination under the throwaway root.
+
+        The protocols expect ``{dir}/{stem}`` and create ``{dir}`` themselves, so
+        we don't create anything here. ``IBMQExperiment`` instead wants a
+        directory that does *not* yet exist (it refuses to clobber an existing
+        checkpoint), hence ``as_directory``.
+        """
+        index = next(CheckpointRedirect.counter)
+        directory = CheckpointRedirect.root / f"{kind}_{index}"
+        if as_directory:
+            return str(directory)
+
+        stem = CheckpointRedirect.sanitize(name or kind)
+        return str(directory / stem)
+
+    @staticmethod
+    def wrap(owner, attribute_name, kind, as_directory=False):
+        """Wrap ``owner.attribute_name`` so a ``checkpoint_path`` of None becomes a temp path."""
+        original = getattr(owner, attribute_name, None)
+        if original is None:
+            return
+        if getattr(original, CheckpointRedirect.WRAPPED_MARKER, False):
+            return
+
+        signature = inspect.signature(original)
+        if "checkpoint_path" not in signature.parameters:
+            return
+
+        wrapper = CheckpointRedirect.build_wrapper(original, signature, kind, as_directory)
+        setattr(owner, attribute_name, wrapper)
+
+    @staticmethod
+    def build_wrapper(original, signature, kind, as_directory):
+        """The replacement callable installed by `wrap`."""
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            bound = signature.bind(*args, **kwargs)
+            bound.apply_defaults()
+            arguments = bound.arguments
+
+            # Test on the *value*, not on whether the argument was supplied:
+            # `pygsti/drivers/longsequence.py` forwards `checkpoint_path=None`
+            # explicitly, and that accounts for most of the calls we care about.
+            caller_chose_a_path = arguments.get("checkpoint_path") is not None
+            checkpointing_is_off = bool(arguments.get("disable_checkpointing", False))
+            if caller_chose_a_path or checkpointing_is_off:
+                return original(*bound.args, **bound.kwargs)
+
             # `self` carries the protocol name, which makes the temp tree readable.
-            name = getattr(args[0], "name", None) if args else None
-            arguments["checkpoint_path"] = _fresh_path(kind, name, as_directory)
-        return fn(*bound.args, **bound.kwargs)
+            protocol = args[0] if args else None
+            name = getattr(protocol, "name", None)
+            arguments["checkpoint_path"] = CheckpointRedirect.fresh_path(kind, name, as_directory)
+            return original(*bound.args, **bound.kwargs)
 
-    wrapper._pygsti_checkpoint_redirected = True
-    setattr(owner, attrname, wrapper)
+        setattr(wrapper, CheckpointRedirect.WRAPPED_MARKER, True)
+        return wrapper
+
+    @staticmethod
+    def find_ibmq_experiment():
+        """``IBMQExperiment``, or None when qiskit isn't installed."""
+        try:
+            from pygsti.extras.ibmq.ibmqexperiment import IBMQExperiment
+        except ImportError:
+            return None
+        return IBMQExperiment
+
+    @staticmethod
+    def install(config):
+        if not CheckpointRedirect.enabled(config):
+            return
+
+        CheckpointRedirect.choose_root(config)
+
+        from pygsti.protocols.gst import GateSetTomography, StandardGST
+        from pygsti.protocols.modeltest import ModelTest
+
+        CheckpointRedirect.wrap(GateSetTomography, "run", "gst")
+        CheckpointRedirect.wrap(StandardGST, "run", "standard_gst")
+        CheckpointRedirect.wrap(ModelTest, "run", "model_test")
+
+        ibmq_experiment = CheckpointRedirect.find_ibmq_experiment()
+        if ibmq_experiment is None:
+            return
+
+        CheckpointRedirect.wrap(
+            ibmq_experiment, "__init__", "ibmqexperiment", as_directory=True)
+
+    @staticmethod
+    def report_header():
+        if CheckpointRedirect.root is None:
+            return None
+        return f"protocol checkpoints redirected to: {CheckpointRedirect.root}"
+
+    @staticmethod
+    def remove_root():
+        if CheckpointRedirect.root is None:
+            return
+        if not CheckpointRedirect.owns_root:
+            return
+        if os.environ.get(CheckpointRedirect.KEEP_ENVIRONMENT_VARIABLE):
+            return
+
+        shutil.rmtree(CheckpointRedirect.root, ignore_errors=True)
 
 
 def pytest_addoption(parser):
-    parser.addoption(
-        "--checkpoint-redirect", action="store", default="on", choices=["on", "off"],
-        help="Redirect default protocol checkpoint paths out of the source tree "
-             "(default: on).")
+    CheckpointRedirect.add_option(parser)
 
 
 def pytest_configure(config):
-    if config.getoption("--checkpoint-redirect") == "off":
-        return
-
-    # Prefer pytest's own basetemp when the user asked for one, so checkpoints
-    # follow the same lifecycle as everything else pytest writes. Otherwise use a
-    # private temp dir we clean up ourselves. Either way each xdist worker runs
-    # this hook separately and gets its own directory, so there's no contention.
-    basetemp = config.getoption("basetemp", None)
-    if basetemp:
-        _root.append(pathlib.Path(basetemp) / "pygsti_checkpoints")
-        _root[0].mkdir(parents=True, exist_ok=True)
-    else:
-        _root.append(pathlib.Path(tempfile.mkdtemp(prefix="pygsti-test-checkpoints-")))
-        _cleanup[0] = True
-
-    from pygsti.protocols.gst import GateSetTomography, StandardGST
-    from pygsti.protocols.modeltest import ModelTest
-
-    _redirect(GateSetTomography, "run", "gst")
-    _redirect(StandardGST, "run", "standard_gst")
-    _redirect(ModelTest, "run", "model_test")
-
-    try:  # optional dependency: only present when qiskit is installed
-        from pygsti.extras.ibmq.ibmqexperiment import IBMQExperiment
-    except ImportError:
-        pass
-    else:
-        _redirect(IBMQExperiment, "__init__", "ibmqexperiment", as_directory=True)
+    CheckpointRedirect.install(config)
 
 
 def pytest_report_header(config):
-    if _root:
-        return f"protocol checkpoints redirected to: {_root[0]}"
-    return None
+    return CheckpointRedirect.report_header()
 
 
 def pytest_unconfigure(config):
-    import os
-    if _root and _cleanup[0] and not os.environ.get("PYGSTI_TEST_KEEP_CHECKPOINTS"):
-        shutil.rmtree(_root[0], ignore_errors=True)
+    CheckpointRedirect.remove_root()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -52,9 +52,14 @@ def _generate_shared_fixtures():
     pygsti.io.write_dataset(str(_TUT / "Example_Dataset_LowCnts.txt"), ds_low)
 
     # --- GateSetTomography results read back by the Results tutorial -------------
+    # ``disable_checkpointing`` because this runs from a sessionstart hook, so the
+    # default checkpoint dir would be resolved against pytest's invocation directory
+    # (the repo root) rather than anything under docs/.  We only want the final
+    # results here; nothing resumes this run, so the checkpoints are pure litter.
     data = pygsti.io.read_data_from_dir(str(gst_data_dir))
     results = pygsti.protocols.GateSetTomography(
-        smq1Q_XYI.target_model("full TP"), verbosity=0).run(data)
+        smq1Q_XYI.target_model("full TP"), verbosity=0).run(
+            data, disable_checkpointing=True)
     results.write()  # -> Example_GST_Data/results/GateSetTomography
 
 


### PR DESCRIPTION
### Problem

A full run of `test/unit`, `test/integration` and `test/test_packages` leaves checkpoint JSON scattered around the checkout. Adding the notebook suite brings the total to 26 directories and ~155 MB. Everything is gitignored, so none of it was ever at risk of being committed, but it's a lot of disk and it makes the working tree tedious to look at.

`GateSetTomography`, `StandardGST`, `ModelTest` and `IBMQExperiment` each default their checkpoint location to a directory relative to the *current working directory* — `./gst_checkpoints/`, `./standard_gst_checkpoints/`, `./model_test_checkpoints/`, `./ibmqexperiment_checkpoint/`. That's a fine default for someone running a fit interactively. Under pytest it means the artifacts land wherever pytest was invoked from, normally the repo root.

### Solution

This PR uses pytest's `conftest.py` mechanism to effectively override the default checkpoint path (`None`) to a temporary directory that's cleaned up after execution.

Destination is pytest's `--basetemp` when one was given, so checkpoints follow the same lifecycle as everything else pytest writes; otherwise a private `mkdtemp` cleaned up at session end. Each xdist worker runs `pytest_configure` separately and gets its own directory, so there's no contention. `--checkpoint-redirect=off` disables the whole thing, and `PYGSTI_TEST_KEEP_CHECKPOINTS=1` keeps the directory around for inspection. The session header reports where things went:

```
protocol checkpoints redirected to: /tmp/pygsti-test-checkpoints-msw2sb6e
```

This PR also changes an existing file `docs/conftest.py` written by a previous agent. That file existed to handle the fact that some notebooks required shared artifacts, but we don't want to have to run the notebooks in a specific order during tests. This PR's change is to pass `disable_checkpointing=True`. That's the right move since none of the example notebooks use the checkpoints as intentional artifacts.

This PR _does not_ cover the rest of the notebook suite's checkpointing artifacts. There's plenty of those, but they all get written to `docs/`, so they aren't cluttering the main repo tree.

### How the robot found the full set

**The following is written by the robot in first person.**

I wrote a pytest plugin that intercepts `Path.mkdir` / `os.mkdir` / `os.makedirs` / write-mode `open`, attributes each write to a test nodeid, and separately diffs the repo tree across a session to catch writes from subprocesses the in-process hooks can't see. Run with its allowlist disabled — counting sanctioned scratch dirs too — it reported for `test/unit` + `test/integration`:

```
   187 writes   31 tests  gst_checkpoints            <- unsanctioned
   138 writes   14 tests  standard_gst_checkpoints   <- unsanctioned
    55 writes    6 tests  model_test_checkpoints     <- unsanctioned
   239 writes    7 tests  test/     (all under test_packages/temp_test_files)
     2 writes    1 tests  .hypothesis
     2 writes    1 tests  .pytest_cache
```

and for `test/test_packages`, 1590 writes under `test/` (1523 of them in `temp_test_files`, 67 in the three checkpoint dirs) plus two to `.pytest_cache`. So checkpoints really are the only artifact escaping into the tree, which is why this PR is scoped to them.

### Notes

Two incidental things that turned up and are *not* addressed here, in case anyone wants them later: seven `test/unit` tests write into `test/test_packages/temp_test_files/`, which is a unit test reaching into the legacy suite's scratch directory; and nothing ever cleans `temp_test_files/` up, so it just accumulates and gets overwritten.
