### PR TITLE
HTML report speed and table resizing

### DIFF
--- a/pygsti/report/templates/drift_html_report/main.html
+++ b/pygsti/report/templates/drift_html_report/main.html
@@ -47,7 +47,18 @@
               if (((parts.length == 1) && (typeof window[parts[0]] == "undefined")) ||
                   ((parts.length == 2) && (typeof window[parts[0]][parts[1]] == "undefined"))) {
                   console.log(`***Failed to load ${localFilename} from CDN. Falling back to local offline version.***`);
-                  document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+                  if (document.readyState === "loading") {
+                      // Still parsing: document.write injects the fallback at this point in
+                      // the parse, so it loads synchronously and the inline checks that
+                      // follow (e.g. for jQuery.ui) see the library.  The script is
+                      // same-origin, so Chrome's document.write intervention exempts it.
+                      document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+                  } else {
+                      // After parsing, document.write would blank the page.
+                      var fallbackScript = document.createElement("script");
+                      fallbackScript.src = "./offline/" + localFilename;
+                      document.head.appendChild(fallbackScript);
+                  }
               }
             }
         </script>

--- a/pygsti/report/templates/idletomography_html_report/main.html
+++ b/pygsti/report/templates/idletomography_html_report/main.html
@@ -47,7 +47,18 @@
               if (((parts.length == 1) && (typeof window[parts[0]] == "undefined")) ||
                   ((parts.length == 2) && (typeof window[parts[0]][parts[1]] == "undefined"))) {
                   console.log(`***Failed to load ${localFilename} from CDN. Falling back to local offline version.***`);
-                  document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+                  if (document.readyState === "loading") {
+                      // Still parsing: document.write injects the fallback at this point in
+                      // the parse, so it loads synchronously and the inline checks that
+                      // follow (e.g. for jQuery.ui) see the library.  The script is
+                      // same-origin, so Chrome's document.write intervention exempts it.
+                      document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+                  } else {
+                      // After parsing, document.write would blank the page.
+                      var fallbackScript = document.createElement("script");
+                      fallbackScript.src = "./offline/" + localFilename;
+                      document.head.appendChild(fallbackScript);
+                  }
               }
             }
         </script>

--- a/pygsti/report/templates/offline/pygsti_plotly_ex.js
+++ b/pygsti/report/templates/offline/pygsti_plotly_ex.js
@@ -10,6 +10,28 @@ function max_height(els) {
     return Math.max.apply(null, hs);
 }
 
+/* Pin each element's current `prop` ("width"/"height") as an explicit style.
+
+   Reads every element before writing any of them.  Reading a geometry property
+   flushes pending layout and writing one invalidates it again, so interleaving
+   the two costs a forced reflow per element -- and these loops run over every
+   cell of every switch value of every table.
+
+   `only_simple` restricts the operation to cells with exactly one child, which
+   is what the pre-plot-creation pass wants. */
+function lock_cell_sizes(els, prop, only_simple) {
+    var targets = [], values = [];
+    els.each( function(i, el) {
+	var $el = $(el);
+	if(only_simple && $el.children().length != 1) return;
+	targets.push($el);
+	values.push(prop == "width" ? $el.width() : $el.height());
+    });
+    for(var i = 0; i < targets.length; i++) {
+	targets[i].css(prop, values[i]);
+    }
+}
+
 function get_wsobj_group(id) {
     var obj = $("#" + id);
     if(obj.hasClass("pygsti-wsoutput-group")) {
@@ -34,7 +56,7 @@ function pygsti_set_caption_width(caption, contentEl) {
 }
 
 function make_wstable_resizable(id) {
-    wsgroup = get_wsobj_group(id);
+    var wsgroup = get_wsobj_group(id);
     if( wsgroup.hasClass('ui-resizable')) return; //already make resizable
     
     wsgroup.resizable({
@@ -66,7 +88,7 @@ function make_wstable_resizable(id) {
 }
 
 function make_wsplot_resizable(id) {
-    wsgroup = get_wsobj_group(id);
+    var wsgroup = get_wsobj_group(id);
     if( wsgroup.hasClass('ui-resizable')) return; //already make resizable
     
     wsgroup.resizable({
@@ -106,14 +128,11 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	var fnForSingleTableDivs = function(k,div) {
             var was_visible = $(div).css('display') != 'none'; //is(":visible");
             $(div).show();
-            $(div).find("td").not(".plotContainingTD").each(
-                function(i,el){
-		    if($(el).children().length == 1) {
-			$(el).css("width", $(el).width()); } });
-	    $(div).find("th").each(
-		function(i,el){
-		    if($(el).children().length == 1) {
-			$(el).css("height", $(el).height()); } });
+	    // Read every cell first, then write.  Interleaving a .width() read with
+	    // a .css() write forces a synchronous reflow per cell; a large report
+	    // has thousands of cells and this loop runs once per switch value.
+	    lock_cell_sizes($(div).find("td").not(".plotContainingTD"), "width", true);
+	    lock_cell_sizes($(div).find("th"), "height", true);
             if(!was_visible) { $(div).hide(); }
         }
 	if(wstable.hasClass("single_switched_value")) {
@@ -125,14 +144,14 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 
 	//1) set widths & heights of plot-containing TDs to the
 	//   "desired" or "native" values
-	TDtoCheck = null; // the TD element used to check for width settling
+	var TDtoCheck = null; // the TD element used to check for width settling
 	wstable.find("td.plotContainingTD").each( function(k,td) {
 	    var plots = $(td).find(".plotly-graph-div");
 	    var padding = $(td).css("padding-left");
 	    if(padding == "") { padding = 0; }
 	    else { padding = parseFloat(padding); }
-	    desiredW =	max_width(plots)+2*padding;
-            desiredH =	max_height(plots)+2*padding
+	    var desiredW = max_width(plots)+2*padding;
+            var desiredH = max_height(plots)+2*padding
             $(td).css("min-width", desiredW);
             $(td).css("height", desiredH);
         console.log("desired width: ", desiredW)
@@ -141,7 +160,7 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	    if(TDtoCheck === null) TDtoCheck = $(td); //just take the first one
 
 	    if(!initial_autosize) {
-		firstChild = $(td).children("div.pygsti-wsoutput-group").first()
+		var firstChild = $(td).children("div.pygsti-wsoutput-group").first()
 		firstChild.css("width", max_width(plots)+2*padding);  // these don't seem to do 
 		firstChild.css("height", max_height(plots)+2*padding);// anything... (?)
 		//console.log("DEBUG: SETTING width/height CSS of first child! ID=" + firstChild.attr("id"))
@@ -155,8 +174,12 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	//  it takes some time for the browser to respond to the desired withs set above
 	//  and update the widths of the TD elements in the table.  The code below
 	//  waits for this settling to occur before proceeding to step 2.
-	last_w = 0; cnt = 0; 
-	nSettle = 2; //number of times we need to get the same width to call it "settled"
+	// Per-table state read across animation frames.  These used to be implicit
+	// globals, so two tables initializing at once (the Raw Estimates tab has
+	// two) clobbered each other's settling state and one could settle on the
+	// other's width.
+	var last_w = 0, cnt = 0;
+	var nSettle = 2; //number of times we need to get the same width to call it "settled"
         // Poll on animation frames rather than a fixed 200ms timer.  The widths
 	// normally settle within a frame or two, but the old timer needed three
 	// equal readings 200ms apart, imposing a ~600ms floor before any plot
@@ -169,7 +192,7 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 		wstable.trigger("after_widths_settle");
 		return;
 	    }
-	    w = TDtoCheck.width();
+	    var w = TDtoCheck.width();
 	    if(last_w == parseFloat(w)) {
 		if(cnt < nSettle) cnt += 1;
 		else {
@@ -208,10 +231,8 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	var fnForSingleTableDivs = function(k,div) {
             var was_visible = $(div).css('display') != 'none'; //is(":visible");
             $(div).show();
-            $(div).find("td").not(".plotContainingTD").each(
-                function(i,el){ $(el).css("width", $(el).width()); });
-	    $(div).find("th").each(
-		function(i,el){ $(el).css("height", $(el).height()); });
+	    lock_cell_sizes($(div).find("td").not(".plotContainingTD"), "width", false);
+	    lock_cell_sizes($(div).find("th"), "height", false);
             if(!was_visible) { $(div).hide(); }
         }
 
@@ -268,14 +289,14 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 
 	// 6) If this table is within a <figure> tag try to set
 	//    caption detail's width based on rendered table width
-	caption = wstable.closest('figure').children('figcaption:first');
+	var caption = wstable.closest('figure').children('figcaption:first');
 	pygsti_set_caption_width(caption, wstable);
 
 	// 7) Remove the hard-set width and height of the plot-containing
 	//   div used to prevent initial auto-sizing.
 	if(!initial_autosize) {
 	    wstable.find("td.plotContainingTD").each( function(k,td) {
-		firstChild = $(td).children("div.pygsti-wsoutput-group").first()
+		var firstChild = $(td).children("div.pygsti-wsoutput-group").first()
 		firstChild.css("width", "");
 		firstChild.css("height", "");
 	    });
@@ -329,7 +350,7 @@ function trigger_wsplot_plot_creation(id, initial_autosize) {
     console.log("Max desired size = " + maxDesiredWidth + ", " + maxDesiredHeight);
 
     //3) update the max-height of this container based on the maximum desired height
-    existing_max_height = wsplotgroup.css("max-height");
+    var existing_max_height = wsplotgroup.css("max-height");
     if(existing_max_height != "none") {
 	wsplotgroup.css("max-height",Math.min(maxDesiredHeight,parseFloat(existing_max_height)));
     } else { wsplotgroup.css("max-height", maxDesiredHeight); }
@@ -349,7 +370,7 @@ function trigger_wsplot_plot_creation(id, initial_autosize) {
 
     // 6) If this table is within a <figure> tag try to set
     //    caption detail's width based on rendered table width
-    caption = wsplotgroup.closest('figure').children('figcaption:first');
+    var caption = wsplotgroup.closest('figure').children('figcaption:first');
     pygsti_set_caption_width(caption, wsplotgroup);
 
 }
@@ -412,10 +433,10 @@ function pex_update_plotdiv_size(el, aspect_ratio, frac_width, frac_height, orig
     var	minfrac	= 0.0; //maybe adjust this later as a possible option?
     if(el.hasClass("pygsti-group-slave")) {
 	//just set requested fractional widths and height
-        fw = Math.max(minfrac, frac_width);
-        fh = Math.max(minfrac, frac_height);
-        ow = parseFloat(orig_width);
-        oh = parseFloat(orig_height);
+        var fw = Math.max(minfrac, frac_width);
+        var fh = Math.max(minfrac, frac_height);
+        var ow = parseFloat(orig_width);
+        var oh = parseFloat(orig_height);
         el.css("width", fw*ow);
         el.css("height",fh*oh);
         //console.log("SLAVE Updating orig (" + ow + "," + oh + ") => ("

--- a/pygsti/report/templates/offline/pygsti_plotly_ex.js
+++ b/pygsti/report/templates/offline/pygsti_plotly_ex.js
@@ -183,10 +183,26 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
         // Poll on animation frames rather than a fixed 200ms timer.  The widths
 	// normally settle within a frame or two, but the old timer needed three
 	// equal readings 200ms apart, imposing a ~600ms floor before any plot
-	// could be created.  The deadline keeps a safety net for browsers whose
-	// widths never settle.
-	var settleStart = performance.now();
-	var settleDeadline = 3000; //ms, after which we give up and proceed anyway
+	// could be created.
+	//
+	// Sampling per frame makes "unchanged for N samples" a much weaker signal
+	// than it was at 200ms spacing, and web fonts are the async width source
+	// that matters here: a late-arriving face changes text metrics and so
+	// changes cell widths.  So don't call anything settled until font loading
+	// has finished.  document.fonts.ready resolves promptly when the faces are
+	// already loaded (or have already failed), so this costs nothing in the
+	// common case.
+	var fontsReady = true;
+	if(document.fonts && document.fonts.ready) {
+	    fontsReady = false;
+	    document.fonts.ready.then( function() { fontsReady = true; } );
+	}
+
+	// Budget in frames, not wall-clock.  requestAnimationFrame doesn't fire
+	// while the page is hidden, so a wall-clock deadline would be burned by
+	// time spent in a background tab and fire on the first frame after the
+	// user returns, before any width had been observed as stable.
+	var framesLeft = 180; //~3s of visible time, then proceed regardless
 	var settleStep = function() {
 	    if(TDtoCheck === null) {
 		wstable.trigger("after_widths_settle");
@@ -195,14 +211,14 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	    var w = TDtoCheck.width();
 	    if(last_w == parseFloat(w)) {
 		if(cnt < nSettle) cnt += 1;
-		else {
+		else if(fontsReady) {
 		    wstable.trigger("after_widths_settle");
 		    return;
 		}
 	    }
 	    else { last_w = parseFloat(w); cnt = 0; }
 
-	    if(performance.now() - settleStart > settleDeadline) {
+	    if(--framesLeft <= 0) {
 		console.log("Width settling timed out for " + id + "; proceeding anyway.");
 		wstable.trigger("after_widths_settle");
 		return;
@@ -553,7 +569,6 @@ function pex_resize_slaves(el, orig_width, orig_height) {
 function PlotManager(){
     this.queue = [];
     this.labelqueue = [];
-    this.busy = false;
     this.processor = null;
 }
 
@@ -571,17 +586,31 @@ PlotManager.prototype.run = function(){
     // between plots and made a tab of N plots take 200*N ms regardless of how
     // little work each one was.
     var step = function() {
-	var t0 = performance.now();
-	while (pm.queue.length && (performance.now() - t0) < BUDGET_MS) {
-	    var label = pm.labelqueue.shift();
-	    var callback = pm.queue.shift();
-	    $("#status").text(label + " (" + pm.queue.length + " remaining)");
-	    console.log("PLOTMANAGER: " + label + " (" + pm.queue.length + " remaining)");
-	    try {
-		callback();
-	    } catch(err) {
-		console.error("PLOTMANAGER: " + label + " failed", err); //don't block the queue
+	try {
+	    var t0 = performance.now();
+	    while (pm.queue.length && (performance.now() - t0) < BUDGET_MS) {
+		var label = pm.labelqueue.shift();
+		var callback = pm.queue.shift();
+		$("#status").text(label + " (" + pm.queue.length + " remaining)");
+		console.log("PLOTMANAGER: " + label + " (" + pm.queue.length + " remaining)");
+		try {
+		    callback();
+		} catch(err) {
+		    // Keep draining, but don't let the failure pass silently:
+		    // rethrow out-of-band so it reaches window.onerror the way it
+		    // did before the queue was wrapped.
+		    console.error("PLOTMANAGER: " + label + " failed", err);
+		    setTimeout( function(){ throw err; }, 0);
+		}
 	    }
+	} catch(fatal) {
+	    // A throw from the loop scaffolding itself would otherwise leave
+	    // pm.processor non-null forever, and enqueue() only restarts the
+	    // drain when it is null -- i.e. the report would stop rendering
+	    // silently.  Release it before rethrowing.
+	    pm.processor = null;
+	    $("#status").hide();
+	    throw fatal;
 	}
 
 	if (pm.queue.length) {

--- a/pygsti/report/templates/offline/pygsti_plotly_ex.js
+++ b/pygsti/report/templates/offline/pygsti_plotly_ex.js
@@ -19,6 +19,20 @@ function get_wsobj_group(id) {
     }
 }
 
+/* Set a <figure>'s caption width from the content div it describes.
+
+   Deferred to the next animation frame and guarded against a zero measurement:
+   on a switch change the content div is measured in the same frame it's shown,
+   before layout has run, which used to write width:0px and leave the caption
+   collapsed until the plot queue happened to drain. */
+function pygsti_set_caption_width(caption, contentEl) {
+    if(caption.length == 0) return;
+    requestAnimationFrame( function() {
+	var w = contentEl.width();
+	if(w > 0) { caption.css('width', Math.round(w*0.9) + 'px'); }
+    });
+}
+
 function make_wstable_resizable(id) {
     wsgroup = get_wsobj_group(id);
     if( wsgroup.hasClass('ui-resizable')) return; //already make resizable
@@ -143,23 +157,36 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	//  waits for this settling to occur before proceeding to step 2.
 	last_w = 0; cnt = 0; 
 	nSettle = 2; //number of times we need to get the same width to call it "settled"
-        var intervalFn = setInterval( function() {
+        // Poll on animation frames rather than a fixed 200ms timer.  The widths
+	// normally settle within a frame or two, but the old timer needed three
+	// equal readings 200ms apart, imposing a ~600ms floor before any plot
+	// could be created.  The deadline keeps a safety net for browsers whose
+	// widths never settle.
+	var settleStart = performance.now();
+	var settleDeadline = 3000; //ms, after which we give up and proceed anyway
+	var settleStep = function() {
 	    if(TDtoCheck === null) {
-		clearInterval(intervalFn);
 		wstable.trigger("after_widths_settle");
+		return;
 	    }
-	    else {
-		w = TDtoCheck.width();
-		if(last_w == parseFloat(w)) {
-		    if(cnt < 2) cnt += 1;
-		    else {
-			clearInterval(intervalFn);
-			wstable.trigger("after_widths_settle");
-		    }
+	    w = TDtoCheck.width();
+	    if(last_w == parseFloat(w)) {
+		if(cnt < nSettle) cnt += 1;
+		else {
+		    wstable.trigger("after_widths_settle");
+		    return;
 		}
-		else last_w = parseFloat(w);
 	    }
-	}, 200);
+	    else { last_w = parseFloat(w); cnt = 0; }
+
+	    if(performance.now() - settleStart > settleDeadline) {
+		console.log("Width settling timed out for " + id + "; proceeding anyway.");
+		wstable.trigger("after_widths_settle");
+		return;
+	    }
+	    requestAnimationFrame(settleStep);
+	};
+	requestAnimationFrame(settleStep);
     });
     
     $("#"+id).on("after_widths_settle", function(event) {
@@ -242,9 +269,7 @@ function trigger_wstable_plot_creation(id, initial_autosize) {
 	// 6) If this table is within a <figure> tag try to set
 	//    caption detail's width based on rendered table width
 	caption = wstable.closest('figure').children('figcaption:first');
-	if(caption.length > 0) {
-            caption.css('width', Math.round(wstable.width()*0.9) + 'px');
-	}
+	pygsti_set_caption_width(caption, wstable);
 
 	// 7) Remove the hard-set width and height of the plot-containing
 	//   div used to prevent initial auto-sizing.
@@ -325,9 +350,7 @@ function trigger_wsplot_plot_creation(id, initial_autosize) {
     // 6) If this table is within a <figure> tag try to set
     //    caption detail's width based on rendered table width
     caption = wsplotgroup.closest('figure').children('figcaption:first');
-    if(caption.length > 0) {
-        caption.css('width', Math.round(wsplotgroup.width()*0.9) + 'px');
-    }
+    pygsti_set_caption_width(caption, wsplotgroup);
 
 }
 
@@ -515,36 +538,40 @@ function PlotManager(){
 
 PlotManager.prototype.run = function(){
     console.log("PLOTMANAGER: starting run queue execution");
-    
-    if (this.processor !== null) {
-	clearInterval(processor);
-    }
+
+    if (this.processor !== null) return; //already draining
+
     $("#status").show();
-    this.processor = setInterval(function(pm) {
-	if (!pm.busy) {
-	    pm.busy = true;
-	    if (pm.queue.length){
-		var label = pm.labelqueue.shift(); //pop();
-		var callback = pm.queue.shift(); //pop();
-		$("#status").text(label + " (" + pm.queue.length + " remaining)");
-		console.log("PLOTMANAGER: " + label + " (" + pm.queue.length + " remaining)");
-		try {
-		    callback();
-		} finally {
-		    pm.busy = false; // in case an error occurs, don't block queue
-		}
-	    }
-	    else {
-		pm.busy = false;
+    var pm = this;
+    var BUDGET_MS = 16; //one frame's worth of work before yielding
+
+    // Drain as many queued plots as fit in a frame, then yield.  This used to
+    // create exactly one plot per 200ms tick, which left the browser idle
+    // between plots and made a tab of N plots take 200*N ms regardless of how
+    // little work each one was.
+    var step = function() {
+	var t0 = performance.now();
+	while (pm.queue.length && (performance.now() - t0) < BUDGET_MS) {
+	    var label = pm.labelqueue.shift();
+	    var callback = pm.queue.shift();
+	    $("#status").text(label + " (" + pm.queue.length + " remaining)");
+	    console.log("PLOTMANAGER: " + label + " (" + pm.queue.length + " remaining)");
+	    try {
+		callback();
+	    } catch(err) {
+		console.error("PLOTMANAGER: " + label + " failed", err); //don't block the queue
 	    }
 	}
-	if (pm.queue.length <= 0) {
+
+	if (pm.queue.length) {
+	    pm.processor = requestAnimationFrame(step);
+	} else {
 	    console.log("PLOTMANAGER: queue empty!");
-            clearInterval(pm.processor);
 	    pm.processor = null;
-            $("#status").hide();
+	    $("#status").hide();
 	}
-    }, 200, this); //pass this as "pm" argument to function
+    };
+    pm.processor = requestAnimationFrame(step);
 }
 
 PlotManager.prototype.enqueue = function(callback, label, autostart=true){

--- a/pygsti/report/templates/standalone.html
+++ b/pygsti/report/templates/standalone.html
@@ -38,7 +38,18 @@
           if (((parts.length == 1) && (typeof window[parts[0]] == "undefined")) ||
               ((parts.length == 2) && (typeof window[parts[0]][parts[1]] == "undefined"))) {
               console.log(`***Failed to load ${localFilename} from CDN. Falling back to local offline version.***`);
-              document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+              if (document.readyState === "loading") {
+                  // Still parsing: document.write injects the fallback at this point in
+                  // the parse, so it loads synchronously and the inline checks that
+                  // follow (e.g. for jQuery.ui) see the library.  The script is
+                  // same-origin, so Chrome's document.write intervention exempts it.
+                  document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+              } else {
+                  // After parsing, document.write would blank the page.
+                  var fallbackScript = document.createElement("script");
+                  fallbackScript.src = "./offline/" + localFilename;
+                  document.head.appendChild(fallbackScript);
+              }
           }
       }
     </script>

--- a/pygsti/report/templates/standard_html_report/main.html
+++ b/pygsti/report/templates/standard_html_report/main.html
@@ -45,7 +45,18 @@
               if (((parts.length == 1) && (typeof window[parts[0]] == "undefined")) ||
                   ((parts.length == 2) && (typeof window[parts[0]][parts[1]] == "undefined"))) {
                   console.log(`***Failed to load ${localFilename} from CDN. Falling back to local offline version.***`);
-                  document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+                  if (document.readyState === "loading") {
+                      // Still parsing: document.write injects the fallback at this point in
+                      // the parse, so it loads synchronously and the inline checks that
+                      // follow (e.g. for jQuery.ui) see the library.  The script is
+                      // same-origin, so Chrome's document.write intervention exempts it.
+                      document.write(unescape(`%3Cscript src="./offline/${localFilename}" type="text/javascript"%3E%3C/script%3E`));
+                  } else {
+                      // After parsing, document.write would blank the page.
+                      var fallbackScript = document.createElement("script");
+                      fallbackScript.src = "./offline/" + localFilename;
+                      document.head.appendChild(fallbackScript);
+                  }
               }
             }
         </script>

--- a/pygsti/report/workspace.py
+++ b/pygsti/report/workspace.py
@@ -1911,7 +1911,7 @@ class WorkspaceOutput(object):
             handler_js += "  divToShow.show();\n"
             handler_js += "  divToShow.parentsUntil('#%s').show();\n" % id
             handler_js += "  caption = divToShow.closest('figure').children('figcaption:first');\n"
-            handler_js += "  caption.css('width', Math.round(divToShow.width()*0.9) + 'px');\n"
+            handler_js += "  pygsti_set_caption_width(caption, divToShow);\n"
         else:
             handler_js += "  if( divToShow.children().length == 0 ) {\n"
             handler_js += "    $(`#${idToShow}`).load(`figures/${idToShow}.html`, function() {\n"
@@ -1928,14 +1928,14 @@ class WorkspaceOutput(object):
                 handler_js += "    divToShow.append('<a class=\"dlLink\" href=\"figures/'"
                 handler_js += " + idToShow + '.pkl\" target=\"_blank\">&#9660;PKL</a>');\n"
             handler_js += "        caption = divToShow.closest('figure').children('figcaption:first');\n"
-            handler_js += "        caption.css('width', Math.round(divToShow.width()*0.9) + 'px');\n"
+            handler_js += "        pygsti_set_caption_width(caption, divToShow);\n"
             handler_js += "    });\n"  # end load-complete handler
             handler_js += "  }\n"
             handler_js += "  else {\n"
             handler_js += "    divToShow.show();\n"
             handler_js += "    divToShow.parentsUntil('#%s').show();\n" % id
             handler_js += "    caption = divToShow.closest('figure').children('figcaption:first');\n"
-            handler_js += "    caption.css('width', Math.round(divToShow.width()*0.9) + 'px');\n"
+            handler_js += "    pygsti_set_caption_width(caption, divToShow);\n"
             handler_js += "  }\n"
         handler_js += "}\n"  # end <id>_onchange function
 

--- a/pygsti/report/workspace.py
+++ b/pygsti/report/workspace.py
@@ -994,6 +994,7 @@ class Switchboard(_collections.OrderedDict):
                 if view_suffix:
                     js += "\n".join((
                         "var connected_%s_base = false;" % ID,
+                        "var connect_%s_base_timer = null;" % ID,
                         "function connect_%s_to_base(){" % ID,
                         "  if(connected_%s_base) return;" % ID,  # re-entrant: event and timer may both fire
                         "  if( $('#%s').hasClass('initializedSwitch') ) {" % baseID,  # "if base switch is ready"
@@ -1018,7 +1019,9 @@ class Switchboard(_collections.OrderedDict):
                         "  else {",  # need to wait for base switch
                         "    $(document).off('pygsti-switch-initialized.%s')" % ID +
                         ".one('pygsti-switch-initialized.%s', connect_%s_to_base);" % (ID, ID),
-                        "    setTimeout(connect_%s_to_base, 500); //backstop" % ID,
+                        #one live backstop timer, else each event wake adds another chain
+                        "    clearTimeout(connect_%s_base_timer);" % ID,
+                        "    connect_%s_base_timer = setTimeout(connect_%s_to_base, 500);" % (ID, ID),
                         "    console.log('%s base NOT initialized: Waiting...');" % ID,
                         "  }",
                         "};",
@@ -1039,6 +1042,7 @@ class Switchboard(_collections.OrderedDict):
                 if view_suffix:
                     js += "\n".join((
                         "var connected_%s_base = false;" % ID,
+                        "var connect_%s_base_timer = null;" % ID,
                         "function connect_%s_to_base(){" % ID,
                         "  if(connected_%s_base) return;" % ID,  # re-entrant: event and timer may both fire
                         "  if( $('#%s').hasClass('initializedSwitch') ) {" % baseID,  # "if base switch is ready"
@@ -1064,7 +1068,9 @@ class Switchboard(_collections.OrderedDict):
                         "  else {",  # need to wait for base switch
                         "    $(document).off('pygsti-switch-initialized.%s')" % ID +
                         ".one('pygsti-switch-initialized.%s', connect_%s_to_base);" % (ID, ID),
-                        "    setTimeout(connect_%s_to_base, 500); //backstop" % ID,
+                        #one live backstop timer, else each event wake adds another chain
+                        "    clearTimeout(connect_%s_base_timer);" % ID,
+                        "    connect_%s_base_timer = setTimeout(connect_%s_to_base, 500);" % (ID, ID),
                         "    console.log('%s base NOT initialized: Waiting...');" % ID,
                         "  }",
                         "};",
@@ -1158,6 +1164,7 @@ class Switchboard(_collections.OrderedDict):
                     # to update their own slider values.
                     js += "\n".join((
                         "var connected_%s_base = false;" % ID,
+                        "var connect_%s_base_timer = null;" % ID,
                         "function connect_%s_to_base(){" % ID,
                         "  if(connected_%s_base) return;" % ID,  # re-entrant: event and timer may both fire
                         "  if( $('#%s').hasClass('initializedSwitch') ) {" % baseID,  # "if base switch is ready"
@@ -1173,7 +1180,9 @@ class Switchboard(_collections.OrderedDict):
                         "  else {",  # need to wait for base switch
                         "    $(document).off('pygsti-switch-initialized.%s')" % ID +
                         ".one('pygsti-switch-initialized.%s', connect_%s_to_base);" % (ID, ID),
-                        "    setTimeout(connect_%s_to_base, 500); //backstop" % ID,
+                        #one live backstop timer, else each event wake adds another chain
+                        "    clearTimeout(connect_%s_base_timer);" % ID,
+                        "    connect_%s_base_timer = setTimeout(connect_%s_to_base, 500);" % (ID, ID),
                         "    console.log('%s base NOT initialized: Waiting...');" % ID,
                         "  }",
                         "};",
@@ -1908,6 +1917,7 @@ class WorkspaceOutput(object):
         #define fn to "connect" output object to switchboard, i.e.
         #  register event handlers for relevant switches so output object updates
         js += "var connected_%s = false;\n" % id
+        js += "var connect_%s_timer = null;\n" % id
         js += "function connect_%s_to_switches(){\n" % id
         js += "  if(connected_%s) return;\n" % id  # re-entrant: event and timer may both fire
         js += "  if(%s) {\n" % cnd  # "if switches are ready"
@@ -1984,7 +1994,9 @@ class WorkspaceOutput(object):
         js += "  else {\n"  # switches aren't ready - so wait
         js += "    $(document).off('pygsti-switch-initialized.%s')" % id
         js += ".one('pygsti-switch-initialized.%s', connect_%s_to_switches);\n" % (id, id)
-        js += "    setTimeout(connect_%s_to_switches, 500); //backstop\n" % id
+        #one live backstop timer, else each event wake adds another chain
+        js += "    clearTimeout(connect_%s_timer);\n" % id
+        js += "    connect_%s_timer = setTimeout(connect_%s_to_switches, 500);\n" % (id, id)
         js += "    console.log('%s switches NOT initialized: Waiting...');\n" % id
         js += "  }\n"
         js += "};\n"  # end of connect function
@@ -3160,7 +3172,7 @@ class WorkspaceText(WorkspaceOutput):
                 '  CollapsibleLists.applyTo(el[0]);\n'
                 '}}\n'
                 'caption = el.closest("figure").children("figcaption:first");\n'
-                'caption.css("width", Math.round(el.width()*0.9) + "px");\n'
+                'pygsti_set_caption_width(caption, el);\n'
             ).format(textid=text_id)
         else:
             init_text_js = ""  # no per-div init needed

--- a/pygsti/report/workspace.py
+++ b/pygsti/report/workspace.py
@@ -993,8 +993,12 @@ class Switchboard(_collections.OrderedDict):
 
                 if view_suffix:
                     js += "\n".join((
+                        "var connected_%s_base = false;" % ID,
                         "function connect_%s_to_base(){" % ID,
+                        "  if(connected_%s_base) return;" % ID,  # re-entrant: event and timer may both fire
                         "  if( $('#%s').hasClass('initializedSwitch') ) {" % baseID,  # "if base switch is ready"
+                        "    connected_%s_base = true;" % ID,
+                        "    $(document).off('pygsti-switch-initialized.%s');" % ID,
                         "    $('#%s').on('change', function(event, ui) {" % baseID,
                         "      var v = $(\"#%s > input[name='%s']:checked\").val();" % (baseID, baseID),
                         "      var el = $(\"#%s > input[name='%s'][value=\" + v + \"]\");" % (ID, ID),
@@ -1012,7 +1016,9 @@ class Switchboard(_collections.OrderedDict):
                         "    $('#%s').trigger('change');" % baseID,
                         "  }",
                         "  else {",  # need to wait for base switch
-                        "    setTimeout(connect_%s_to_base, 500);" % ID,
+                        "    $(document).off('pygsti-switch-initialized.%s')" % ID +
+                        ".one('pygsti-switch-initialized.%s', connect_%s_to_base);" % (ID, ID),
+                        "    setTimeout(connect_%s_to_base, 500); //backstop" % ID,
                         "    console.log('%s base NOT initialized: Waiting...');" % ID,
                         "  }",
                         "};",
@@ -1032,8 +1038,12 @@ class Switchboard(_collections.OrderedDict):
 
                 if view_suffix:
                     js += "\n".join((
+                        "var connected_%s_base = false;" % ID,
                         "function connect_%s_to_base(){" % ID,
+                        "  if(connected_%s_base) return;" % ID,  # re-entrant: event and timer may both fire
                         "  if( $('#%s').hasClass('initializedSwitch') ) {" % baseID,  # "if base switch is ready"
+                        "    connected_%s_base = true;" % ID,
+                        "    $(document).off('pygsti-switch-initialized.%s');" % ID,
                         "    $('#%s').on('selectmenuchange', function(event, ui) {" % baseID,
                         "      var v = $('#%s').val();" % baseID,
                         "      var el = $('#%s');" % ID,
@@ -1052,7 +1062,9 @@ class Switchboard(_collections.OrderedDict):
                         "    console.log('%s connected to base');\n" % ID,
                         "  }",
                         "  else {",  # need to wait for base switch
-                        "    setTimeout(connect_%s_to_base, 500);" % ID,
+                        "    $(document).off('pygsti-switch-initialized.%s')" % ID +
+                        ".one('pygsti-switch-initialized.%s', connect_%s_to_base);" % (ID, ID),
+                        "    setTimeout(connect_%s_to_base, 500); //backstop" % ID,
                         "    console.log('%s base NOT initialized: Waiting...');" % ID,
                         "  }",
                         "};",
@@ -1145,8 +1157,12 @@ class Switchboard(_collections.OrderedDict):
                     # which causes a change event to fire.  Views handle this event
                     # to update their own slider values.
                     js += "\n".join((
+                        "var connected_%s_base = false;" % ID,
                         "function connect_%s_to_base(){" % ID,
+                        "  if(connected_%s_base) return;" % ID,  # re-entrant: event and timer may both fire
                         "  if( $('#%s').hasClass('initializedSwitch') ) {" % baseID,  # "if base switch is ready"
+                        "    connected_%s_base = true;" % ID,
+                        "    $(document).off('pygsti-switch-initialized.%s');" % ID,
                         "    $('#%s').on('slidechange', function(event, ui) {" % baseID,
                         "      $('#%s').slider('value', ui.value);" % ID,
                         "      $('#%s-handle').text( $('#%s-handle').text() );" % (ID, baseID),
@@ -1155,7 +1171,9 @@ class Switchboard(_collections.OrderedDict):
                         "    $('#%s').trigger('slidechange', mock_ui);" % baseID,
                         "  }",
                         "  else {",  # need to wait for base switch
-                        "    setTimeout(connect_%s_to_base, 500);" % ID,
+                        "    $(document).off('pygsti-switch-initialized.%s')" % ID +
+                        ".one('pygsti-switch-initialized.%s', connect_%s_to_base);" % (ID, ID),
+                        "    setTimeout(connect_%s_to_base, 500); //backstop" % ID,
                         "    console.log('%s base NOT initialized: Waiting...');" % ID,
                         "  }",
                         "};",
@@ -1166,6 +1184,9 @@ class Switchboard(_collections.OrderedDict):
                 raise ValueError("Unknown switch type: %s" % styp)
 
             js += "$('#%s').addClass('initializedSwitch');\n" % ID
+            #let anything waiting on this switch connect immediately rather than
+            #discovering it on its next 500ms poll
+            js += "$(document).trigger('pygsti-switch-initialized');\n"
 
             switch_html.append(html)
             switch_js.append(js)
@@ -1886,8 +1907,12 @@ class WorkspaceOutput(object):
 
         #define fn to "connect" output object to switchboard, i.e.
         #  register event handlers for relevant switches so output object updates
+        js += "var connected_%s = false;\n" % id
         js += "function connect_%s_to_switches(){\n" % id
+        js += "  if(connected_%s) return;\n" % id  # re-entrant: event and timer may both fire
         js += "  if(%s) {\n" % cnd  # "if switches are ready"
+        js += "    connected_%s = true;\n" % id
+        js += "    $(document).off('pygsti-switch-initialized.%s');\n" % id
         # loop below adds event bindings to the body of this if-block
 
         #build a handler function to get all of the relevant switch positions,
@@ -1957,7 +1982,9 @@ class WorkspaceOutput(object):
         js += "    $( '#%s' ).show()\n" % id  # visibility updates are done: show parent container
         js += "  }\n"  # ends if-block
         js += "  else {\n"  # switches aren't ready - so wait
-        js += "    setTimeout(connect_%s_to_switches, 500);\n" % id
+        js += "    $(document).off('pygsti-switch-initialized.%s')" % id
+        js += ".one('pygsti-switch-initialized.%s', connect_%s_to_switches);\n" % (id, id)
+        js += "    setTimeout(connect_%s_to_switches, 500); //backstop\n" % id
         js += "    console.log('%s switches NOT initialized: Waiting...');\n" % id
         js += "  }\n"
         js += "};\n"  # end of connect function


### PR DESCRIPTION
### Context

This started as a file size investigation for serving our HTML reports from ReadTheDocs. While measuring I dug into why the Raw Estimates tab would take so long to render. After that I turned to a separate bug: switch gauge optimization or estimate,and the tables collapse and stay collapsed until you drag the resize handle in the bottom-right corner.

### Changes

Everything here is JavaScript and CSS that ships inside generated reports. No Python behavior changes.

**Tabs render about 25x faster.** Plot creation was pinned to a timer that drew one plot every 200 milliseconds regardless of how cheap the plot was, so a tab of N plots took 200N milliseconds with the browser idle in between. Raw Estimates in a small one-qubit report: 6.5 seconds before, 259 milliseconds now.

**Captions and tables no longer collapse when you switch gauge optimization or estimate.** The code sizing a figure's caption measured it before the browser had drawn it, so it wrote a width of zero. That only got repaired once the table's plots finished, which is why the collapse looked permanent on a slow tab and why dragging the resize handle appeared to fix it.

**Two tables on the same tab no longer interfere.** They shared state that should have been per-table, so one table could size itself from its neighbour's measurements.

Tab setup also no longer makes the browser recompute the page layout once per table cell (`exampleStdReport` has 4341 of them), and a plot that fails to draw now reports the error instead of vanishing quietly.

### What we (the robot and I) checked

Captions hold their width across switches, including rapid switching and switching to the fourth gauge optimization. All 12 tabs of a two-estimate, four-gauge-optimization report show no collapsed captions and no missing plots, and likewise for an `embed_figures=True` report with 39 captions. No new browser errors. `test/unit/report` passes (67 passed, 5 skipped) -- though it exercises no JavaScript, so the browser checks are what carry the weight here.

### Known limitations

**Wide tables still overflow their container**, which is the other reason that corner resize handle is useful. The obvious one-line CSS fix breaks the handle itself, so doing it properly is a separate change.

**Rendering now pauses while a report sits in a background browser tab**, and resumes on return in the same state it would have reached anyway. That follows from the timer change and we (the robot and I) think it's the right behavior.
