### PR TITLE
Enforce branch-cut convention in unitary_superoperator_matrix_log

### DIFF
--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -817,11 +817,25 @@ def unitary_superoperator_matrix_log(m: _np.ndarray, mx_basis: Union[str, Basis]
         values are Matrix-unit (std), Gell-Mann (gm), Pauli-product (pp),
         and Qutrit (qt) (or a custom basis object).
 
+    Notes
+    -----
+    The matrix logarithm is not unique: each eigenvalue of `H` is only determined
+    by `m` up to an additive multiple of 2*pi. This function chooses the branch
+    where the eigenvalues of `H` lie in [-pi, pi). The boundary case is an
+    eigenvalue of `U` at -1 (a pi rotation), where H's eigenvalue could be +pi or
+    -pi and scipy.linalg.logm picks between them based on floating-point rounding
+    -- which varies across BLAS backends (OpenBLAS rounds one way, Apple's
+    Accelerate the other). We instead map every eigenvalue of `U` within a small
+    tolerance of the negative real axis to exactly -pi in `H`, so the result is
+    the same on all backends. (-pi rather than +pi keeps the output identical to
+    what scipy.linalg.logm produced historically under OpenBLAS.)
+
     Returns
     -------
     numpy array
         A matrix `logM`, of the same shape as `m`, such that `m = exp(logM)`
-        and `logM` can be written as the action `rho -> -i[H,rho]`.
+        and `logM` can be written as the action `rho -> -i[H,rho]` where `H`
+        is Hermitian with eigenvalues in [-pi, pi).
     """
     from . import lindbladtools as _lt  # (would create circular imports if at top)
     from . import optools as _ot  # (would create circular imports if at top)
@@ -832,7 +846,14 @@ def unitary_superoperator_matrix_log(m: _np.ndarray, mx_basis: Union[str, Basis]
     # (e.g. could be anti-unitary: diag(1, -1, -1, -1))
 
     U = _ot.std_process_mx_to_unitary(M_std)
-    H = _spl.logm(U) / -1j  # U = exp(-iH)
+
+    # H = logm(U) / -1j, computed eigenvalue-wise so we control the branch of the
+    # logarithm (see Notes). U is normal, so its complex Schur form is diagonal.
+    T, Z = _spl.schur(U.astype(complex), output='complex')
+    H_evals = -_np.angle(T.diagonal())  # U = exp(-iH), so H's eigenvalues are in [-pi, pi)
+    H_evals[_np.pi - _np.abs(H_evals) < 1e-10] = -_np.pi  # eigenvalues of U on the branch cut map to -pi
+    H = (Z * H_evals) @ Z.conjugate().T
+    H = (H + H.conjugate().T) / 2  # exactly Hermitian
     logM_std = _lt.create_elementary_errorgen('H', H)  # rho --> -i[H, rho]
     logM = change_basis(logM_std, "std", mx_basis)
     assert(_np.linalg.norm(_spl.expm(logM) - m) < 1e-8)  # expensive b/c of expm - could comment for performance

--- a/test/unit/report/test_reportables.py
+++ b/test/unit/report/test_reportables.py
@@ -172,12 +172,26 @@ class HadamardRegressionTester(BaseCase):
             self.assertGreater(np.linalg.norm(mt.real_matrix_log(_HADAMARD_ESTIMATE, "ignore").imag), 1.0)
 
     def test_decomposition_values(self):
+        # The target is a pi rotation, so log(target) lands on the branch cut of the principal
+        # logarithm: log(-1) = +/- i*pi, and which sign comes out of scipy.linalg.logm depends on the
+        # LAPACK backend (OpenBLAS and Accelerate disagree). The two branches are both valid
+        # logarithms, and they report the same rotation as (axis, angle) and (-axis, 2*pi - angle).
+        # Everything asserted here is therefore phrased to be invariant under that flip.
         decomp = self._decomp(self.estimate)
-        # Angle is in units of pi, so a Hadamard should come out just under 1.
-        self.assertAlmostEqual(decomp['Gh angle'], 0.9999652938, places=9)
-        self.assertAlmostEqual(decomp['Gh log inexactness'], 0.0021073766, places=9)
+
+        # Angle is in units of pi, so a Hadamard comes out at 1 to within ~4e-05 -- on one branch just
+        # under, on the other just over. Pinning the signed offset would pin the backend.
+        self.assertAlmostEqual(decomp['Gh angle'], 1.0, places=4)
+
+        self.assertAlmostEqual(decomp['Gh log inexactness'], 0.0021073766, places=4)
+
+        # Fix the overall sign of the axis by its largest-magnitude component before comparing, since
+        # the branch flip negates the whole vector. The middle (Y) component is ~1e-05, i.e. numerical
+        # zero for a Hadamard, and it is the component that limits the tolerance to 4 places.
+        axis = np.asarray(decomp['Gh axis'])
+        axis = axis * np.sign(axis[np.argmax(np.abs(axis))])
         self.assertArraysAlmostEqual(
-            decomp['Gh axis'], np.array([0.7070608183, 7.9894403e-06, 0.7071527410]), places=8)
+            axis, np.array([0.7070608183, 7.9894403e-06, 0.7071527410]), places=4)
 
     def test_inexactness_is_near_the_obstruction_floor(self):
         # Because no real logarithm exists, a nonzero inexactness is unavoidable. Its lower bound is

--- a/test/unit/report/test_reportables.py
+++ b/test/unit/report/test_reportables.py
@@ -173,25 +173,23 @@ class HadamardRegressionTester(BaseCase):
 
     def test_decomposition_values(self):
         # The target is a pi rotation, so log(target) lands on the branch cut of the principal
-        # logarithm: log(-1) = +/- i*pi, and which sign comes out of scipy.linalg.logm depends on the
-        # LAPACK backend (OpenBLAS and Accelerate disagree). The two branches are both valid
-        # logarithms, and they report the same rotation as (axis, angle) and (-axis, 2*pi - angle).
-        # Everything asserted here is therefore phrased to be invariant under that flip.
+        # logarithm: log(-1) = +/- i*pi, and the two branches report the same rotation as
+        # (axis, angle) and (-axis, 2*pi - angle). unitary_superoperator_matrix_log's branch
+        # convention fixes the choice identically on every BLAS backend (OpenBLAS and Accelerate
+        # agree to ~1e-14 here), so the signed values below are pinned tightly on purpose: if the
+        # convention is ever lost (e.g. by reverting to scipy.linalg.logm, where the backend picks
+        # the branch), the angle crosses to just above 1 and the axis flips sign on Accelerate.
         decomp = self._decomp(self.estimate)
 
-        # Angle is in units of pi, so a Hadamard comes out at 1 to within ~4e-05 -- on one branch just
-        # under, on the other just over. Pinning the signed offset would pin the backend.
-        self.assertAlmostEqual(decomp['Gh angle'], 1.0, places=4)
+        # Angle is in units of pi; a Hadamard comes out just *under* 1 on the chosen branch.
+        self.assertAlmostEqual(decomp['Gh angle'], 0.9999652938, places=8)
 
-        self.assertAlmostEqual(decomp['Gh log inexactness'], 0.0021073766, places=4)
+        self.assertAlmostEqual(decomp['Gh log inexactness'], 0.0021073766, places=8)
 
-        # Fix the overall sign of the axis by its largest-magnitude component before comparing, since
-        # the branch flip negates the whole vector. The middle (Y) component is ~1e-05, i.e. numerical
-        # zero for a Hadamard, and it is the component that limits the tolerance to 4 places.
-        axis = np.asarray(decomp['Gh axis'])
-        axis = axis * np.sign(axis[np.argmax(np.abs(axis))])
+        # The middle (Y) component is ~1e-05, i.e. numerical zero for a Hadamard.
         self.assertArraysAlmostEqual(
-            axis, np.array([0.7070608183, 7.9894403e-06, 0.7071527410]), places=4)
+            np.asarray(decomp['Gh axis']),
+            np.array([0.7070608183, 7.9894403e-06, 0.7071527410]), places=8)
 
     def test_inexactness_is_near_the_obstruction_floor(self):
         # Because no real logarithm exists, a nonzero inexactness is unavoidable. Its lower bound is

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -373,8 +373,15 @@ class ApproximateMatrixLogBCHTester(BaseCase):
         errs = [np.linalg.norm(
             spl.expm(mt.approximate_matrix_log_BCH(self.HADAMARD_ESTIMATE, self.HADAMARD_TARGET, 'pp', order=o))
             - self.HADAMARD_ESTIMATE) for o in (1, 2, 3, 4, 5)]
+        # These are pinned only to 4 places. The reference values were recorded against OpenBLAS;
+        # Accelerate (the BLAS behind the macOS CI wheels) disagrees by up to 1.3e-05 because
+        # log(HADAMARD_TARGET) sits on the branch cut of the principal logarithm -- the target has an
+        # eigenvalue of exactly -1, log(-1) = +/- i*pi, and the two backends pick opposite signs. The
+        # sign choice is not a rounding difference, and it survives to whatever precision we ask for;
+        # 4 places is the tightest pin that admits both branches. See the monotonicity checks below,
+        # which are branch-independent and remain exact.
         for expected, actual in zip([7.6994e-03, 4.4667e-03, 2.1074e-03, 2.1073e-03, 1.9894e-03], errs):
-            self.assertAlmostEqual(actual, expected, places=6)
+            self.assertAlmostEqual(actual, expected, places=4)
         self.assertLess(errs[1], errs[0])
         self.assertLess(errs[2], errs[1])
 

--- a/test/unit/tools/test_matrixtools.py
+++ b/test/unit/tools/test_matrixtools.py
@@ -373,15 +373,14 @@ class ApproximateMatrixLogBCHTester(BaseCase):
         errs = [np.linalg.norm(
             spl.expm(mt.approximate_matrix_log_BCH(self.HADAMARD_ESTIMATE, self.HADAMARD_TARGET, 'pp', order=o))
             - self.HADAMARD_ESTIMATE) for o in (1, 2, 3, 4, 5)]
-        # These are pinned only to 4 places. The reference values were recorded against OpenBLAS;
-        # Accelerate (the BLAS behind the macOS CI wheels) disagrees by up to 1.3e-05 because
-        # log(HADAMARD_TARGET) sits on the branch cut of the principal logarithm -- the target has an
-        # eigenvalue of exactly -1, log(-1) = +/- i*pi, and the two backends pick opposite signs. The
-        # sign choice is not a rounding difference, and it survives to whatever precision we ask for;
-        # 4 places is the tightest pin that admits both branches. See the monotonicity checks below,
-        # which are branch-independent and remain exact.
-        for expected, actual in zip([7.6994e-03, 4.4667e-03, 2.1074e-03, 2.1073e-03, 1.9894e-03], errs):
-            self.assertAlmostEqual(actual, expected, places=4)
+        # log(HADAMARD_TARGET) sits on the branch cut of the principal logarithm (the target has an
+        # eigenvalue of exactly -1), so unitary_superoperator_matrix_log's branch convention decides
+        # these values. OpenBLAS and Accelerate now agree to ~1e-14; the pin is tight on purpose, so
+        # that losing the convention (e.g. reverting to scipy.linalg.logm, where the backends pick
+        # opposite signs of i*pi and these values move by up to 1.3e-05) fails loudly.
+        expected = [7.6994089126e-03, 4.4666983901e-03, 2.1073765900e-03, 2.1072954417e-03, 1.9893895605e-03]
+        for exp_err, actual in zip(expected, errs):
+            self.assertAlmostEqual(actual, exp_err, places=8)
         self.assertLess(errs[1], errs[0])
         self.assertLess(errs[2], errs[1])
 


### PR DESCRIPTION
The following was written by a robot and verified by me.

-------------------

All five macOS jobs on `beta-master` failed the two tests #897 added (run
32985871846), while Ubuntu and Windows stayed green. The failures aren't a
tolerance problem. `unitary_superoperator_matrix_log` computes `logm(U)`, and a
Hadamard target gives `U` an eigenvalue of exactly -1. That's on the branch cut
of the principal logarithm: log(-1) = +i\*pi or -i\*pi, both correct, and which
one `scipy.linalg.logm` returns is decided by rounding inside the LAPACK
backend. The macOS wheels link Accelerate, everything else we test links
OpenBLAS, and the two pick opposite signs. Through BCH the branches report the
same rotation as (axis, angle) and (-axis, 2\*pi - angle), so the rotation axis
in the gate decompositions table comes out negated on a Mac. No choice of
tolerance will resolve tests that fail due to the sign ambiguity.

The fix gives the function an explicit branch convention instead of inheriting
one from LAPACK. `U` is normal, so the function now diagonalizes it with a
complex Schur decomposition and reads off eigenphases directly, under the
convention that the eigenvalues of `H` lie in [-pi, pi), with any eigenvalue of
`U` within 1e-10 of the negative real axis mapping to exactly -pi. I chose -pi
because it reproduces what `logm` returned under OpenBLAS, so nothing recorded
on Linux or Windows CI moves. With the convention in place the two backends
agree to ~1e-14 on every quantity the failing tests pin.

The test changes actually tighten the tolerance to 8 places, where before they
used 6 places.

Verified against OpenBLAS (conda, 3.13) and Accelerate (pip wheels, 3.13). The
original failure reproduced identically on 3.10 through 3.14, so I don't expect
the Python version to matter here.

One thing this PR does not do: feature-branch CI still runs without macOS. With
the divergence resolved at the source I'm comfortable deferring that.
