### PR TITLE
Bugfix Approx Logarithm Failures

### DIFF
--- a/pygsti/report/reportables.py
+++ b/pygsti/report/reportables.py
@@ -2288,8 +2288,21 @@ def general_decomposition(model_a, model_b):
         failed = False
         try:
             if _np.any(_np.isclose(target_evals, -1.0)):
-                target_logG = _tools.unitary_superoperator_matrix_log(targetOp, mxBasis)
-                logG = _tools.approximate_matrix_log(gate, target_logG)
+                # `targetOp` has an eigenvalue of -1 (e.g. a pi-rotation), which means its logarithm has a
+                # pair of eigenvalues differing by exactly 2*pi*i. The Frechet derivative of expm is
+                # singular there, so `gate` generically has no real logarithm at all and a direct log is
+                # neither unique nor a smooth function of `gate`. Both properties are needed here, since
+                # this quantity gets finite differenced to produce error bars. The BCH construction sides-
+                # steps this by taking the (unique, smooth) logarithm of the near-identity error map
+                # inv(targetOp) @ gate and adding it to the analytically known logarithm of the target.
+                # The BCH order is HARDCODED to 3. Order 4 measurably adds nothing (its contribution
+                # enters only at second order in the error generator). Order 5 is not merely
+                # unhelpful but actively unsafe: the BCH series converges only while the spectral
+                # radius of ad_{log(targetOp)} stays below 2*pi, and that radius is *exactly* 2*pi
+                # for a single-qubit pi rotation and can exceed it for multi-qubit targets (it is
+                # 3*pi for CNOT@(X kron I)). Order 3 stays accurate past that boundary whereas order
+                # 5 degrades sharply, so do not raise this without re-measuring on multi-qubit gates.
+                logG = _tools.approximate_matrix_log_BCH(gate, targetOp, mxBasis, order=3)
             else:
                 logG = _tools.real_matrix_log(gate, "warn")
                 if _np.linalg.norm(logG.imag) > 1e-6:

--- a/pygsti/report/reportables.py
+++ b/pygsti/report/reportables.py
@@ -2295,13 +2295,11 @@ def general_decomposition(model_a, model_b):
                 # this quantity gets finite differenced to produce error bars. The BCH construction sides-
                 # steps this by taking the (unique, smooth) logarithm of the near-identity error map
                 # inv(targetOp) @ gate and adding it to the analytically known logarithm of the target.
-                # The BCH order is HARDCODED to 3. Order 4 measurably adds nothing (its contribution
-                # enters only at second order in the error generator). Order 5 is not merely
-                # unhelpful but actively unsafe: the BCH series converges only while the spectral
-                # radius of ad_{log(targetOp)} stays below 2*pi, and that radius is *exactly* 2*pi
-                # for a single-qubit pi rotation and can exceed it for multi-qubit targets (it is
-                # 3*pi for CNOT@(X kron I)). Order 3 stays accurate past that boundary whereas order
-                # 5 degrades sharply, so do not raise this without re-measuring on multi-qubit gates.
+                # The BCH order is HARDCODED to 3. Order 4 was not found to measurably add anything. 
+                # Order 5 was found to be unsafe in empircally representative use cases. 
+                # The BCH series converges only while the spectral radius of ad_{log(targetOp)} 
+                # stays below 2*pi, and that radius is *exactly* 2*pi for a single-qubit pi rotation and can 
+                # exceed it for multi-qubit targets. Order 3 empirically stays accurate past that boundary.
                 logG = _tools.approximate_matrix_log_BCH(gate, targetOp, mxBasis, order=3)
             else:
                 logG = _tools.real_matrix_log(gate, "warn")

--- a/pygsti/tools/errgenproptools.py
+++ b/pygsti/tools/errgenproptools.py
@@ -6913,8 +6913,8 @@ def pairwise_bch_numerical(mat1: _np.ndarray, mat2: _np.ndarray, order: Literal[
     Helper function for doing the numerical BCH in a pairwise fashion. Note this function is primarily intended
     for numerical validations as part of testing infrastructure.
     """
-    if order > 5:
-        raise ValueError('Maximum supported BCH order is 5')
+    if not 1 <= order <= 5:
+        raise ValueError('BCH order must be between 1 and 5 (inclusive), got %s' % str(order))
 
     bch_result = _np.zeros(mat1.shape, dtype=_np.complex128)
     if order >= 1:

--- a/pygsti/tools/errgenproptools.py
+++ b/pygsti/tools/errgenproptools.py
@@ -6908,11 +6908,14 @@ def bch_numerical(propagated_errorgen_layers, error_propagator, bch_order=1):
         
     return combined_err_layer  
 
-def pairwise_bch_numerical(mat1, mat2, order=1):
+def pairwise_bch_numerical(mat1: _np.ndarray, mat2: _np.ndarray, order: Literal[1,2,3,4,5]=1) -> _np.ndarray[_np.complex128]:
     """
     Helper function for doing the numerical BCH in a pairwise fashion. Note this function is primarily intended
     for numerical validations as part of testing infrastructure.
     """
+    if order > 5:
+        raise ValueError('Maximum supported BCH order is 5')
+
     bch_result = _np.zeros(mat1.shape, dtype=_np.complex128)
     if order >= 1:
         bch_result += mat1 + mat2
@@ -6926,7 +6929,7 @@ def pairwise_bch_numerical(mat1, mat2, order=1):
     if order >= 4:
         commutator2112 = _matrix_commutator(mat2, commutator112)
         bch_result += (-1/24)*commutator2112
-    if order >= 5:
+    if order == 5:
         commutator1112 = _matrix_commutator(mat1, commutator112)
         commutator2212 = _matrix_commutator(mat2, commutator212)
         

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -983,10 +983,6 @@ def approximate_matrix_log_BCH(m: _np.ndarray, target: _np.ndarray, mx_basis: Un
 
     log_target = unitary_superoperator_matrix_log(target, mx_basis)
 
-    # Note: `target` is a unitary superoperator, so its conjugate transpose is its inverse. Using the
-    # conjugate transpose rather than an explicit inverse/solve matters: LU-based routines make discrete
-    # pivoting choices which are not smooth functions of their input, and this logarithm is finite
-    # differenced with respect to model parameters when computing error bars.
     E = target.conj().T@m
     log_E = near_identity_matrix_log(E)
 

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -949,13 +949,13 @@ def approximate_matrix_log_BCH(m: _np.ndarray, target: _np.ndarray, mx_basis: Un
     Notes
     -----
     In this brief note we'll make the use of the BCH expansion more explicit.
-    Let T be the target unitary superoperator. Observe that m = T@T^-1@m. Let E= T^-1@m.
-    The we have that log(m) = log(T@E). T = exp(log(T)), E = exp(log(E)), so
+    Let T be the target unitary superoperator. Observe that m = T@T^-1@m. Let E = T^-1@m.
+    Then we have that log(m) = log(T@E). T = exp(log(T)), E = exp(log(E)), so
     log(m) = log( exp(log(T)) @ exp(log(E) ) ~  log(T) + log(E) + (1/2)[log(T), log(E)] + ...
 
     The gymnastics here are useful because log(T) can be computed leveraging the fact that T is a
-    unitary matrix. And because m is close to T, E is close to the identity, meaning log(E) should
-    have a well-defined real-valued logarithm. 
+    unitary matrix. And because m is close to T, E is close to the identity, meaning E should
+    have a well-defined real-valued logarithm.
 
     Parameters
     ----------    
@@ -964,9 +964,9 @@ def approximate_matrix_log_BCH(m: _np.ndarray, target: _np.ndarray, mx_basis: Un
 
     target : numpy array
         The target superoperator matrix. Should correspond to unitary superoperator, but this is not
-        explicitly enforced and must be enfored by callers.
+        explicitly enforced and must be enforced by callers.
 
-    mx_basis : stf or Basis object
+    mx_basis : str or Basis object
         Basis for m and target. Allowed values are strings castable to a basis, e.g.
         Matrix-unit (std), Gell-Mann (gm), Pauli-product (pp), and Qutrit (qt), see `Basis` documentation
         for more. Or a custom `Basis` object.
@@ -977,18 +977,29 @@ def approximate_matrix_log_BCH(m: _np.ndarray, target: _np.ndarray, mx_basis: Un
     Returns
     -------
     logM : numpy array
-        An matrix of the same shape as `m`.
+        A matrix of the same shape as `m`.
     """
     from pygsti.tools.errgenproptools import pairwise_bch_numerical
 
     log_target = unitary_superoperator_matrix_log(target, mx_basis)
 
+    # Note: `target` is a unitary superoperator, so its conjugate transpose is its inverse. Using the
+    # conjugate transpose rather than an explicit inverse/solve matters: LU-based routines make discrete
+    # pivoting choices which are not smooth functions of their input, and this logarithm is finite
+    # differenced with respect to model parameters when computing error bars.
     E = target.conj().T@m
     log_E = near_identity_matrix_log(E)
 
     approx_log_m = pairwise_bch_numerical(log_target, log_E, order)
 
-    return approx_log_m
+    # Both log_target and log_E are real, so the BCH result should be too (pairwise_bch_numerical
+    # allocates a complex array regardless). Validate before discarding the imaginary part.
+    imag_norm = _np.linalg.norm(approx_log_m.imag)
+    if imag_norm > 1e-8:
+        raise ValueError("BCH approximation to the matrix logarithm was not real-valued "
+                         "(norm of imaginary part is %g)!" % imag_norm)
+
+    return approx_log_m.real
 
 def eigenvalues(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None,
                 assume_normal: bool = False) -> _np.ndarray:

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -940,6 +940,55 @@ def approximate_matrix_log(m: _np.ndarray, target_logm: _np.ndarray,
 
     return logM
 
+def approximate_matrix_log_BCH(m: _np.ndarray, target: _np.ndarray, mx_basis: Union[str, Basis], 
+                               order: Literal[1,2,3,4,5]= 1) -> _np.ndarray:
+    """
+    Construct an approximate logarithm of superoperator matrix `m` that is real and near a specific target
+    unitary superoperator using the BCH approximation.
+
+    Notes
+    -----
+    In this brief note we'll make the use of the BCH expansion more explicit.
+    Let T be the target unitary superoperator. Observe that m = T@T^-1@m. Let E= T^-1@m.
+    The we have that log(m) = log(T@E). T = exp(log(T)), E = exp(log(E)), so
+    log(m) = log( exp(log(T)) @ exp(log(E) ) ~  log(T) + log(E) + (1/2)[log(T), log(E)] + ...
+
+    The gymnastics here are useful because log(T) can be computed leveraging the fact that T is a
+    unitary matrix. And because m is close to T, E is close to the identity, meaning log(E) should
+    have a well-defined real-valued logarithm. 
+
+    Parameters
+    ----------    
+    m : numpy array
+        The superoperator matrix whose logarithm is taken.
+
+    target : numpy array
+        The target superoperator matrix. Should correspond to unitary superoperator, but this is not
+        explicitly enforced and must be enfored by callers.
+
+    mx_basis : stf or Basis object
+        Basis for m and target. Allowed values are strings castable to a basis, e.g.
+        Matrix-unit (std), Gell-Mann (gm), Pauli-product (pp), and Qutrit (qt), see `Basis` documentation
+        for more. Or a custom `Basis` object.
+    
+    order : int, optional (default 1)
+        Order of the BCH approximation to apply
+    
+    Returns
+    -------
+    logM : numpy array
+        An matrix of the same shape as `m`.
+    """
+    from pygsti.tools.errgenproptools import pairwise_bch_numerical
+
+    log_target = unitary_superoperator_matrix_log(target, mx_basis)
+
+    E = target.conj().T@m
+    log_E = near_identity_matrix_log(E)
+
+    approx_log_m = pairwise_bch_numerical(log_target, log_E, order)
+
+    return approx_log_m
 
 def eigenvalues(m: _np.ndarray, *, assume_hermitian: Optional[bool] = None,
                 assume_normal: bool = False) -> _np.ndarray:

--- a/test/unit/report/test_reportables.py
+++ b/test/unit/report/test_reportables.py
@@ -1,0 +1,211 @@
+import warnings
+
+import numpy as np
+
+import pygsti.tools.matrixtools as mt
+from pygsti.models import ExplicitOpModel
+from pygsti.models import modelconstruction as mc
+from pygsti.modelmembers.operations import FullArbitraryOp
+from pygsti.processors import QubitProcessorSpec
+from pygsti.report import reportables as rptbl
+from ..util import BaseCase
+
+# A Hadamard gate estimate taken from a failing case reported by an end user, whose error bars on the
+# rotation angle and log inexactness came back thousands of times too large. Kept verbatim (up to
+# zeroing the first row, which was TP to within 1e-16) because it exercises every part of the
+# pathology at once: the target has -1 eigenvalues, and the estimate has two *distinct* real negative
+# eigenvalues and therefore no real matrix logarithm at all.
+_HADAMARD_ESTIMATE = np.array([
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0005827386057873005, -1.596081539413828e-06, 0.0026842386726460437, 0.9931235460359923],
+    [-0.00047897732274857033, -0.0026434875205955393, -0.9881533456738786, -0.0028483281874282394],
+    [-0.000516711221855366, 0.9890358028125664, 0.0028055709936753892, 0.00026052111853187057]])
+
+_HADAMARD_TARGET = np.array([
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 1.0],
+    [0.0, 0.0, -1.0, 0.0],
+    [0.0, 1.0, 0.0, 0.0]])
+
+
+def _single_gate_model(mx):
+    """A one-qubit, one-gate model wrapping `mx` in the Pauli-product basis."""
+    model = ExplicitOpModel(['Q0'], 'pp')
+    model.operations['Gh'] = FullArbitraryOp(mx)
+    return model
+
+
+def _pi_rotation_target_model():
+    """A one-qubit model containing a pi rotation (Gxpi), whose superoperator has -1 eigenvalues,
+    alongside a pi/2 rotation (Gzpi2), whose superoperator does not."""
+    ps = QubitProcessorSpec(1, ['Gxpi', 'Gzpi2'], geometry='line')
+    return mc.create_explicit_model(ps, ideal_gate_type='full')
+
+
+def _damped(model, target, rates=(0.01, 0.02, 0.03)):
+    """Damp every gate of `target` anisotropically. Applied to a pi rotation this splits the
+    degenerate -1 eigenvalue into two distinct negative reals, so no real logarithm exists."""
+    damping = np.diag([1.0] + [1.0 - r for r in rates])
+    noisy = model.copy()
+    for gl in list(noisy.operations.keys()):
+        noisy.operations[gl] = FullArbitraryOp(
+            damping @ np.asarray(target.operations[gl].to_dense('HilbertSchmidt')))
+    return noisy
+
+
+class GeneralDecompositionTester(BaseCase):
+    """Covers the `-1`-eigenvalue branch of `general_decomposition`, which uses the BCH
+    approximation to the matrix logarithm."""
+
+    def setUp(self):
+        self.target = _pi_rotation_target_model()
+        self.noisy = _damped(self.target, self.target)
+
+    def _decomp(self, model):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return rptbl.general_decomposition(model, self.target)
+
+    def test_pi_rotation_decomposition(self):
+        # Gxpi has -1 eigenvalues and so exercises the BCH branch; Gzpi2 goes through real_matrix_log.
+        self.assertTrue(np.any(np.isclose(
+            np.linalg.eigvals(self.target.operations['Gxpi', 0].to_dense('HilbertSchmidt')), -1.0)))
+        self.assertFalse(np.any(np.isclose(
+            np.linalg.eigvals(self.target.operations['Gzpi2', 0].to_dense('HilbertSchmidt')), -1.0)))
+
+        decomp = self._decomp(self.noisy)
+
+        # Angles are reported in units of pi.
+        self.assertAlmostEqual(decomp['Gxpi:0 angle'], 1.0, places=4)
+        self.assertAlmostEqual(decomp['Gzpi2:0 angle'], 0.5, places=4)
+        self.assertArraysAlmostEqual(np.abs(decomp['Gxpi:0 axis']), np.array([1.0, 0.0, 0.0]), places=4)
+        self.assertArraysAlmostEqual(np.abs(decomp['Gzpi2:0 axis']), np.array([0.0, 0.0, 1.0]), places=4)
+        # The two rotation axes are perpendicular (pi/2 apart, again in units of pi).
+        self.assertAlmostEqual(decomp['Gxpi:0,Gzpi2:0 axis angle'], 0.5, places=4)
+
+    def test_pi_rotation_no_real_log_inexactness(self):
+        # The damped pi rotation has no real logarithm, so a nonzero inexactness is expected, but it
+        # should sit at the obstruction floor set by the splitting of the two negative eigenvalues.
+        decomp = self._decomp(self.noisy)
+        evals = np.linalg.eigvals(self.noisy.operations['Gxpi', 0].to_dense('HilbertSchmidt'))
+        neg = np.sort(evals[evals.real < 0].real)
+        self.assertEqual(len(neg), 2)
+        floor = np.sqrt(2) * abs(neg[1] - neg[0]) / 2
+        self.assertAlmostEqual(decomp['Gxpi:0 log inexactness'], floor, places=6)
+
+        # The pi/2 gate does have an exact real logarithm.
+        self.assertAlmostEqual(decomp['Gzpi2:0 log inexactness'], 0.0, places=8)
+
+    def test_pi_rotation_out_of_domain_yields_nan(self):
+        # If a gate is nowhere near its target the BCH construction has no valid domain, and the
+        # quantities for *that gate only* should degrade to NaN rather than raising.
+        broken = self.noisy.copy()
+        broken.operations['Gxpi', 0] = FullArbitraryOp(np.eye(4))
+
+        with self.assertWarns(Warning):
+            decomp = rptbl.general_decomposition(broken, self.target)
+
+        self.assertTrue(np.isnan(decomp['Gxpi:0 angle']))
+        self.assertTrue(np.isnan(decomp['Gxpi:0 log inexactness']))
+        self.assertTrue(np.all(np.isnan(decomp['Gxpi:0 axis'])))
+        self.assertFalse(np.isnan(decomp['Gzpi2:0 angle']))
+
+    def test_pi_rotation_gradient_is_step_size_independent(self):
+        """Regression test for spuriously large error bars on pi-rotation angles.
+
+        `ConfidenceRegionFactoryView` finite differences these quantities with respect to model
+        parameters. The logarithm must therefore be a smooth function of the gate. The optimizer-based
+        `approximate_matrix_log` is not: its output jitters at a level set by the optimizer tolerance
+        rather than by the perturbation, so the difference quotient blows up as 1/eps and the resulting
+        error bars are pure noise. The BCH construction is smooth, so the difference quotient converges.
+        """
+        base = self.noisy
+        v0 = base.to_vector()
+        rng = np.random.default_rng(2024)
+        direction = rng.normal(size=len(v0))
+        direction /= np.linalg.norm(direction)
+
+        def angle(eps):
+            perturbed = base.copy()
+            perturbed.from_vector(v0 + eps * direction)
+            return self._decomp(perturbed)['Gxpi:0 angle']
+
+        a0 = angle(0.0)
+        derivs = [(angle(eps) - a0) / eps for eps in (1e-8, 1e-7, 1e-6, 1e-5)]
+
+        # Spread across four decades of step size must be tiny relative to the derivative itself.
+        # With `approximate_matrix_log` these span roughly -108 to -0.25.
+        spread = max(derivs) - min(derivs)
+        self.assertLess(spread, 1e-4 * abs(np.mean(derivs)))
+
+
+class HadamardRegressionTester(BaseCase):
+    """Regression tests pinned to a real Hadamard estimate reported by an end user.
+
+    See `_HADAMARD_ESTIMATE`. This gate produced error bars roughly three orders of magnitude too
+    large, because the quantities below were computed with an optimizer whose output was not a smooth
+    function of the gate.
+    """
+
+    def setUp(self):
+        self.estimate = _single_gate_model(_HADAMARD_ESTIMATE)
+        self.target = _single_gate_model(_HADAMARD_TARGET)
+
+    def _decomp(self, model):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return rptbl.general_decomposition(model, self.target)
+
+    def test_no_real_logarithm_exists(self):
+        # The target is a pi rotation, and the estimate carries the resulting pathology: its two
+        # negative eigenvalues are real but *distinct*, which violates the condition for a real matrix
+        # logarithm to exist (they would have to be paired). real_matrix_log is forced to go complex.
+        evals = np.linalg.eigvals(_HADAMARD_ESTIMATE)
+        self.assertTrue(np.allclose(evals.imag, 0.0))
+        neg = np.sort(evals[evals.real < 0].real)
+        self.assertEqual(len(neg), 2)
+        self.assertAlmostEqual(neg[0], -0.990943613941, places=10)
+        self.assertAlmostEqual(neg[1], -0.988150228999, places=10)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertGreater(np.linalg.norm(mt.real_matrix_log(_HADAMARD_ESTIMATE, "ignore").imag), 1.0)
+
+    def test_decomposition_values(self):
+        decomp = self._decomp(self.estimate)
+        # Angle is in units of pi, so a Hadamard should come out just under 1.
+        self.assertAlmostEqual(decomp['Gh angle'], 0.9999652938, places=9)
+        self.assertAlmostEqual(decomp['Gh log inexactness'], 0.0021073766, places=9)
+        self.assertArraysAlmostEqual(
+            decomp['Gh axis'], np.array([0.7070608183, 7.9894403e-06, 0.7071527410]), places=8)
+
+    def test_inexactness_is_near_the_obstruction_floor(self):
+        # Because no real logarithm exists, a nonzero inexactness is unavoidable. Its lower bound is
+        # set by the splitting of the two negative eigenvalues, and BCH should land close to it -- so
+        # the reported inexactness reflects a real property of the gate rather than optimizer noise.
+        decomp = self._decomp(self.estimate)
+        evals = np.linalg.eigvals(_HADAMARD_ESTIMATE)
+        neg = np.sort(evals[evals.real < 0].real)
+        floor = np.sqrt(2) * abs(neg[1] - neg[0]) / 2
+        self.assertAlmostEqual(floor, 0.001975221, places=8)
+        self.assertGreaterEqual(decomp['Gh log inexactness'], floor)
+        self.assertLess(decomp['Gh log inexactness'], 1.1 * floor)
+
+    def test_gradient_is_step_size_independent(self):
+        # The failure this gate was reported for. `approximate_matrix_log` gives a relative spread of
+        # about 3.0 here (i.e. the finite difference is entirely noise, and diverges as 1/eps);
+        # the BCH construction gives about 8e-7.
+        v0 = self.estimate.to_vector()
+        rng = np.random.default_rng(0)
+        direction = rng.normal(size=len(v0))
+        direction /= np.linalg.norm(direction)
+
+        def angle(eps):
+            perturbed = _single_gate_model(_HADAMARD_ESTIMATE)
+            perturbed.from_vector(v0 + eps * direction)
+            return self._decomp(perturbed)['Gh angle']
+
+        a0 = angle(0.0)
+        derivs = [(angle(eps) - a0) / eps for eps in (1e-9, 1e-8, 1e-7, 1e-6)]
+        spread = (max(derivs) - min(derivs)) / abs(np.mean(derivs))
+        self.assertLess(spread, 1e-4)

--- a/test/unit/report/test_reportables.py
+++ b/test/unit/report/test_reportables.py
@@ -49,7 +49,7 @@ def _damped(model, target, rates=(0.01, 0.02, 0.03)):
     noisy = model.copy()
     for gl in list(noisy.operations.keys()):
         noisy.operations[gl] = FullArbitraryOp(
-            damping @ np.asarray(target.operations[gl].to_dense('HilbertSchmidt')))
+            damping @ target.operations[gl].to_dense('HilbertSchmidt'))
     return noisy
 
 

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -8,53 +8,7 @@ import pygsti.tools.matrixtools as mt
 from ..util import BaseCase
 
 
-# Hamiltonian generators in the normalized Pauli-product basis, as real superoperator generators.
-_HX = np.zeros((4, 4)); _HX[2, 3] = -1; _HX[3, 2] = 1
-_HZ = np.zeros((4, 4)); _HZ[1, 2] = -1; _HZ[2, 1] = 1
-
-
-def _pi_rotation_superop():
-    """X(pi) as a superoperator in the normalized Pauli-product basis: eigenvalues (1, 1, -1, -1)."""
-    return np.diag([1.0, 1.0, -1.0, -1.0])
-
-
-def _pi_over_2_rotation_superop():
-    """Z(pi/2) as a superoperator; eigenvalues (1, 1, +i, -i), so its real logarithm is unique."""
-    return spl.expm((np.pi / 2) * _HZ)
-
-
-def _anisotropically_damped(target, rates=(0.01, 0.02, 0.03)):
-    """Damp the three Pauli axes at *different* rates.
-
-    Applied to a pi-rotation this splits the doubly-degenerate -1 eigenvalue into two distinct
-    negative real eigenvalues, so the result has no real matrix logarithm at all.
-    """
-    return np.diag([1.0] + [1.0 - r for r in rates]) @ target
-
-
-def _coherently_perturbed(target, scale=1.0):
-    """Apply a real, trace-preserving error generator with a coherent part that does not commute
-    with log(target), so that the BCH truncation error is actually visible."""
-    L = scale * (0.3 * _HZ + 0.15 * _HX + np.diag([0.0, -0.01, -0.02, -0.03]))
-    return spl.expm(L) @ target
-
-
-# A Hadamard gate estimate and its target, taken from a failing case reported by an end user. The
-# estimate has two distinct real negative eigenvalues and so has no real matrix logarithm.
-_HADAMARD_ESTIMATE = np.array([
-    [1.0, 0.0, 0.0, 0.0],
-    [0.0005827386057873005, -1.596081539413828e-06, 0.0026842386726460437, 0.9931235460359923],
-    [-0.00047897732274857033, -0.0026434875205955393, -0.9881533456738786, -0.0028483281874282394],
-    [-0.000516711221855366, 0.9890358028125664, 0.0028055709936753892, 0.00026052111853187057]])
-
-_HADAMARD_TARGET = np.array([
-    [1.0, 0.0, 0.0, 0.0],
-    [0.0, 0.0, 0.0, 1.0],
-    [0.0, 0.0, -1.0, 0.0],
-    [0.0, 1.0, 0.0, 0.0]])
-
-
-class MatrixToolsTester(BaseCase):
+class GeneralMatrixToolsTester(BaseCase):
 
     def test_is_hermitian(self):
         herm_mx = np.array([[ 1, 1+2j],
@@ -156,100 +110,6 @@ class MatrixToolsTester(BaseCase):
                     message='invalid value encountered in dot', category=RuntimeWarning
                 )
                 mt.real_matrix_log(a)
-
-    def test_approximate_matrix_log_BCH_exact_at_target(self):
-        # When m == target the error map is the identity, so the BCH result should be exactly log(target).
-        target = _pi_rotation_superop()
-        log_target = mt.unitary_superoperator_matrix_log(target, 'pp')
-        for order in (1, 2, 3, 4, 5):
-            logM = mt.approximate_matrix_log_BCH(target, target, 'pp', order=order)
-            self.assertArraysAlmostEqual(logM, log_target)
-            self.assertArraysAlmostEqual(spl.expm(logM), target)
-
-    def test_approximate_matrix_log_BCH_returns_real(self):
-        target = _pi_rotation_superop()
-        m = _anisotropically_damped(target)
-        logM = mt.approximate_matrix_log_BCH(m, target, 'pp', order=3)
-        self.assertTrue(np.isrealobj(logM), "approximate_matrix_log_BCH must return a real array")
-
-    def test_approximate_matrix_log_BCH_no_real_log_exists(self):
-        # A pi-rotation with anisotropic damping perpendicular to the rotation axis has two *distinct*
-        # negative real eigenvalues, so it has no real logarithm at all: real_matrix_log cannot pair them
-        # and returns a complex result. The BCH construction still produces a usable real generator.
-        target = _pi_rotation_superop()
-        m = _anisotropically_damped(target)
-
-        neg = np.sort(np.linalg.eigvals(m)[np.linalg.eigvals(m).real < 0].real)
-        self.assertEqual(len(neg), 2)
-        self.assertGreater(abs(neg[1] - neg[0]), 1e-3)  # distinct => no real log
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self.assertGreater(np.linalg.norm(mt.real_matrix_log(m, "ignore").imag), 1e-6)
-
-        logM = mt.approximate_matrix_log_BCH(m, target, 'pp', order=3)
-        self.assertTrue(np.isrealobj(logM))
-        # exp(logM) cannot equal m exactly. The obstruction floor is set by the splitting of the two
-        # negative eigenvalues; for this purely dissipative error BCH already saturates it.
-        floor = np.sqrt(2) * abs(neg[1] - neg[0]) / 2
-        self.assertAlmostEqual(np.linalg.norm(spl.expm(logM) - m), floor, places=6)
-
-    def test_approximate_matrix_log_BCH_improves_with_order(self):
-        # The BCH series is only truncated when log(target) and log(error map) fail to commute, so this
-        # needs a coherent error component; pure damping is reproduced exactly at every order.
-        target = _pi_rotation_superop()
-        m = _coherently_perturbed(target)
-        errs = [np.linalg.norm(spl.expm(mt.approximate_matrix_log_BCH(m, target, 'pp', order=o)) - m)
-                for o in (1, 2, 3)]
-        self.assertLess(errs[1], errs[0])
-        self.assertLess(errs[2], errs[1])
-
-    def test_approximate_matrix_log_BCH_on_reported_hadamard(self):
-        # Pinned against a real failing gate (see _HADAMARD_ESTIMATE). Order 4 is deliberately not
-        # expected to improve on order 3: its contribution enters only at second order in the error
-        # generator. This is why general_decomposition hardcodes order 3.
-        errs = [np.linalg.norm(
-            spl.expm(mt.approximate_matrix_log_BCH(_HADAMARD_ESTIMATE, _HADAMARD_TARGET, 'pp', order=o))
-            - _HADAMARD_ESTIMATE) for o in (1, 2, 3, 4, 5)]
-        for expected, actual in zip([7.6994e-03, 4.4667e-03, 2.1074e-03, 2.1073e-03, 1.9894e-03], errs):
-            self.assertAlmostEqual(actual, expected, places=6)
-        self.assertLess(errs[1], errs[0])
-        self.assertLess(errs[2], errs[1])
-
-    def test_approximate_matrix_log_BCH_at_convergence_boundary(self):
-        # For a pi rotation the spectral radius of ad_{log(target)} is *exactly* 2*pi, the radius of
-        # convergence of the BCH series. Order 3 remains well behaved on that boundary, but the margin
-        # is nil -- multi-qubit targets can exceed 2*pi, where higher orders degrade.
-        log_target = mt.unitary_superoperator_matrix_log(_HADAMARD_TARGET, 'pp')
-        d = log_target.shape[0]
-        ad = np.kron(log_target, np.eye(d)) - np.kron(np.eye(d), log_target.T)
-        self.assertAlmostEqual(max(abs(np.linalg.eigvals(ad))), 2 * np.pi, places=9)
-
-    def test_approximate_matrix_log_BCH_converges_to_real_log(self):
-        # A pi-rotation target has *no unique* logarithm (branches differ by 2*pi*i), so compare against
-        # real_matrix_log on a pi/2 target, where the principal real log is unique and BCH must converge
-        # to it as the order increases.
-        target = _pi_over_2_rotation_superop()
-        m = _coherently_perturbed(target, scale=0.1)
-        exact = np.real(mt.real_matrix_log(m, "raise"))
-        errs = [np.linalg.norm(mt.approximate_matrix_log_BCH(m, target, 'pp', order=o) - exact)
-                for o in (1, 3, 5)]
-        self.assertLess(errs[1], errs[0])
-        self.assertLess(errs[2], errs[1])
-        self.assertLess(errs[2], 1e-3)
-
-    def test_approximate_matrix_log_BCH_raises_out_of_domain(self):
-        # If inv(target) @ m is not near the identity its principal log is not real, and
-        # near_identity_matrix_log raises. general_decomposition relies on this being an AssertionError.
-        target = _pi_rotation_superop()
-        with self.assertRaises(AssertionError):
-            mt.approximate_matrix_log_BCH(-target, target, 'pp', order=3)
-
-    def test_approximate_matrix_log_BCH_validates_order(self):
-        target = _pi_rotation_superop()
-        m = _anisotropically_damped(target)
-        for bad_order in (0, -1, 6):
-            with self.assertRaises(ValueError):
-                mt.approximate_matrix_log_BCH(m, target, 'pp', order=bad_order)
 
     def test_minweight_match(self):
         a = np.array([1, 2, 3, 4], 'd')
@@ -402,24 +262,157 @@ class MatrixToolsTester(BaseCase):
             np.array(sorted(actual, key=sort_key)), np.array(sorted(expected, key=sort_key)))
 
 
-def _pp_computational_superket(zvals):
+class ApproximateMatrixLogBCHTester(BaseCase):
     """
-    Independent reference for the Pauli-product super-ket of a computational
-    basis state, built by explicit Kronecker product.
-
-    |z><z| = (I + (-1)**z Z) / 2, whose Pauli-product coefficient vector
-    (normalized so the PP basis is orthonormal) is [1, 0, 0, (-1)**z]/sqrt(2).
-    Deliberately does not share any code with the routines under test.
+    Cover ``approximate_matrix_log_BCH``, which builds a *real* generator for a
+    gate that may have no real matrix logarithm at all, by BCH-combining the
+    (unique, real) logarithm of the target with the near-identity logarithm of
+    the error map.
     """
-    vec = np.array([1.0])
-    for z in zvals:
-        vec = np.kron(vec, np.array([1, 0, 0, 1 - 2 * z], 'd') / np.sqrt(2))
-    return vec
 
+    # Hamiltonian generators in the normalized Pauli-product basis, as real superoperator generators.
+    HX = np.array([[0, 0, 0, 0],
+                   [0, 0, 0, 0],
+                   [0, 0, 0, -1],
+                   [0, 0, 1, 0]], 'd')
+    HZ = np.array([[0, 0, 0, 0],
+                   [0, 0, -1, 0],
+                   [0, 1, 0, 0],
+                   [0, 0, 0, 0]], 'd')
 
-def _zvals_to_int(zvals):
-    """Encode z-values little-endian, matching EffectRepComputational."""
-    return sum(z << i for i, z in enumerate(zvals))
+    # A Hadamard gate estimate and its target, taken from a failing case reported by an end user. The
+    # estimate has two distinct real negative eigenvalues and so has no real matrix logarithm.
+    HADAMARD_ESTIMATE = np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0005827386057873005, -1.596081539413828e-06, 0.0026842386726460437, 0.9931235460359923],
+        [-0.00047897732274857033, -0.0026434875205955393, -0.9881533456738786, -0.0028483281874282394],
+        [-0.000516711221855366, 0.9890358028125664, 0.0028055709936753892, 0.00026052111853187057]])
+
+    HADAMARD_TARGET = np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, -1.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0]])
+
+    @staticmethod
+    def pi_rotation_superop():
+        """X(pi) as a superoperator in the normalized Pauli-product basis: eigenvalues (1, 1, -1, -1)."""
+        return np.diag([1.0, 1.0, -1.0, -1.0])
+
+    @classmethod
+    def pi_over_2_rotation_superop(cls):
+        """Z(pi/2) as a superoperator; eigenvalues (1, 1, +i, -i), so its real logarithm is unique."""
+        return spl.expm((np.pi / 2) * cls.HZ)
+
+    @staticmethod
+    def anisotropically_damped(target, rates=(0.01, 0.02, 0.03)):
+        """Damp the three Pauli axes at *different* rates.
+
+        Applied to a pi-rotation this splits the doubly-degenerate -1 eigenvalue into two distinct
+        negative real eigenvalues, so the result has no real matrix logarithm at all.
+        """
+        return np.diag([1.0] + [1.0 - r for r in rates]) @ target
+
+    @classmethod
+    def coherently_perturbed(cls, target, scale=1.0):
+        """Apply a real, trace-preserving error generator with a coherent part that does not commute
+        with log(target), so that the BCH truncation error is actually visible."""
+        L = scale * (0.3 * cls.HZ + 0.15 * cls.HX + np.diag([0.0, -0.01, -0.02, -0.03]))
+        return spl.expm(L) @ target
+
+    def test_exact_at_target(self):
+        # When m == target the error map is the identity, so the BCH result should be exactly log(target).
+        target = self.pi_rotation_superop()
+        log_target = mt.unitary_superoperator_matrix_log(target, 'pp')
+        for order in (1, 2, 3, 4, 5):
+            logM = mt.approximate_matrix_log_BCH(target, target, 'pp', order=order)
+            self.assertArraysAlmostEqual(logM, log_target)
+            self.assertArraysAlmostEqual(spl.expm(logM), target)
+
+    def test_returns_real(self):
+        target = self.pi_rotation_superop()
+        m = self.anisotropically_damped(target)
+        logM = mt.approximate_matrix_log_BCH(m, target, 'pp', order=3)
+        self.assertTrue(np.isrealobj(logM), "approximate_matrix_log_BCH must return a real array")
+
+    def test_no_real_log_exists(self):
+        # A pi-rotation with anisotropic damping perpendicular to the rotation axis has two *distinct*
+        # negative real eigenvalues, so it has no real logarithm at all: real_matrix_log cannot pair them
+        # and returns a complex result. The BCH construction still produces a usable real generator.
+        target = self.pi_rotation_superop()
+        m = self.anisotropically_damped(target)
+
+        neg = np.sort(np.linalg.eigvals(m)[np.linalg.eigvals(m).real < 0].real)
+        self.assertEqual(len(neg), 2)
+        self.assertGreater(abs(neg[1] - neg[0]), 1e-3)  # distinct => no real log
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertGreater(np.linalg.norm(mt.real_matrix_log(m, "ignore").imag), 1e-6)
+
+        logM = mt.approximate_matrix_log_BCH(m, target, 'pp', order=3)
+        self.assertTrue(np.isrealobj(logM))
+        # exp(logM) cannot equal m exactly. The obstruction floor is set by the splitting of the two
+        # negative eigenvalues; for this purely dissipative error BCH already saturates it.
+        floor = np.sqrt(2) * abs(neg[1] - neg[0]) / 2
+        self.assertAlmostEqual(np.linalg.norm(spl.expm(logM) - m), floor, places=6)
+
+    def test_improves_with_order(self):
+        # The BCH series is only truncated when log(target) and log(error map) fail to commute, so this
+        # needs a coherent error component; pure damping is reproduced exactly at every order.
+        target = self.pi_rotation_superop()
+        m = self.coherently_perturbed(target)
+        errs = [np.linalg.norm(spl.expm(mt.approximate_matrix_log_BCH(m, target, 'pp', order=o)) - m)
+                for o in (1, 2, 3)]
+        self.assertLess(errs[1], errs[0])
+        self.assertLess(errs[2], errs[1])
+
+    def test_on_reported_hadamard(self):
+        # Pinned against a real failing gate (see HADAMARD_ESTIMATE). Order 4 is deliberately not
+        # expected to improve on order 3: its contribution enters only at second order in the error
+        # generator. This is why general_decomposition hardcodes order 3.
+        errs = [np.linalg.norm(
+            spl.expm(mt.approximate_matrix_log_BCH(self.HADAMARD_ESTIMATE, self.HADAMARD_TARGET, 'pp', order=o))
+            - self.HADAMARD_ESTIMATE) for o in (1, 2, 3, 4, 5)]
+        for expected, actual in zip([7.6994e-03, 4.4667e-03, 2.1074e-03, 2.1073e-03, 1.9894e-03], errs):
+            self.assertAlmostEqual(actual, expected, places=6)
+        self.assertLess(errs[1], errs[0])
+        self.assertLess(errs[2], errs[1])
+
+    def test_at_convergence_boundary(self):
+        # For a pi rotation the spectral radius of ad_{log(target)} is *exactly* 2*pi, the radius of
+        # convergence of the BCH series. Order 3 remains well behaved on that boundary, but the margin
+        # is nil -- multi-qubit targets can exceed 2*pi, where higher orders degrade.
+        log_target = mt.unitary_superoperator_matrix_log(self.HADAMARD_TARGET, 'pp')
+        d = log_target.shape[0]
+        ad = np.kron(log_target, np.eye(d)) - np.kron(np.eye(d), log_target.T)
+        self.assertAlmostEqual(max(abs(np.linalg.eigvals(ad))), 2 * np.pi, places=9)
+
+    def test_converges_to_real_log(self):
+        # A pi-rotation target has *no unique* logarithm (branches differ by 2*pi*i), so compare against
+        # real_matrix_log on a pi/2 target, where the principal real log is unique and BCH must converge
+        # to it as the order increases.
+        target = self.pi_over_2_rotation_superop()
+        m = self.coherently_perturbed(target, scale=0.1)
+        exact = np.real(mt.real_matrix_log(m, "raise"))
+        errs = [np.linalg.norm(mt.approximate_matrix_log_BCH(m, target, 'pp', order=o) - exact)
+                for o in (1, 3, 5)]
+        self.assertLess(errs[1], errs[0])
+        self.assertLess(errs[2], errs[1])
+        self.assertLess(errs[2], 1e-3)
+
+    def test_raises_out_of_domain(self):
+        # If inv(target) @ m is not near the identity its principal log is not real, and
+        # near_identity_matrix_log raises. general_decomposition relies on this being an AssertionError.
+        target = self.pi_rotation_superop()
+        with self.assertRaises(AssertionError):
+            mt.approximate_matrix_log_BCH(-target, target, 'pp', order=3)
+
+    def test_validates_order(self):
+        target = self.pi_rotation_superop()
+        m = self.anisotropically_damped(target)
+        for bad_order in (0, -1, 6):
+            with self.assertRaises(ValueError):
+                mt.approximate_matrix_log_BCH(m, target, 'pp', order=bad_order)
 
 
 class ZvalsInt64Tester(BaseCase):
@@ -436,19 +429,39 @@ class ZvalsInt64Tester(BaseCase):
     ALL_ZVALS = [(), (0,), (1,), (0, 0), (0, 1), (1, 0), (1, 1),
                  (0, 1, 0), (1, 1, 0), (1, 0, 1), (1, 1, 1)]
 
+    @staticmethod
+    def pp_computational_superket(zvals):
+        """
+        Independent reference for the Pauli-product super-ket of a computational
+        basis state, built by explicit Kronecker product.
+
+        |z><z| = (I + (-1)**z Z) / 2, whose Pauli-product coefficient vector
+        (normalized so the PP basis is orthonormal) is [1, 0, 0, (-1)**z]/sqrt(2).
+        Deliberately does not share any code with the routines under test.
+        """
+        vec = np.array([1.0])
+        for z in zvals:
+            vec = np.kron(vec, np.array([1, 0, 0, 1 - 2 * z], 'd') / np.sqrt(2))
+        return vec
+
+    @staticmethod
+    def zvals_to_int(zvals):
+        """Encode z-values little-endian, matching EffectRepComputational."""
+        return sum(z << i for i, z in enumerate(zvals))
+
     def test_to_dense_matches_kron_reference(self):
         for zvals in self.ALL_ZVALS:
             with self.subTest(zvals=zvals):
-                actual = mt.zvals_int64_to_dense(_zvals_to_int(zvals), len(zvals))
-                self.assertArraysAlmostEqual(actual, _pp_computational_superket(zvals))
+                actual = mt.zvals_int64_to_dense(self.zvals_to_int(zvals), len(zvals))
+                self.assertArraysAlmostEqual(actual, self.pp_computational_superket(zvals))
 
     def test_probability_matches_kron_reference(self):
         rng = np.random.default_rng(0)
         for zvals in self.ALL_ZVALS:
             with self.subTest(zvals=zvals):
                 state = rng.standard_normal(4 ** len(zvals))
-                actual = mt.zvals_int64_probability(_zvals_to_int(zvals), len(zvals), state)
-                expected = np.dot(_pp_computational_superket(zvals), state)
+                actual = mt.zvals_int64_probability(self.zvals_to_int(zvals), len(zvals), state)
+                expected = np.dot(self.pp_computational_superket(zvals), state)
                 self.assertAlmostEqual(actual, expected)
 
     def test_probability_agrees_with_densifying_then_dotting(self):
@@ -457,7 +470,7 @@ class ZvalsInt64Tester(BaseCase):
         rng = np.random.default_rng(1)
         for zvals in self.ALL_ZVALS:
             with self.subTest(zvals=zvals):
-                zvals_int, nq = _zvals_to_int(zvals), len(zvals)
+                zvals_int, nq = self.zvals_to_int(zvals), len(zvals)
                 state = rng.standard_normal(4 ** nq)
                 dense = mt.zvals_int64_to_dense(zvals_int, nq)
                 self.assertAlmostEqual(mt.zvals_int64_probability(zvals_int, nq, state),
@@ -478,7 +491,7 @@ class ZvalsInt64Tester(BaseCase):
         # abs_elval is a caller-supplied cache of 1/sqrt(2)**nqubits; omitting it
         # must compute the same thing.
         zvals = (1, 0, 1)
-        zvals_int, nq = _zvals_to_int(zvals), len(zvals)
+        zvals_int, nq = self.zvals_to_int(zvals), len(zvals)
         state = np.random.default_rng(2).standard_normal(4 ** nq)
         abs_elval = 1 / (np.sqrt(2) ** nq)
         self.assertArraysAlmostEqual(mt.zvals_int64_to_dense(zvals_int, nq),
@@ -518,5 +531,5 @@ class ZvalsInt64Tester(BaseCase):
         mt._zvals_int64_to_dense_cache.clear()
         first = mt.zvals_int64_to_dense(0b01, 2)
         second = mt.zvals_int64_to_dense(0b10, 2)
-        self.assertArraysAlmostEqual(first, _pp_computational_superket((1, 0)))
-        self.assertArraysAlmostEqual(second, _pp_computational_superket((0, 1)))
+        self.assertArraysAlmostEqual(first, self.pp_computational_superket((1, 0)))
+        self.assertArraysAlmostEqual(second, self.pp_computational_superket((0, 1)))

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -1,9 +1,57 @@
+import warnings
+
 import numpy as np
 import scipy.linalg as spl
 import scipy.sparse as sps
 
 import pygsti.tools.matrixtools as mt
 from ..util import BaseCase
+
+
+# Hamiltonian generators in the normalized Pauli-product basis, as real superoperator generators.
+_HX = np.zeros((4, 4)); _HX[2, 3] = -1; _HX[3, 2] = 1
+_HZ = np.zeros((4, 4)); _HZ[1, 2] = -1; _HZ[2, 1] = 1
+
+
+def _pi_rotation_superop():
+    """X(pi) as a superoperator in the normalized Pauli-product basis: eigenvalues (1, 1, -1, -1)."""
+    return np.diag([1.0, 1.0, -1.0, -1.0])
+
+
+def _pi_over_2_rotation_superop():
+    """Z(pi/2) as a superoperator; eigenvalues (1, 1, +i, -i), so its real logarithm is unique."""
+    return spl.expm((np.pi / 2) * _HZ)
+
+
+def _anisotropically_damped(target, rates=(0.01, 0.02, 0.03)):
+    """Damp the three Pauli axes at *different* rates.
+
+    Applied to a pi-rotation this splits the doubly-degenerate -1 eigenvalue into two distinct
+    negative real eigenvalues, so the result has no real matrix logarithm at all.
+    """
+    return np.diag([1.0] + [1.0 - r for r in rates]) @ target
+
+
+def _coherently_perturbed(target, scale=1.0):
+    """Apply a real, trace-preserving error generator with a coherent part that does not commute
+    with log(target), so that the BCH truncation error is actually visible."""
+    L = scale * (0.3 * _HZ + 0.15 * _HX + np.diag([0.0, -0.01, -0.02, -0.03]))
+    return spl.expm(L) @ target
+
+
+# A Hadamard gate estimate and its target, taken from a failing case reported by an end user. The
+# estimate has two distinct real negative eigenvalues and so has no real matrix logarithm.
+_HADAMARD_ESTIMATE = np.array([
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0005827386057873005, -1.596081539413828e-06, 0.0026842386726460437, 0.9931235460359923],
+    [-0.00047897732274857033, -0.0026434875205955393, -0.9881533456738786, -0.0028483281874282394],
+    [-0.000516711221855366, 0.9890358028125664, 0.0028055709936753892, 0.00026052111853187057]])
+
+_HADAMARD_TARGET = np.array([
+    [1.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 1.0],
+    [0.0, 0.0, -1.0, 0.0],
+    [0.0, 1.0, 0.0, 0.0]])
 
 
 class MatrixToolsTester(BaseCase):
@@ -108,6 +156,100 @@ class MatrixToolsTester(BaseCase):
                     message='invalid value encountered in dot', category=RuntimeWarning
                 )
                 mt.real_matrix_log(a)
+
+    def test_approximate_matrix_log_BCH_exact_at_target(self):
+        # When m == target the error map is the identity, so the BCH result should be exactly log(target).
+        target = _pi_rotation_superop()
+        log_target = mt.unitary_superoperator_matrix_log(target, 'pp')
+        for order in (1, 2, 3, 4, 5):
+            logM = mt.approximate_matrix_log_BCH(target, target, 'pp', order=order)
+            self.assertArraysAlmostEqual(logM, log_target)
+            self.assertArraysAlmostEqual(spl.expm(logM), target)
+
+    def test_approximate_matrix_log_BCH_returns_real(self):
+        target = _pi_rotation_superop()
+        m = _anisotropically_damped(target)
+        logM = mt.approximate_matrix_log_BCH(m, target, 'pp', order=3)
+        self.assertTrue(np.isrealobj(logM), "approximate_matrix_log_BCH must return a real array")
+
+    def test_approximate_matrix_log_BCH_no_real_log_exists(self):
+        # A pi-rotation with anisotropic damping perpendicular to the rotation axis has two *distinct*
+        # negative real eigenvalues, so it has no real logarithm at all: real_matrix_log cannot pair them
+        # and returns a complex result. The BCH construction still produces a usable real generator.
+        target = _pi_rotation_superop()
+        m = _anisotropically_damped(target)
+
+        neg = np.sort(np.linalg.eigvals(m)[np.linalg.eigvals(m).real < 0].real)
+        self.assertEqual(len(neg), 2)
+        self.assertGreater(abs(neg[1] - neg[0]), 1e-3)  # distinct => no real log
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertGreater(np.linalg.norm(mt.real_matrix_log(m, "ignore").imag), 1e-6)
+
+        logM = mt.approximate_matrix_log_BCH(m, target, 'pp', order=3)
+        self.assertTrue(np.isrealobj(logM))
+        # exp(logM) cannot equal m exactly. The obstruction floor is set by the splitting of the two
+        # negative eigenvalues; for this purely dissipative error BCH already saturates it.
+        floor = np.sqrt(2) * abs(neg[1] - neg[0]) / 2
+        self.assertAlmostEqual(np.linalg.norm(spl.expm(logM) - m), floor, places=6)
+
+    def test_approximate_matrix_log_BCH_improves_with_order(self):
+        # The BCH series is only truncated when log(target) and log(error map) fail to commute, so this
+        # needs a coherent error component; pure damping is reproduced exactly at every order.
+        target = _pi_rotation_superop()
+        m = _coherently_perturbed(target)
+        errs = [np.linalg.norm(spl.expm(mt.approximate_matrix_log_BCH(m, target, 'pp', order=o)) - m)
+                for o in (1, 2, 3)]
+        self.assertLess(errs[1], errs[0])
+        self.assertLess(errs[2], errs[1])
+
+    def test_approximate_matrix_log_BCH_on_reported_hadamard(self):
+        # Pinned against a real failing gate (see _HADAMARD_ESTIMATE). Order 4 is deliberately not
+        # expected to improve on order 3: its contribution enters only at second order in the error
+        # generator. This is why general_decomposition hardcodes order 3.
+        errs = [np.linalg.norm(
+            spl.expm(mt.approximate_matrix_log_BCH(_HADAMARD_ESTIMATE, _HADAMARD_TARGET, 'pp', order=o))
+            - _HADAMARD_ESTIMATE) for o in (1, 2, 3, 4, 5)]
+        for expected, actual in zip([7.6994e-03, 4.4667e-03, 2.1074e-03, 2.1073e-03, 1.9894e-03], errs):
+            self.assertAlmostEqual(actual, expected, places=6)
+        self.assertLess(errs[1], errs[0])
+        self.assertLess(errs[2], errs[1])
+
+    def test_approximate_matrix_log_BCH_at_convergence_boundary(self):
+        # For a pi rotation the spectral radius of ad_{log(target)} is *exactly* 2*pi, the radius of
+        # convergence of the BCH series. Order 3 remains well behaved on that boundary, but the margin
+        # is nil -- multi-qubit targets can exceed 2*pi, where higher orders degrade.
+        log_target = mt.unitary_superoperator_matrix_log(_HADAMARD_TARGET, 'pp')
+        d = log_target.shape[0]
+        ad = np.kron(log_target, np.eye(d)) - np.kron(np.eye(d), log_target.T)
+        self.assertAlmostEqual(max(abs(np.linalg.eigvals(ad))), 2 * np.pi, places=9)
+
+    def test_approximate_matrix_log_BCH_converges_to_real_log(self):
+        # A pi-rotation target has *no unique* logarithm (branches differ by 2*pi*i), so compare against
+        # real_matrix_log on a pi/2 target, where the principal real log is unique and BCH must converge
+        # to it as the order increases.
+        target = _pi_over_2_rotation_superop()
+        m = _coherently_perturbed(target, scale=0.1)
+        exact = np.real(mt.real_matrix_log(m, "raise"))
+        errs = [np.linalg.norm(mt.approximate_matrix_log_BCH(m, target, 'pp', order=o) - exact)
+                for o in (1, 3, 5)]
+        self.assertLess(errs[1], errs[0])
+        self.assertLess(errs[2], errs[1])
+        self.assertLess(errs[2], 1e-3)
+
+    def test_approximate_matrix_log_BCH_raises_out_of_domain(self):
+        # If inv(target) @ m is not near the identity its principal log is not real, and
+        # near_identity_matrix_log raises. general_decomposition relies on this being an AssertionError.
+        target = _pi_rotation_superop()
+        with self.assertRaises(AssertionError):
+            mt.approximate_matrix_log_BCH(-target, target, 'pp', order=3)
+
+    def test_approximate_matrix_log_BCH_validates_order(self):
+        target = _pi_rotation_superop()
+        m = _anisotropically_damped(target)
+        for bad_order in (0, -1, 6):
+            with self.assertRaises(ValueError):
+                mt.approximate_matrix_log_BCH(m, target, 'pp', order=bad_order)
 
     def test_minweight_match(self):
         a = np.array([1, 2, 3, 4], 'd')


### PR DESCRIPTION
# Fix spuriously large error bars on pi-rotation gate angles

## Problem

This problem was found while investigating an issue reported by @pcwysoc in which anamolously large error bars for the rotation angle of a Hadamard gate were reported by the general_decomposition function in `pygsti.report.reportables`, and found in the gate decompositions table of GST reports. This problem was isolated to the failure of the computation of the matrix logarithm, and the underlying pathology will generally hold for gates whose target has a `-1` eigenvalue (any pi rotation: Hadamard, X(pi), CNOT, CZ). In the case reported by @pcwysoc error bars up to three orders-of-magnitude too large were reported.

For such a target to have a real-valued logarithm, as is required for extracting the rotation angle, it must have negative eigenvalues that are paired (See Walter J. Culver Proceedings of the American Mathematical Society, Vol. 17, No. 5. (Oct., 1966), pp. 1146-1151). This is true at the target, but for the noisy estimated gate this degeneracy is broken,  so generically it has no real logarithm at all. The original fallback for this case was to use the function  `pygsti.tools.matrixtools.approximate_matrix_log`, which used an L-BFGS-B optimization to find approximate real-valued logarithms. This function was failing, and this was being reported as a large value of the 'log inexactness' reported by `general_decomposition`, which corresponds to the error picked up from a round trip through the logarithm and re-exponentiation. Additionally, the output of this optimization was not numerically stable in general, and large jumps in the solution would result in finite differences computed by `ConfidenceRegionFactoryView` as part of error bar construction to blow up.

## Fix
New `matrixtools.approximate_matrix_log_BCH`: take the logarithm of the near-identity error map `inv(target)@ m`, which is unique and smooth, then recombine with the analytically known `log(target)` via BCH. Truncated BCH is a polynomial in the matrix entries, so it is smooth by construction. Used in the `-1`-eigenvalue branch of `general_decomposition`; other gates are untouched.

On a user-reported Hadamard estimate (95% CI):

| | before | after |
|---|---|---|
| angle |0.9999583578541491 ± 0.12358208448741723 | 0.9999652938476625 ± 7.52e-05 |
| log inexactness |0.002597049819903578 ± 4.75471751032029 | 0.0021073765899969656 ± 2.25e-04 |
| runtime | 12.1 s | 0.8 s |

(While running these tests I also just notices the error bar pathologies unsurprisingly extended to the rotation axis uncertainty. From before the fix 'Gh:0 axis': ReportableQty([ 7.06958993e-01 -1.13832251e-05  7.07254538e-01] +/- [1.4709484  0.10589819 1.47032276]).)

Another symptom of this issue was instability in the value of finite difference derivatives with step size eps.  `d(angle)/d(eps)` is now stable to 6 significant figures across four decades of step size.

## Notes

- **Order is hardcoded to 3.** Order empirically found not to help. Order 5 found empirically to be unsafe, since BCH converges only while the spectral radius of `ad_log(target)` is under `2*pi` — exactly attained by a single-qubit pi rotation and exceeded by some multi-qubit targets. In testing nonmonotonicity was observed.

## Tests

`test/unit/report/test_reportables.py` (new) pins the reported gate in a one-gate model, reproducing the full pipeline; reverting the fix fails 3 of its 4 regression tests. `test/unit/tools/test_matrixtools.py` adds round-trip, order-convergence, domain-guard, and order-validation coverage.