### PR TITLE
Fix parameterization-preserving gauge optimization for instrument-bearing models

### DIFF
--- a/pygsti/modelmembers/instruments/instrument.py
+++ b/pygsti/modelmembers/instruments/instrument.py
@@ -337,9 +337,15 @@ class Instrument(_StackedMemberDictTorchable, _collections.OrderedDict):
         dict_to_pickle = self.__dict__.copy()
         dict_to_pickle['_parent'] = None
 
-        #Note: must *copy* elements for pickling/copying
+        #Note: must *copy* elements for pickling/copying.  All the members are copied under a
+        # *single shared* memo so that any submember reachable from more than one member stays
+        # aliased in the copy.  (E.g. the members built by `from_effects` / `from_cptr_superops`
+        # all share one ComposedPOVM error map -- that sharing is what enforces the instrument's
+        # trace preservation, and duplicating it per member would silently inflate the
+        # instrument's parameter count.)
+        memo = {}
         return (Instrument, (None, self.evotype, self.state_space, True,
-                             [(key, gate.copy()) for key, gate in self.items()]),
+                             [(key, gate.copy(memo=memo)) for key, gate in self.items()]),
                 dict_to_pickle)
 
     def __pygsti_reduce__(self) -> tuple:

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -1866,7 +1866,12 @@ def transform_composed_model(mdl: ExplicitOpModel, s : _GaugeGroupElement) -> Ex
     # reverse order. For example, ComposedOp([X,Y,Z]) is applied to
     # a vector v as Z @ Y @ X @ v.
 
-    for key, rho in oldmdl.preps.items():
+    # NOTE: we rebuild from the members of `mdl` (the copy) rather than those of `oldmdl`.
+    # A rebuilt member holds a *reference* to the member it wraps, so wrapping `oldmdl`'s
+    # members would leave the returned model sharing parameterized objects with its input:
+    # calling `from_vector` on either model would then silently mutate the other.
+
+    for key, rho in list(mdl.preps.items()):
         # replace each ComposedState superket `rhoVec` with `invU @ rhoVec`;
         # do this by packing invU into a new ComposedState's error map.
         assert isinstance(rho, ComposedState)
@@ -1874,16 +1879,16 @@ def transform_composed_model(mdl: ExplicitOpModel, s : _GaugeGroupElement) -> Ex
         errmap  = ComposedOp([rho.error_map, invU], state_space=mdl.state_space) # type: ignore
         mdl.preps[key] = ComposedState(static_rho, errmap)
 
-    for key, povm in oldmdl.povms.items():
+    for key, povm in list(mdl.povms.items()):
         # replace each ComposedPOVM `p` with another ComposedPOVM `q`, where
-        # effects `Evec` belonging to `p` are mapped to effects `EVec @ U` 
+        # effects `Evec` belonging to `p` are mapped to effects `EVec @ U`
         # belonging to `q`. Do this by packing U into the error map of `q`.
         assert isinstance(povm, ComposedPOVM)
         static_povm = povm.base_povm
         errmap = ComposedOp([U, povm.error_map], state_space=mdl.state_space) # type: ignore
         mdl.povms[key] = ComposedPOVM(errmap, static_povm, mx_basis=oldmdl.basis)
 
-    for key, op in oldmdl.operations.items():
+    for key, op in list(mdl.operations.items()):
         # replace each operation `G` with `invU @ G @ U`.
         op_s = ComposedOp([U, op, invU])
         mdl.operations[key] = op_s

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -3453,6 +3453,12 @@ def _add_param_preserving_gauge_opt(results: ModelEstimateResults, est_key: str,
     # ^ That can convert to whatever parameterization it wants
     #   It'll write to est._gaugeopt_suite.
     for gop_name, gop_dictorlist in est._gaugeopt_suite.gaugeopt_argument_dicts.items():
+        if gop_dictorlist is None:
+            # e.g. 'trivial_gauge_opt' (inserted for instrument-bearing models):
+            # no gauge transformation, so the parameterization-preserving result
+            # is the final iteration estimate itself.
+            est.models[gop_name] = est.models['final iteration estimate']
+            continue
         if isinstance(gop_dictorlist, list):
             ggel_mx = _np.eye(seed_mdl.basis.dim)
             for sub_gopdict in gop_dictorlist:

--- a/test/unit/modelmembers/test_instrument.py
+++ b/test/unit/modelmembers/test_instrument.py
@@ -1,3 +1,6 @@
+import copy
+import pickle
+
 import numpy as np
 
 import pygsti
@@ -388,6 +391,53 @@ class FromEffectsTester(BaseCase):
     def test_raises_on_non_tp_gate(self):
         with self.assertRaises(ValueError):
             Instrument.from_effects({'p0': (self.E0, 0.9 * np.eye(4)), 'p1': self.E1}, self.basis)
+
+
+class SharedErrorMapCopyTester(BaseCase):
+    """`Instrument.__reduce__` copies each member, and it must do so under a single
+    shared memo: the members of a `from_effects` / `from_cptr_superops` instrument all
+    reference one ComposedPOVM error map, and copying them independently would break
+    that aliasing -- inflating the instrument's parameter count and letting the
+    effects drift apart (i.e. losing joint trace preservation) under re-optimization."""
+
+    def setUp(self):
+        model = std.target_model()
+        self.E0, self.E1, _, _ = z_measurement_projectors(model)
+        self.basis = model.basis
+        self.instrument = Instrument.from_effects({'p0': self.E0, 'p1': self.E1}, self.basis)
+
+    @staticmethod
+    def _errormap(instrument, key):
+        """The shared ComposedPOVM error map behind `instrument[key]`'s effect."""
+        composed_effect = instrument[key].factorops[0].submembers()[0]  # ComposedPOVMEffect
+        return composed_effect.submembers()[0]
+
+    def _assert_shared(self, instrument, msg):
+        self.assertIs(self._errormap(instrument, 'p0'), self._errormap(instrument, 'p1'), msg)
+
+    def test_built_instrument_shares_errormap(self):
+        self._assert_shared(self.instrument, "from_effects should share one error map")
+
+    def test_copy_preserves_shared_errormap(self):
+        self._assert_shared(self.instrument.copy(), "Instrument.copy() duplicated the error map")
+
+    def test_deepcopy_preserves_shared_errormap(self):
+        self._assert_shared(copy.deepcopy(self.instrument), "deepcopy duplicated the error map")
+
+    def test_pickle_preserves_shared_errormap(self):
+        roundtripped = pickle.loads(pickle.dumps(self.instrument))
+        self._assert_shared(roundtripped, "pickle round-trip duplicated the error map")
+
+    def test_copy_preserves_num_params(self):
+        self.assertEqual(self.instrument.copy().num_params, self.instrument.num_params)
+
+    def test_model_copy_preserves_num_params(self):
+        model = pygsti.models.ExplicitOpModel(pygsti.baseobjs.QubitSpace(1), self.basis)
+        model[('Iz', 0)] = self.instrument
+        model.to_vector()
+        self.assertEqual(model.copy().num_params, model.num_params)
+        self._assert_shared(model.copy().instruments[('Iz', 0)],
+                            "ExplicitOpModel.copy() duplicated the error map")
 
 
 class TPInstrumentOpTester(ImmutableDenseOpBase, BaseCase):

--- a/test/unit/objects/test_explicitmodel.py
+++ b/test/unit/objects/test_explicitmodel.py
@@ -182,6 +182,32 @@ def _make_cptplnd_model_with_instrument():
     return base
 
 
+def _make_cptplnd_model_with_from_effects_instrument():
+    """Like `_make_cptplnd_model_with_instrument`, but the instrument uses the
+    effect-then-gate parameterization, whose members all share a single
+    ComposedPOVM error map."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        base = smq1Q_XYI.target_model('CPTPLND')
+    E0 = np.array([1., 0., 0.,  1.]) / np.sqrt(2)   # |0><0| as a pp superket
+    E1 = np.array([1., 0., 0., -1.]) / np.sqrt(2)   # |1><1|
+    base.instruments['Iz'] = Instrument.from_effects({'p0': E0, 'p1': E1}, base.basis)
+    base.to_vector()  # force the parameter vector (and gpindices) to be built
+    return base
+
+
+def _povm_errormap_of(instrument, key):
+    """The ComposedPOVM error map behind `instrument[key]`'s measurement effect, for
+    an instrument member wrapped by `transform_composed_model` (i.e. one extra
+    ComposedOp([U, member, invU]) layer) or for a bare member."""
+    member = instrument[key]
+    if len(member.factorops) == 3:
+        member = member.factorops[1]  # unwrap the ComposedOp([U, member, invU])
+    root_conj = member.factorops[0]                      # RootConjOperator
+    composed_effect = root_conj.submembers()[0]          # ComposedPOVMEffect
+    return composed_effect.submembers()[0]               # the shared error map
+
+
 def _unitary_ggel(theta: float) -> UnitaryGaugeGroupElement:
     U = la.expm(theta * 1j * np.array([[1, -1],[-1, 1]]))
     return UnitaryGaugeGroupElement(unitary_to_pauligate(U))
@@ -346,3 +372,67 @@ class AutoEmbedTester(BaseCase):
                               pygsti.models.ExplicitOpModel.loads(self.model.dumps())):
             npt.assert_allclose(round_tripped.operations[('Gcnot', 1, 0)].to_dense('HilbertSchmidt'),
                                 self.CNOT_10, atol=1e-12)
+
+
+class Test_TransformComposedModelPreservesParameterization(BaseCase):
+    """`transform_composed_model` must be parameterization-preserving: the returned
+    model has to have the *same* free parameters as its input, and must not share
+    any parameterized object with it."""
+
+    def setUp(self):
+        self.mdl = _make_cptplnd_model_with_from_effects_instrument()
+        self.inst_keys = list(self.mdl.instruments['Iz'].keys())
+
+    def test_from_effects_instrument_shares_one_errormap(self):
+        # Baseline for the tests below: the members really do share one error map.
+        inst = self.mdl.instruments['Iz']
+        self.assertIs(_povm_errormap_of(inst, self.inst_keys[0]),
+                      _povm_errormap_of(inst, self.inst_keys[1]))
+
+    def test_identity_transform_preserves_num_params(self):
+        result = transform_composed_model(self.mdl, UnitaryGaugeGroupElement(np.eye(4)))
+        self.assertEqual(result.num_params, self.mdl.num_params)
+
+    def test_nontrivial_transform_preserves_num_params(self):
+        result = transform_composed_model(self.mdl, _unitary_ggel(0.3))
+        self.assertEqual(result.num_params, self.mdl.num_params)
+
+    def test_transformed_instrument_still_shares_one_errormap(self):
+        # The shared error map is what ties the effects together, and therefore what
+        # enforces the instrument's trace preservation.  Duplicating it per member
+        # would let the effects drift apart under re-optimization.
+        inst = transform_composed_model(self.mdl, _unitary_ggel(0.3)).instruments['Iz']
+        self.assertIs(_povm_errormap_of(inst, self.inst_keys[0]),
+                      _povm_errormap_of(inst, self.inst_keys[1]))
+
+    def test_transformed_instrument_stays_tp_under_reoptimization(self):
+        # Perturb the transformed model's parameters; the instrument's members must
+        # still sum to a trace-preserving channel.
+        result = transform_composed_model(self.mdl, _unitary_ggel(0.3))
+        v = result.to_vector()
+        result.from_vector(v + 0.02 * np.random.default_rng(0).standard_normal(len(v)))
+        total = sum(result.instruments['Iz'][ek].to_dense() for ek in self.inst_keys)
+        trace_functional = np.array([np.sqrt(2), 0., 0., 0.])  # <<I| in the pp basis
+        npt.assert_allclose(trace_functional @ total, trace_functional, atol=1e-9)
+
+    def test_result_does_not_alias_input_model(self):
+        # A rebuilt member holds a reference to the member it wraps, so the rebuild
+        # must consume the *copy's* members: otherwise from_vector on the result
+        # silently mutates the input model.
+        result = transform_composed_model(self.mdl, _unitary_ggel(0.3))
+        before = {k: np.array(self.mdl.operations[k].to_dense()) for k in self.mdl.operations}
+        before.update({('rho', k): np.array(self.mdl.preps[k].to_dense()) for k in self.mdl.preps})
+        before.update({('Iz', ek): np.array(self.mdl.instruments['Iz'][ek].to_dense())
+                       for ek in self.inst_keys})
+        v = result.to_vector()
+        result.from_vector(v + 0.05 * np.random.default_rng(1).standard_normal(len(v)))
+        for k in self.mdl.operations:
+            npt.assert_allclose(self.mdl.operations[k].to_dense(), before[k], atol=1e-12,
+                                err_msg=f'operation {k!r} was mutated via the transformed model')
+        for k in self.mdl.preps:
+            npt.assert_allclose(self.mdl.preps[k].to_dense(), before[('rho', k)], atol=1e-12,
+                                err_msg=f'prep {k!r} was mutated via the transformed model')
+        for ek in self.inst_keys:
+            npt.assert_allclose(self.mdl.instruments['Iz'][ek].to_dense(), before[('Iz', ek)],
+                                atol=1e-12,
+                                err_msg=f'instrument member {ek!r} was mutated via the transformed model')

--- a/test/unit/protocols/test_gst.py
+++ b/test/unit/protocols/test_gst.py
@@ -89,6 +89,23 @@ class GSTUtilTester(BaseCase):
         self.assertTrue('stdgaugeopt' in res.estimates['test-estimate'].models)
         self.assertTrue('stdgaugeopt' in res.estimates['test-estimate'].goparameters)
 
+    def test_add_param_preserving_gauge_opt_handles_trivial_entry(self):
+        # A 'trivial_gauge_opt' entry (goparameters value None, no gauge transformation)
+        # is inserted by ModelTest and by GST runs on instrument-bearing models.
+        # _add_param_preserving_gauge_opt iterates over goparameters entries and used to
+        # crash on the None; it must instead install the final iteration estimate itself.
+        res = self.results.copy()
+        est = res.estimates['test-estimate']
+        mdl_lnd = smq1Q_XYI.target_model('CPTPLND')  # ComposedState/ComposedPOVM members,
+        est.models['final iteration estimate'] = mdl_lnd  # as _add_param_preserving_gauge_opt requires
+        est.goparameters['trivial_gauge_opt'] = None
+        est.protocol = gst.GateSetTomography(self.target_model)
+        # ^ the estimate's protocol supplies badfit_options/optimizer; the default
+        #   options have no actions, so no badfit machinery actually runs.
+        gst._add_param_preserving_gauge_opt(res, 'test-estimate',
+                                            GSTGaugeOptSuite(gaugeopt_argument_dicts={}))
+        self.assertIs(est.models['trivial_gauge_opt'], est.models['final iteration estimate'])
+
 
 class StandardGSTDesignTester(BaseCase):
     """


### PR DESCRIPTION
This PR extracts the bugfix content of #862 so it can merge without waiting on that PR's
feature work (instrument seeding tools, still WIP). It resolves #826.

Parameterization-preserving gauge optimization mishandled instrument-bearing models in
three ways. The first two are aliasing bugs and are the substance of the PR; the third is
a crash.

1. `Instrument.__reduce__` copied its members independently. The members of a
   `from_effects` or `from_cptr_superops` instrument all reference one ComposedPOVM error
   map, and that sharing is what enforces the instrument's trace preservation. Copying the
   members independently broke the aliasing, so every copy (via `copy`, `deepcopy`,
   pickling, or `Model.copy`) had an inflated parameter count and effects free to drift
   apart under re-optimization. Members are now copied under a single shared memo.

2. `transform_composed_model` rebuilt members by wrapping the *input* model's members
   rather than the copy's. A rebuilt member holds a reference to whatever it wraps, so the
   returned model shared parameterized objects with its input: `from_vector` on either
   model silently mutated the other. It now wraps the copy's members.

Together these meant the gauge-transformed model wasn't in the same hypothesis class as
its input, which is why error bars for Lindblad-parameterized instruments came out too
large (see #826 and the discussion in #862).

3. `_add_param_preserving_gauge_opt` crashed on gauge-opt suite entries that carry no
   gauge transformation, i.e. the `'trivial_gauge_opt'` entry (value `None`) that
   ModelTest runs insert. For such an entry the parameterization-preserving result is just
   the final iteration estimate, and the function now installs exactly that.

The source diff is under 30 lines across three files; the rest is tests. The new test
classes check that copies and gauge transforms preserve `num_params` and the shared error
map, that the transformed instrument stays trace preserving under re-optimization, that
the transform doesn't alias its input, and that the `None` guard works (robot confirmed that
last test fails without the guard). One caveat: #862 also exercises these fixes through a
full GST regression test, but that test depends on unmerged feature code, so it stays
behind. Once this merges I'll rebase #862 and it will shed these changes.
