### PR TITLE
Tensor-product gauge groups: gauge optimization that acts on each subsystem independently

### DIFF
--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -249,16 +249,25 @@ class ExplicitOpModel(_mdl.OpModel):
         return self._default_gauge_group
 
     @default_gauge_group.setter
-    def default_gauge_group(self, value: Union[Literal['tp', 'unitary'], _GaugeGroup]) -> None:
+    def default_gauge_group(self, value: Union[Literal['tp', 'unitary', 'local tp', 'local unitary'],
+                                               _GaugeGroup]) -> None:
         """
         The default gauge group.
+
+        Strings select a standard group built from this model's state space and basis:
+        ``'unitary'``, ``'tp'``, and their per-subsystem versions ``'local unitary'`` and
+        ``'local tp'`` (see :class:`TensorProductGaugeGroup`).
         """
         if isinstance(value, str):
             lower = value.lower()
             if lower == 'unitary':
                 value = _gg.UnitaryGaugeGroup(self.state_space, self.basis, self.evotype)
             elif lower == 'tp':
-                value = _gg.TPGaugeGroup(self.state_space, self.basis, self.evotypes)
+                value = _gg.TPGaugeGroup(self.state_space, self.basis, self.evotype)
+            elif lower == 'local unitary':
+                value = _gg.TensorProductGaugeGroup.local_unitary(self.state_space, self.basis, self.evotype)
+            elif lower == 'local tp':
+                value = _gg.TensorProductGaugeGroup.local_tp(self.state_space, self.basis, self.evotype)
             else:
                 msg = f'string "{value}" cannot be used to set this model\'s gauge group.'
                 raise ValueError(msg)

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -27,7 +27,7 @@ from pygsti.baseobjs import (
 )
 from pygsti.baseobjs import _compatibility as _compat
 from pygsti.modelmembers import operations as _op
-from pygsti.baseobjs.basis import Basis as _Basis, BuiltinBasis as _BuiltinBasis
+from pygsti.baseobjs.basis import Basis as _Basis, BuiltinBasis as _BuiltinBasis, TensorProdBasis as _TensorProdBasis
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
 from pygsti.evotypes.evotype import Evotype as _Evotype
 from pygsti.tools.optools import superop_to_unitary, unitary_to_superop
@@ -359,6 +359,17 @@ class OpGaugeGroup(GaugeGroup):
         GaugeGroup.__init__(self, name)
 
     @property
+    def state_space(self) -> _StateSpace:
+        """
+        The state space that elements of this gauge group act on.
+
+        Returns
+        -------
+        StateSpace
+        """
+        return self._operation.state_space
+
+    @property
     def num_params(self) -> int:
         """
         Return the number of parameters (degrees of freedom) of this gauge group.
@@ -415,6 +426,17 @@ class OpGaugeGroupWithBasis(OpGaugeGroup):
     def __init__(self, operation: _LinearOperator, elementcls, name: str, basis):
         self._basis = basis
         super().__init__(operation, elementcls, name)
+
+    @property
+    def basis(self) -> Union[_Basis, str]:
+        """
+        The basis in which elements of this gauge group express their transform matrices.
+
+        Returns
+        -------
+        Basis or str
+        """
+        return self._basis
 
     def _to_nice_serialization(self):
         state = super()._to_nice_serialization()
@@ -802,11 +824,10 @@ class UnitaryGaugeGroup(OpGaugeGroupWithBasis):
             raise ValueError()
         evotype = _Evotype.cast(str(evotype), default_prefer_dense_reps=True)  # since we use deriv_wrt_params
         errgen = _op.LindbladErrorgen.from_operation_matrix(
-            _np.eye(state_space.dim), "H", basis, mx_basis=basis, evotype=evotype
+            _np.eye(state_space.dim), "H", basis, mx_basis=basis, evotype=evotype, state_space=state_space
         )
         operation = _op.ExpErrorgenOp(errgen)
         OpGaugeGroupWithBasis.__init__(self, operation, UnitaryGaugeGroupElement, "Unitary", basis)
-        self.state_space = state_space
 
     def compute_element(self, param_vec) -> UnitaryGaugeGroupElement:
         return super().compute_element(param_vec)
@@ -1434,3 +1455,278 @@ class DirectSumUnitaryGroupElement(GaugeGroupElement):
         basis = state['basis'] if isinstance(state['basis'], str) else _Basis.from_nice_serialization(state['basis'])
         level_partition = state.get('level_partition', None)
         return cls(subelements, basis, level_partition)
+
+
+def _match_factors_to_label_runs(factor_udims, labels, label_udims):
+    """
+    Assign each tensor factor of a :class:`TensorProductGaugeGroup` to a contiguous run of state-space labels.
+
+    Walks the labels of a single tensor-product block in order and gives factor ``j`` the shortest
+    run of not-yet-assigned labels whose Hilbert-space dimensions multiply to ``factor_udims[j]``.
+    Returns a tuple of index tuples, one per factor. Raises ValueError if a factor's dimension
+    cannot be matched this way or if labels are left over after the last factor.
+    """
+    runs = []
+    i = 0
+    for j, fudim in enumerate(factor_udims):
+        start, prod = i, 1
+        while prod < fudim and i < len(labels):
+            prod *= label_udims[i]
+            i += 1
+        if prod != fudim:
+            raise ValueError(
+                f"Factor {j} has Hilbert-space dimension {fudim}, but the state-space labels "
+                f"{labels[start:i]} (dimensions {label_udims[start:i]}) starting at position {start} "
+                f"cannot be grouped to match it. Factors must act on contiguous labels, in order.")
+        runs.append(tuple(range(start, i)))
+    if i != len(labels):
+        raise ValueError(
+            f"The factors account for state-space labels {labels[:i]} but the state space also "
+            f"contains {labels[i:]}. Supply a factor (e.g. a TrivialGaugeGroup) for every label.")
+    return tuple(runs)
+
+
+class TensorProductGaugeGroup(GaugeGroup):
+    """
+    A gauge group whose elements act independently on each tensor factor of a state space.
+
+    Each element is a Kronecker product ``S = S_1 ⊗ S_2 ⊗ ... ⊗ S_k`` of elements of the given
+    factor groups (expressed in the model's basis), so gauge optimization over this group can only
+    move each subsystem by itself.  The motivating case is local unitary gauge freedom, ``U(d)^{⊗k}``,
+    built by :meth:`local_unitary`, but the construction is agnostic to the factor type: TP, full,
+    trivial (to pin a subsystem) and mixed choices all work.
+
+    Parameters
+    ----------
+    factors : sequence of GaugeGroup
+        One gauge group per tensor factor, in state-space label order.  Each acts on its own
+        (single- or multi-label) state space.
+
+    state_space : StateSpace
+        The state space of the model this group will transform.  Must consist of a single
+        tensor-product block whose labels, walked in order, can be partitioned into contiguous
+        runs matching the factors' Hilbert-space dimensions.
+
+    basis : Basis or str
+        The basis in which the model expresses its operations.  Elements return transform
+        matrices in this basis.
+
+    factor_bases : sequence of (Basis or str), optional
+        The basis each factor expresses its transform matrix in.  Usually unnecessary: a factor
+        that declares a basis (the `OpGaugeGroupWithBasis` family) supplies its own, and other
+        factors get the matching component of `basis`.
+
+    name : str, optional
+        A name for this group, used in reporting.
+    """
+
+    def __init__(self, factors, state_space: _StateSpace, basis: Union[_Basis, str],
+                 factor_bases=None, name: str = "Tensor product gauge group"):
+        factors = tuple(factors)
+        if len(factors) == 0:
+            raise ValueError("TensorProductGaugeGroup needs at least one factor.")
+        state_space = _StateSpace.cast(state_space)
+        if state_space.num_tensor_product_blocks != 1:
+            raise ValueError(
+                f"TensorProductGaugeGroup requires a state space with a single tensor-product block; "
+                f"got {state_space.num_tensor_product_blocks}.")
+        labels = state_space.tensor_product_blocks_labels[0]
+        label_udims = state_space.tensor_product_blocks_udimensions[0]
+        factor_udims = [f.state_space.udim for f in factors]
+        self._label_runs = _match_factors_to_label_runs(factor_udims, labels, label_udims)
+
+        if isinstance(basis, str):
+            basis = _Basis.cast(basis, state_space)
+        if basis.dim != state_space.dim:
+            raise ValueError(f"`basis` has dimension {basis.dim} but the state space has dimension "
+                             f"{state_space.dim}.")
+
+        if factor_bases is None:
+            factor_bases = [None] * len(factors)
+        elif len(factor_bases) != len(factors):
+            raise ValueError("`factor_bases` must have one entry per factor.")
+        resolved = tuple(self._resolve_factor_basis(j, f, fb, basis, labels)
+                         for j, (f, fb) in enumerate(zip(factors, factor_bases)))
+
+        self.factors = factors
+        self.state_space = state_space
+        self.basis = basis
+        self.factor_bases = resolved
+        self._param_dims = _np.array([f.num_params for f in factors], dtype=int)
+        self._num_params = int(_np.sum(self._param_dims))
+        self._change_of_basis = self._compute_change_of_basis(resolved, basis)
+        super().__init__(name)
+
+    def _resolve_factor_basis(self, j, factor, explicit, basis, labels):
+        dim = factor.state_space.dim
+        declared = getattr(factor, 'basis', None)
+        if declared is not None:
+            declared = _Basis.cast(declared, dim)
+        if explicit is not None:
+            explicit = _Basis.cast(explicit, dim)
+            if declared is not None and not explicit.is_equivalent(declared, sparseness_must_match=False):
+                raise ValueError(f"factor_bases[{j}] disagrees with the basis factor {j} was constructed with.")
+            return explicit
+        if declared is not None:
+            return declared
+        run = self._label_runs[j]
+        if isinstance(basis, _TensorProdBasis) and len(basis.component_bases) == len(labels):
+            comps = [basis.component_bases[i] for i in run]
+            return comps[0] if len(comps) == 1 else _TensorProdBasis(comps)
+        try:
+            return _Basis.cast(basis.name, dim)
+        except Exception as e:
+            raise ValueError(
+                f"Could not determine a basis for factor {j} from the model basis '{basis.name}'. "
+                f"Pass `factor_bases` explicitly.") from e
+
+    @staticmethod
+    def _compute_change_of_basis(factor_bases, basis):
+        """
+        The matrix C with S_model = C @ kron(S_1, ..., S_k) @ inv(C), or None when C is the identity.
+        """
+        tp_basis = _TensorProdBasis(factor_bases) if len(factor_bases) > 1 else factor_bases[0]
+        C = tp_basis.create_transform_matrix(basis)
+        if hasattr(C, 'toarray'):
+            C = C.toarray()
+        C = _np.asarray(C)
+        if _np.allclose(C, _np.eye(C.shape[0])):
+            return None
+        if _np.allclose(C.imag, 0):
+            C = C.real
+        return C
+
+    @property
+    def num_params(self) -> int:
+        return self._num_params
+
+    @property
+    def initial_params(self) -> _np.ndarray:
+        return _np.concatenate([f.initial_params for f in self.factors])
+
+    def compute_element(self, param_vec: _np.ndarray) -> TensorProductGaugeGroupElement:
+        assert param_vec.size == self.num_params
+        elements, offset = [], 0
+        for pd, f in zip(self._param_dims, self.factors):
+            elements.append(f.compute_element(param_vec[offset:offset + pd]))
+            offset += pd
+        return TensorProductGaugeGroupElement(tuple(elements), self._change_of_basis)
+
+    def _to_nice_serialization(self):
+        state = super()._to_nice_serialization()
+        state.update({
+            'factors': [f.to_nice_serialization() for f in self.factors],
+            'state_space': self.state_space.to_nice_serialization(),
+            'basis': self.basis.to_nice_serialization(),
+            'factor_bases': [b.to_nice_serialization() for b in self.factor_bases],
+            'name': self.name
+        })
+        return state
+
+    @classmethod
+    def _from_nice_serialization(cls, state):
+        factors = [GaugeGroup.from_nice_serialization(f) for f in state['factors']]
+        state_space = _StateSpace.from_nice_serialization(state['state_space'])
+        basis = _Basis.from_nice_serialization(state['basis'])
+        factor_bases = [_Basis.from_nice_serialization(b) for b in state['factor_bases']]
+        return cls(factors, state_space, basis, factor_bases, state['name'])
+
+
+class TensorProductGaugeGroupElement(GaugeGroupElement):
+    """
+    Element of a :class:`TensorProductGaugeGroup`: a Kronecker product of factor elements.
+
+    Parameters
+    ----------
+    factor_elements : tuple of GaugeGroupElement
+        The per-factor elements, in state-space order.
+
+    change_of_basis : numpy.ndarray, optional
+        Matrix ``C`` such that the transform matrix in the model's basis is
+        ``C @ kron(S_1, ..., S_k) @ inv(C)``.  ``None`` means the identity.
+    """
+
+    def __init__(self, factor_elements, change_of_basis=None):
+        self.factor_elements = tuple(factor_elements)
+        self._C = change_of_basis
+        self._Cinv = None if change_of_basis is None else _np.linalg.inv(change_of_basis)
+        self._param_dims = _np.array([e.num_params for e in self.factor_elements], dtype=int)
+        self._param_offsets = _np.concatenate([[0], _np.cumsum(self._param_dims)])
+        self._num_params = int(self._param_offsets[-1])
+        self._clear_cache()
+        super().__init__()
+
+    def _clear_cache(self):
+        self._factor_mxs = None
+        self._factor_inv_mxs = None
+        self._mx = None
+        self._inv_mx = None
+
+    def _conjugate(self, mx):
+        return mx if self._C is None else self._C @ mx @ self._Cinv
+
+    @staticmethod
+    def _kron(mxs):
+        out = mxs[0]
+        for m in mxs[1:]:
+            out = _np.kron(out, m)
+        return out
+
+    @property
+    def factor_matrices(self) -> Tuple[_np.ndarray, ...]:
+        """ The factor transform matrices, each in its own factor basis. """
+        if self._factor_mxs is None:
+            self._factor_mxs = tuple(e.transform_matrix for e in self.factor_elements)
+        return self._factor_mxs
+
+    @property
+    def factor_matrix_inverses(self) -> Tuple[_np.ndarray, ...]:
+        """ The inverses of the factor transform matrices, each in its own factor basis. """
+        if self._factor_inv_mxs is None:
+            self._factor_inv_mxs = tuple(e.transform_matrix_inverse for e in self.factor_elements)
+        return self._factor_inv_mxs
+
+    @property
+    def transform_matrix(self) -> _np.ndarray:
+        if self._mx is None:
+            self._mx = self._conjugate(self._kron(self.factor_matrices))
+        return self._mx
+
+    @property
+    def transform_matrix_inverse(self) -> _np.ndarray:
+        if self._inv_mx is None:
+            self._inv_mx = self._conjugate(self._kron(self.factor_matrix_inverses))
+        return self._inv_mx
+
+    def deriv_wrt_params(self, wrt_filter=None) -> _np.ndarray:
+        raise NotImplementedError()
+
+    def to_vector(self) -> _np.ndarray:
+        return _np.concatenate([e.to_vector() for e in self.factor_elements])
+
+    def from_vector(self, v: _np.ndarray) -> None:
+        assert v.size == self.num_params
+        for e, start, stop in zip(self.factor_elements, self._param_offsets[:-1], self._param_offsets[1:]):
+            e.from_vector(v[start:stop])
+        self._clear_cache()
+
+    @property
+    def num_params(self) -> int:
+        return self._num_params
+
+    def inverse(self) -> InverseGaugeGroupElement:
+        return InverseGaugeGroupElement(self)
+
+    def _to_nice_serialization(self):
+        state = super()._to_nice_serialization()
+        state.update({
+            'factor_elements': [e.to_nice_serialization() for e in self.factor_elements],
+            'change_of_basis': None if self._C is None else self._encodemx(self._C)
+        })
+        return state
+
+    @classmethod
+    def _from_nice_serialization(cls, state):
+        elements = [GaugeGroupElement.from_nice_serialization(e) for e in state['factor_elements']]
+        C = None if state['change_of_basis'] is None else cls._decodemx(state['change_of_basis'])
+        return cls(tuple(elements), C)

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -1470,7 +1470,7 @@ def _match_factors_to_label_runs(factor_udims, labels, label_udims):
     i = 0
     for j, fudim in enumerate(factor_udims):
         start, prod = i, 1
-        while prod < fudim and i < len(labels):
+        while (prod < fudim or i == start) and i < len(labels):  # always consume at least one label
             prod *= label_udims[i]
             i += 1
         if prod != fudim:
@@ -1595,6 +1595,80 @@ class TensorProductGaugeGroup(GaugeGroup):
         if _np.allclose(C.imag, 0):
             C = C.real
         return C
+
+    @staticmethod
+    def _per_label_factor_spaces_and_bases(state_space, basis):
+        """
+        One (state space, basis) pair per label of a single-block `state_space`, for building local factors.
+        """
+        state_space = _StateSpace.cast(state_space)
+        if state_space.num_tensor_product_blocks != 1:
+            raise ValueError("Local gauge groups require a state space with a single tensor-product block.")
+        labels = state_space.tensor_product_blocks_labels[0]
+        udims = state_space.tensor_product_blocks_udimensions[0]
+        if isinstance(basis, _TensorProdBasis) and len(basis.component_bases) == len(labels):
+            bases = list(basis.component_bases)
+        else:
+            name = basis if isinstance(basis, str) else basis.name
+            bases = [_Basis.cast(name, udim ** 2) for udim in udims]
+        spaces = [_ExplicitStateSpace([lbl], [udim]) for lbl, udim in zip(labels, udims)]
+        return spaces, bases
+
+    @classmethod
+    def local_unitary(cls, state_space: _StateSpace, basis: Union[_Basis, str],
+                      evotype: Optional[Union[_Evotype, str]] = 'default') -> TensorProductGaugeGroup:
+        """
+        The local unitary gauge group: an independent :class:`UnitaryGaugeGroup` on each label of `state_space`.
+
+        Labels of Hilbert-space dimension 1 get a :class:`TrivialGaugeGroup`.
+
+        Parameters
+        ----------
+        state_space : StateSpace
+            The model's state space (a single tensor-product block).
+
+        basis : Basis or str
+            The model's basis.
+
+        evotype : Evotype or str, optional
+            The evolution type for the factor groups.
+
+        Returns
+        -------
+        TensorProductGaugeGroup
+        """
+        spaces, bases = cls._per_label_factor_spaces_and_bases(state_space, basis)
+        factors = [UnitaryGaugeGroup(ss, b, evotype) if ss.udim > 1 else TrivialGaugeGroup(ss)
+                   for ss, b in zip(spaces, bases)]
+        return cls(factors, state_space, basis, name="Local unitary gauge group")
+
+    @classmethod
+    def local_tp(cls, state_space: _StateSpace, basis: Union[_Basis, str],
+                 evotype: Optional[Union[_Evotype, str]] = 'default') -> TensorProductGaugeGroup:
+        """
+        The local TP gauge group: an independent :class:`TPGaugeGroup` on each label of `state_space`.
+
+        Labels of Hilbert-space dimension 1 get a :class:`TrivialGaugeGroup`.
+
+        Parameters
+        ----------
+        state_space : StateSpace
+            The model's state space (a single tensor-product block).
+
+        basis : Basis or str
+            The model's basis.
+
+        evotype : Evotype or str, optional
+            The evolution type for the factor groups.
+
+        Returns
+        -------
+        TensorProductGaugeGroup
+        """
+        spaces, bases = cls._per_label_factor_spaces_and_bases(state_space, basis)
+        factors = [TPGaugeGroup(ss, b, evotype) if ss.udim > 1 else TrivialGaugeGroup(ss)
+                   for ss, b in zip(spaces, bases)]
+        return cls(factors, state_space, basis, name="Local TP gauge group")
 
     @property
     def num_params(self) -> int:

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -289,7 +289,7 @@ class InverseGaugeGroupElement(GaugeGroupElement):
         -------
         None
         """
-        return self.inverse_element.from_vector()
+        self.inverse_element.from_vector(v)
 
     @property
     def num_params(self) -> int:

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -1699,7 +1699,42 @@ class TensorProductGaugeGroupElement(GaugeGroupElement):
         return self._inv_mx
 
     def deriv_wrt_params(self, wrt_filter=None) -> _np.ndarray:
-        raise NotImplementedError()
+        """
+        Derivative of the transform matrix with respect to this element's parameters.
+
+        Product rule over the Kronecker factors: for a parameter of factor ``j``,
+        ``dS = C (S_1 ⊗ ... ⊗ dS_j ⊗ ... ⊗ S_k) C^{-1}``.
+
+        Parameters
+        ----------
+        wrt_filter : list or numpy.ndarray, optional
+            Indices of the parameters to differentiate with respect to (all if None).
+
+        Returns
+        -------
+        numpy.ndarray
+            Shape ``(dim**2, n)``; column ``i`` is the C-order flattening of ``dS/dθ_i``.
+        """
+        S = self.factor_matrices
+        d = int(_np.prod([m.shape[0] for m in S]))
+        indices = _np.arange(self.num_params) if wrt_filter is None else _np.asarray(wrt_filter, dtype=int)
+        if indices.size == 0:
+            return _np.zeros((d * d, 0), dtype='d')
+        owner = _np.searchsorted(self._param_offsets, indices, side='right') - 1
+        local = indices - self._param_offsets[owner]
+
+        columns = {}
+        for j, el in enumerate(self.factor_elements):
+            local_j = _np.unique(local[owner == j])
+            if local_j.size == 0:
+                continue
+            dSj = el.deriv_wrt_params(list(local_j))  # (d_j**2, len(local_j)), C-order columns
+            dj = S[j].shape[0]
+            for col, li in enumerate(local_j):
+                mxs = list(S)
+                mxs[j] = dSj[:, col].reshape(dj, dj)
+                columns[(j, int(li))] = self._conjugate(self._kron(mxs)).reshape(d * d)
+        return _np.column_stack([columns[(int(j), int(li))] for j, li in zip(owner, local)])
 
     def to_vector(self) -> _np.ndarray:
         return _np.concatenate([e.to_vector() for e in self.factor_elements])

--- a/test/unit/algorithms/test_gaugeopt_correctness.py
+++ b/test/unit/algorithms/test_gaugeopt_correctness.py
@@ -342,6 +342,90 @@ class FindPerfectGauge_DirectSumGaugeGroupTester(BaseCase):
 
 
 
+class FindPerfectGauge_TensorProductGroup_Tester(BaseCase):
+    """
+    Gauge optimization over the local unitary group (a TensorProductGaugeGroup of one
+    UnitaryGaugeGroup per qubit) on two-qubit models.
+    """
+
+    @staticmethod
+    def _max_gate_distance(a, b):
+        return max(np.linalg.norm(a.operations[lbl].to_dense('minimal') - b.operations[lbl].to_dense('minimal'))
+                   for lbl in a.operations)
+
+    def _two_qubit_target(self, cnot_qubits):
+        from pygsti.processors import QubitProcessorSpec
+        from pygsti.models import create_explicit_model
+        pspec = QubitProcessorSpec(2, ['Gxpi2', 'Gypi2', 'Gcnot'], availability={'Gcnot': [cnot_qubits]})
+        target = create_explicit_model(pspec)
+        target.set_all_parameterizations('full TP')
+        return target.depolarize(op_noise=0.01, spam_noise=0.001)
+
+    def _prep(self, target, seed, strength=0.03):
+        from pygsti.models.gaugegroup import TensorProductGaugeGroup
+        gg = TensorProductGaugeGroup.local_unitary(target.state_space, target.basis)
+        rng = np.random.default_rng(seed)
+        el = gg.compute_element(strength * rng.normal(size=gg.num_params))
+        model = target.copy()
+        model.transform_inplace(el)
+        model.default_gauge_group = gg
+        check_gate_metrics_are_nontrivial(gate_metrics_dict(model, target), tol=1e-4)
+        return model, el
+
+    def _check_recovery(self, target, cnot_qubits_desc):
+        for seed in range(2):
+            model, _ = self._prep(target, seed)
+            for method, alg_tol, test_tol in (('L-BFGS-B', 1e-7, 1e-5), ('ls', 1e-15, 1e-6)):
+                out = gop.gaugeopt_to_target(model, target, method=method, tol=alg_tol,
+                                             spam_metric='frobenius', gates_metric='frobenius', verbosity=0)
+                metrics = gate_metrics_dict(out, target)
+                check_gate_metrics_near_zero(metrics, test_tol)
+
+    def test_recovers_local_unitary_gauge(self):
+        self._check_recovery(self._two_qubit_target((0, 1)), 'Gcnot:0:1')
+
+    def test_recovers_local_unitary_gauge_with_out_of_order_cnot(self):
+        # The entangler targets (1, 0). Its superoperator lives in the full-space basis whose
+        # Kronecker order follows the state-space labels, not the gate's target order.
+        target = self._two_qubit_target((1, 0))
+        self.assertIn(pgl.Label('Gcnot', (1, 0)), target.operations)
+        self._check_recovery(target, 'Gcnot:1:0')
+
+    def test_local_element_acts_like_full_space_unitary_element(self):
+        from pygsti.models.gaugegroup import OpGaugeGroupElement
+        from pygsti.modelmembers.operations import StaticArbitraryOp
+        for cnot_qubits in ((0, 1), (1, 0)):
+            target = self._two_qubit_target(cnot_qubits)
+            model_local, el = self._prep(target, seed=5)
+            Ua, Ub = (pgo.superop_to_unitary(m, 'pp') for m in el.factor_matrices)
+            full_el = OpGaugeGroupElement(StaticArbitraryOp(pgo.unitary_to_superop(np.kron(Ua, Ub), target.basis),
+                                                            basis=target.basis))
+            model_full = target.copy()
+            model_full.transform_inplace(full_el)
+            self.assertLess(self._max_gate_distance(model_local, model_full), 1e-12)
+
+    def test_local_group_cannot_undo_entangling_gauge(self):
+        from pygsti.models.gaugegroup import UnitaryGaugeGroup, TensorProductGaugeGroup
+        target = self._two_qubit_target((0, 1))
+        full = UnitaryGaugeGroup(target.state_space, target.basis)
+        v = np.zeros(full.num_params)
+        v[-1] = 0.05  # the last Hamiltonian generator is a two-body Pauli (ZZ)
+        model = target.copy()
+        model.transform_inplace(full.compute_element(v))
+        before = self._max_gate_distance(model, target)
+        self.assertGreater(before, 1e-2)
+
+        model.default_gauge_group = TensorProductGaugeGroup.local_unitary(target.state_space, target.basis)
+        out_local = gop.gaugeopt_to_target(model, target, method='ls', tol=1e-15,
+                                           spam_metric='frobenius', gates_metric='frobenius', verbosity=0)
+        self.assertGreater(self._max_gate_distance(out_local, target), 0.1 * before)
+
+        model.default_gauge_group = full
+        out_full = gop.gaugeopt_to_target(model, target, method='ls', tol=1e-15,
+                                          spam_metric='frobenius', gates_metric='frobenius', verbosity=0)
+        self.assertLess(self._max_gate_distance(out_full, target), 1e-6)
+
+
 class LeakageDirectSumGroupTester(BaseCase):
     """
     Structural tests for pygsti.leakage.gaugeopt._leakage_direct_sum_group, which

--- a/test/unit/objects/test_explicitmodel.py
+++ b/test/unit/objects/test_explicitmodel.py
@@ -58,6 +58,24 @@ class ExplicitOpModelToolTester(BaseCase):
             [('Q0', 'Q1')], ['Gix', 'Giy', 'Gxi', 'Gyi', 'Gcnot'],
             ["I(Q0):X(pi/2,Q1)", "I(Q0):Y(pi/2,Q1)", "X(pi/2,Q0):I(Q1)", "Y(pi/2,Q0):I(Q1)", "CX(pi,Q0,Q1)"])
 
+    def test_default_gauge_group_setter_strings(self):
+        from pygsti.models import gaugegroup as gg
+        m = self.gateset_2q
+        m.default_gauge_group = 'unitary'
+        self.assertIsInstance(m.default_gauge_group, gg.UnitaryGaugeGroup)
+        m.default_gauge_group = 'tp'
+        self.assertIsInstance(m.default_gauge_group, gg.TPGaugeGroup)
+        m.default_gauge_group = 'local unitary'
+        self.assertIsInstance(m.default_gauge_group, gg.TensorProductGaugeGroup)
+        self.assertEqual(m.default_gauge_group.num_params, 6)
+        self.assertTrue(all(isinstance(f, gg.UnitaryGaugeGroup) for f in m.default_gauge_group.factors))
+        m.default_gauge_group = 'Local TP'
+        self.assertIsInstance(m.default_gauge_group, gg.TensorProductGaugeGroup)
+        self.assertEqual(m.default_gauge_group.num_params, 24)
+        self.assertTrue(all(isinstance(f, gg.TPGaugeGroup) for f in m.default_gauge_group.factors))
+        with self.assertRaises(ValueError):
+            m.default_gauge_group = 'local full'
+
     def test_randomize_with_unitary(self):
         gateset_randu = self.model.randomize_with_unitary(0.01)
         gateset_randu = self.model.randomize_with_unitary(0.01, seed=1234)

--- a/test/unit/objects/test_gaugegroup.py
+++ b/test/unit/objects/test_gaugegroup.py
@@ -196,7 +196,6 @@ class U1GroupTester(GaugeGroupBase, BaseCase):
 class TensorProductGaugeGroupTester(GaugeGroupBase, BaseCase):
     n_params = 6
     element_type = ggrp.TensorProductGaugeGroupElement
-    HAS_DERIV_WRT_PARAMS = False  # implemented in a later phase
 
     def setUp(self):
         GaugeGroupBase.setUp(self)
@@ -265,3 +264,45 @@ class TensorProductGaugeGroupTester(GaugeGroupBase, BaseCase):
         el = self.gg.compute_element(self.v)
         inv = el.inverse()
         self.assertArraysAlmostEqual(inv.transform_matrix @ el.transform_matrix, np.eye(16))
+
+    def _finite_difference_deriv(self, gg, v, h=1e-6):
+        el = gg.compute_element(v)
+        cols = []
+        for i in range(gg.num_params):
+            vp, vm = v.copy(), v.copy()
+            vp[i] += h
+            vm[i] -= h
+            cols.append(((gg.compute_element(vp).transform_matrix
+                          - gg.compute_element(vm).transform_matrix) / (2 * h)).reshape(-1))
+        return el, np.column_stack(cols)
+
+    def test_deriv_wrt_params_matches_finite_differences(self):
+        el, fd = self._finite_difference_deriv(self.gg, self.v)
+        deriv = el.deriv_wrt_params()
+        self.assertEqual(deriv.shape, (16 * 16, 6))
+        self.assertArraysAlmostEqual(deriv, fd, places=6)
+
+    def test_deriv_wrt_params_honors_filter(self):
+        el = self.gg.compute_element(self.v)
+        full = el.deriv_wrt_params()
+        flt = [4, 1, 3, 1]
+        self.assertArraysAlmostEqual(el.deriv_wrt_params(flt), full[:, flt])
+        self.assertEqual(el.deriv_wrt_params([]).shape, (256, 0))
+
+    def test_deriv_wrt_params_with_change_of_basis(self):
+        qutrit = ggrp.UnitaryGaugeGroup(QuditSpace(1, 3), 'gm')
+        gg = ggrp.TensorProductGaugeGroup([qutrit, qutrit], QuditSpace(2, 3), Basis.cast('gm', 81))
+        self.assertIsNotNone(gg._change_of_basis)
+        v = 0.3 * self.rng.normal(size=gg.num_params)
+        el, fd = self._finite_difference_deriv(gg, v)
+        self.assertArraysAlmostEqual(el.deriv_wrt_params(), fd, places=6)
+        # and the element itself agrees with the direct unitary computation in the builtin gm basis
+        Ua, Ub = (superop_to_unitary(m, 'gm') for m in el.factor_matrices)
+        self.assertArraysAlmostEqual(el.transform_matrix, unitary_to_superop(np.kron(Ua, Ub), Basis.cast('gm', 81)))
+
+    def test_inverse_element_deriv(self):
+        el = self.gg.compute_element(self.v)
+        inv = el.inverse()
+        S_inv, dS = el.transform_matrix_inverse, el.deriv_wrt_params()
+        expected = np.column_stack([(-S_inv @ dS[:, i].reshape(16, 16) @ S_inv).reshape(-1) for i in range(6)])
+        self.assertArraysAlmostEqual(inv.deriv_wrt_params(), expected)

--- a/test/unit/objects/test_gaugegroup.py
+++ b/test/unit/objects/test_gaugegroup.py
@@ -2,7 +2,9 @@ import numpy as np
 
 from pygsti.modelmembers import operations as op
 from pygsti.models import gaugegroup as ggrp
-from pygsti.baseobjs.statespace import QubitSpace, ExplicitStateSpace
+from pygsti.baseobjs.statespace import QubitSpace, QuditSpace, ExplicitStateSpace
+from pygsti.baseobjs.basis import Basis, TensorProdBasis
+from pygsti.tools.optools import unitary_to_superop, superop_to_unitary
 from ..util import BaseCase
 
 
@@ -189,3 +191,77 @@ class U1GroupTester(GaugeGroupBase, BaseCase):
         el = self.gg.compute_element(np.array([0.7]))
         product = el.transform_matrix @ el.inverse().transform_matrix
         self.assertArraysAlmostEqual(product, np.eye(1, dtype=complex))
+
+
+class TensorProductGaugeGroupTester(GaugeGroupBase, BaseCase):
+    n_params = 6
+    element_type = ggrp.TensorProductGaugeGroupElement
+    HAS_DERIV_WRT_PARAMS = False  # implemented in a later phase
+
+    def setUp(self):
+        GaugeGroupBase.setUp(self)
+        self.state_space = QubitSpace(2)
+        self.factor = ggrp.UnitaryGaugeGroup(QubitSpace(1), 'pp')
+        self.gg = ggrp.TensorProductGaugeGroup([self.factor, self.factor], self.state_space, 'pp')
+        self.v = np.array([0.3, -0.2, 0.5, 0.1, 0.7, -0.4])
+
+    def test_pp_on_qubits_needs_no_change_of_basis(self):
+        self.assertIsNone(self.gg._change_of_basis)
+
+    def test_element_is_kronecker_product_of_factors(self):
+        el = self.gg.compute_element(self.v)
+        S1 = self.factor.compute_element(self.v[:3]).transform_matrix
+        S2 = self.factor.compute_element(self.v[3:]).transform_matrix
+        self.assertArraysAlmostEqual(el.transform_matrix, np.kron(S1, S2))
+        self.assertArraysAlmostEqual(el.transform_matrix_inverse, np.kron(np.linalg.inv(S1), np.linalg.inv(S2)))
+        self.assertEqual(el.transform_matrix.dtype, np.dtype('d'))
+
+    def test_element_matches_full_space_unitary(self):
+        el = self.gg.compute_element(self.v)
+        U1, U2 = (superop_to_unitary(m, 'pp') for m in el.factor_matrices)
+        self.assertArraysAlmostEqual(el.transform_matrix, unitary_to_superop(np.kron(U1, U2), 'pp'))
+
+    def test_tensor_product_model_basis(self):
+        # Models built by pyGSTi carry a TensorProdBasis ('pp*pp') rather than the builtin pp of dim 16.
+        tpb = TensorProdBasis([Basis.cast('pp', 4)] * 2)
+        gg = ggrp.TensorProductGaugeGroup([self.factor, self.factor], self.state_space, tpb)
+        self.assertIsNone(gg._change_of_basis)
+        self.assertArraysAlmostEqual(gg.compute_element(self.v).transform_matrix,
+                                     self.gg.compute_element(self.v).transform_matrix)
+
+    def test_mixed_factor_types(self):
+        tp = ggrp.TPGaugeGroup(QubitSpace(1), 'pp')
+        triv = ggrp.TrivialGaugeGroup(QubitSpace(1))
+        gg = ggrp.TensorProductGaugeGroup([tp, triv], self.state_space, 'pp')
+        self.assertEqual(gg.num_params, tp.num_params)
+        v = self.rng.random(gg.num_params)
+        el = gg.compute_element(v)
+        self.assertArraysAlmostEqual(el.transform_matrix, np.kron(tp.compute_element(v).transform_matrix, np.eye(4)))
+        self.assertArraysAlmostEqual(el.transform_matrix_inverse @ el.transform_matrix, np.eye(16))
+
+    def test_multi_label_factor(self):
+        two_q = ggrp.UnitaryGaugeGroup(QubitSpace(2), 'pp')
+        gg = ggrp.TensorProductGaugeGroup([two_q, self.factor], QubitSpace(3), 'pp')
+        self.assertEqual(gg.num_params, 15 + 3)
+        self.assertEqual(gg._label_runs, ((0, 1), (2,)))
+        el = gg.compute_element(gg.initial_params)
+        self.assertArraysAlmostEqual(el.transform_matrix, np.eye(64))
+
+    def test_constructor_rejects_bad_factor_layouts(self):
+        with self.assertRaises(ValueError):  # too few factors
+            ggrp.TensorProductGaugeGroup([self.factor], self.state_space, 'pp')
+        with self.assertRaises(ValueError):  # too many factors
+            ggrp.TensorProductGaugeGroup([self.factor] * 3, self.state_space, 'pp')
+        with self.assertRaises(ValueError):  # dimension mismatch
+            ggrp.TensorProductGaugeGroup([self.factor, ggrp.UnitaryGaugeGroup(QuditSpace(1, 3), 'gm')],
+                                         self.state_space, 'pp')
+        with self.assertRaises(ValueError):  # multi-block state space
+            ss = ExplicitStateSpace([('Q0',), ('L',)], [(2,), (1,)])
+            ggrp.TensorProductGaugeGroup([self.factor], ss, 'pp')
+        with self.assertRaises(ValueError):  # basis / state space dimension mismatch
+            ggrp.TensorProductGaugeGroup([self.factor, self.factor], self.state_space, Basis.cast('pp', 4))
+
+    def test_inverse_element(self):
+        el = self.gg.compute_element(self.v)
+        inv = el.inverse()
+        self.assertArraysAlmostEqual(inv.transform_matrix @ el.transform_matrix, np.eye(16))

--- a/test/unit/objects/test_gaugegroup.py
+++ b/test/unit/objects/test_gaugegroup.py
@@ -306,3 +306,42 @@ class TensorProductGaugeGroupTester(GaugeGroupBase, BaseCase):
         S_inv, dS = el.transform_matrix_inverse, el.deriv_wrt_params()
         expected = np.column_stack([(-S_inv @ dS[:, i].reshape(16, 16) @ S_inv).reshape(-1) for i in range(6)])
         self.assertArraysAlmostEqual(inv.deriv_wrt_params(), expected)
+
+    def test_local_unitary_constructor(self):
+        gg = ggrp.TensorProductGaugeGroup.local_unitary(self.state_space, 'pp')
+        self.assertEqual(gg.num_params, 6)
+        self.assertTrue(all(isinstance(f, ggrp.UnitaryGaugeGroup) for f in gg.factors))
+        self.assertEqual([f.state_space.tensor_product_blocks_labels[0] for f in gg.factors], [(0,), (1,)])
+        self.assertIsNone(gg._change_of_basis)
+        self.assertArraysAlmostEqual(gg.compute_element(self.v).transform_matrix,
+                                     self.gg.compute_element(self.v).transform_matrix)
+        # with the TensorProdBasis that pyGSTi-built models carry
+        tpb = TensorProdBasis([Basis.cast('pp', 4)] * 2)
+        gg2 = ggrp.TensorProductGaugeGroup.local_unitary(self.state_space, tpb)
+        self.assertIsNone(gg2._change_of_basis)
+        self.assertArraysAlmostEqual(gg2.compute_element(self.v).transform_matrix,
+                                     self.gg.compute_element(self.v).transform_matrix)
+
+    def test_local_tp_constructor(self):
+        gg = ggrp.TensorProductGaugeGroup.local_tp(QubitSpace(3), 'pp')
+        self.assertEqual(gg.num_params, 3 * 12)
+        self.assertTrue(all(isinstance(f, ggrp.TPGaugeGroup) for f in gg.factors))
+        el = gg.compute_element(self.rng.random(gg.num_params))
+        S = el.transform_matrix
+        self.assertArraysAlmostEqual(S[0, :], np.eye(64)[0, :])  # TP: first row is e_0
+        self.assertArraysAlmostEqual(el.transform_matrix_inverse @ S, np.eye(64))
+
+    def test_local_constructors_with_dimension_one_label(self):
+        ss = ExplicitStateSpace(['Q0', 'L', 'Q1'], [2, 1, 3])
+        gg = ggrp.TensorProductGaugeGroup.local_unitary(ss, 'gm')
+        self.assertEqual([type(f) for f in gg.factors],
+                         [ggrp.UnitaryGaugeGroup, ggrp.TrivialGaugeGroup, ggrp.UnitaryGaugeGroup])
+        self.assertEqual(gg._label_runs, ((0,), (1,), (2,)))
+        self.assertEqual(gg.num_params, 3 + 0 + 8)
+        el = gg.compute_element(0.3 * self.rng.normal(size=gg.num_params))
+        self.assertArraysAlmostEqual(el.transform_matrix_inverse @ el.transform_matrix, np.eye(36))
+
+    def test_local_constructors_reject_multi_block_space(self):
+        ss = ExplicitStateSpace([('Q0',), ('L',)], [(2,), (1,)])
+        with self.assertRaises(ValueError):
+            ggrp.TensorProductGaugeGroup.local_unitary(ss, 'pp')

--- a/test/unit/objects/test_gaugegroup.py
+++ b/test/unit/objects/test_gaugegroup.py
@@ -345,3 +345,28 @@ class TensorProductGaugeGroupTester(GaugeGroupBase, BaseCase):
         ss = ExplicitStateSpace([('Q0',), ('L',)], [(2,), (1,)])
         with self.assertRaises(ValueError):
             ggrp.TensorProductGaugeGroup.local_unitary(ss, 'pp')
+
+    def test_serialization_round_trip(self):
+        import json
+        for gg in (self.gg,
+                   ggrp.TensorProductGaugeGroup.local_unitary(ExplicitStateSpace(['Q0', 'L', 'Q1'], [2, 1, 3]), 'gm'),
+                   ggrp.TensorProductGaugeGroup([ggrp.UnitaryGaugeGroup(QuditSpace(1, 3), 'gm')] * 2,
+                                                QuditSpace(2, 3), Basis.cast('gm', 81))):
+            state = gg.to_nice_serialization()
+            json.dumps(state)  # "nice" means JSON-able
+            gg2 = ggrp.GaugeGroup.from_nice_serialization(state)
+            self.assertIsInstance(gg2, ggrp.TensorProductGaugeGroup)
+            self.assertEqual(gg2.num_params, gg.num_params)
+            self.assertEqual(gg2.state_space, gg.state_space)
+            self.assertEqual([type(f) for f in gg2.factors], [type(f) for f in gg.factors])
+            self.assertEqual(gg2._change_of_basis is None, gg._change_of_basis is None)
+            v = 0.3 * self.rng.normal(size=gg.num_params)
+            el, el2 = gg.compute_element(v), gg2.compute_element(v)
+            self.assertArraysAlmostEqual(el.transform_matrix, el2.transform_matrix)
+            # element round trip (like other Op-based elements, this keeps the matrices, not the parameterization)
+            estate = el.to_nice_serialization()
+            json.dumps(estate)
+            el3 = ggrp.GaugeGroupElement.from_nice_serialization(estate)
+            self.assertIsInstance(el3, ggrp.TensorProductGaugeGroupElement)
+            self.assertArraysAlmostEqual(el.transform_matrix, el3.transform_matrix)
+            self.assertArraysAlmostEqual(el.transform_matrix_inverse, el3.transform_matrix_inverse)

--- a/test/unit/objects/test_gaugegroup.py
+++ b/test/unit/objects/test_gaugegroup.py
@@ -265,6 +265,15 @@ class TensorProductGaugeGroupTester(GaugeGroupBase, BaseCase):
         inv = el.inverse()
         self.assertArraysAlmostEqual(inv.transform_matrix @ el.transform_matrix, np.eye(16))
 
+    def test_inverse_element_from_vector_updates_wrapped_element(self):
+        el = self.gg.compute_element(self.v)
+        inv = el.inverse()
+        w = self.rng.random(self.n_params)
+        inv.from_vector(w)
+        self.assertArraysAlmostEqual(el.to_vector(), w)
+        self.assertArraysAlmostEqual(inv.to_vector(), w)
+        self.assertArraysAlmostEqual(inv.transform_matrix, np.linalg.inv(self.gg.compute_element(w).transform_matrix))
+
     def _finite_difference_deriv(self, gg, v, h=1e-6):
         el = gg.compute_element(v)
         cols = []


### PR DESCRIPTION
The following is written by a robot, and edited by me. It's been revised from the original PR description following changes made after a round of review.

----------------

This PR adds `TensorProductGaugeGroup`, a gauge group whose elements are Kronecker products of per-subsystem gauge transformations. The motivating case is local unitary gauge freedom, `U(d)` on each of `k` qudits. When we gauge-optimize a multi-qubit estimate over the full unitary or TP group, the optimizer is free to absorb crosstalk or entangling error into a non-local gauge choice. Restricting to local transformations removes that freedom.

### The abstraction

`TensorProductGaugeGroup(factors, state_space, basis)` takes a(ny) sequence of ordinary `GaugeGroup` objects, one per contiguous run of state-space labels. A two-qubit factor next to a one-qubit factor on a three-qubit space is fine too, as is a mix of qubits and qubits.

An element's transform matrix is `(C_1 S_1 C_1^{-1}) ⊗ ... ⊗ (C_k S_k C_k^{-1})`, where the `S_j` are the factor elements' matrices in their own bases and each `C_j` is a fixed change of basis from factor `j`'s basis to the model basis's component on that factor's labels. This is the same operator as `C (S_1 ⊗ ... ⊗ S_k) C^{-1}` with `C = C_1 ⊗ ... ⊗ C_k`, but only factor-sized operators are ever built. For `pp` on qubits, and for the `TensorProdBasis` objects our model constructors already produce, every `C_j` is the identity and is skipped. The model basis has to be a tensor product over the factors for this to make sense: a `TensorProdBasis` with one component per label, or the builtin `pp`, which splits as `pp(d1 d2) = pp(d1) ⊗ pp(d2)`. The builtin `gm` or `std` of the full dimension on several qudits is rejected (`gm` on two qutrits is not `gm ⊗ gm`), since the change of basis it would need couples the factors and is a dense operator on the whole space.

Feature entry points:
 * Two convenience constructors, `TensorProductGaugeGroup.local_unitary(state_space, basis)` and `.local_tp(...)`, build one factor per state-space label.
 * `ExplicitOpModel.default_gauge_group` now accepts the strings `'local unitary'` and `'local tp'` alongside `'unitary'` and `'tp'`.

### Small supporting changes

- `OpGaugeGroup` exposes a public `state_space` property and `OpGaugeGroupWithBasis` a public `basis` property, so every factor can be interrogated uniformly.
- `UnitaryGaugeGroup` passes its state space into the Lindblad error generator instead of stashing it as an instance attribute, which would now collide with the property.
- The `'tp'` branch of the `default_gauge_group` setter referenced `self.evotypes`, which doesn't exist. It would have raised on first use. Fixed while I was in there.
- `TensorProdBasis` gets a Notes section recording that its transform matrices don't exploit the tensor-product structure. That's why the group does the change of basis factor by factor rather than asking the basis for it.
- `InverseGaugeGroupElement.from_vector` called the wrapped element's `from_vector` with no argument, so it would have raised on first use. Nothing in the gauge-optimization path calls it, but the tensor-product tests exercise inverse elements, so I fixed it and added a test that the vector reaches the wrapped element.

### Testing

Unit tests in `test/unit/objects/test_gaugegroup.py` check the element against `np.kron` of the factor matrices and against `unitary_to_superop` of the product unitary, check the derivative against central finite differences on both the identity and non-identity change-of-basis paths (the latter with factors in `l2p1` on a model in `gm ⊗ gm`), and cover `wrt_filter` ordering, mixed factor types, multi-label factors, the constructor's rejection cases, and nice-serialization round trips.

End-to-end tests in `test/unit/algorithms/test_gaugeopt_correctness.py` use two-qubit full-TP models built from a processor spec. A local-unitary gauge perturbation is recovered by both L-BFGS-B and least squares, including when the only entangler is `Gcnot` on `(1, 0)`; that case checks that the Kronecker order follows the state-space labels and not the gate's target order. The local element is also checked gate by gate against the full-space unitary element for `U_a ⊗ U_b`. Finally, an entangling `ZZ` gauge perturbation is left in place by the local group and removed by the full unitary group, which is the behavioral reason this class exists.

Regression over `test/unit/{objects,algorithms,leakage,protocols}` on py313: 1715 passed, 14 skipped, 1 xfailed.

### What this PR doesn't do

- Factors must act on contiguous runs of labels, in state-space order. A factor on qubits 0 and 2 with another on qubit 1 would need a qudit permutation, analogous to `level_partition` in `DirectSumUnitaryGroup`. The constructor rejects that layout with a message saying so.
- The model basis must be a tensor product over the factors. Factors in one basis and a model in another are fine, since that's what the per-factor `C_j` are for, but a model in the builtin `gm` or `std` of the full dimension, on more than one factor, raises with a message pointing at `Basis.cast('gm', state_space)`. Supporting it would mean a dense change of basis on the full space, which defeats the point of keeping everything factor-sized.
- Only single-block state spaces are supported. Leakage-style spaces (direct sums of tensor products) raise. Composing with `DirectSumUnitaryGroup` is the natural next step, but I didn't want to widen the scope here.
- `set_default_gauge_group_for_member_type` is untouched. It maps member parameterizations to groups, and locality is a property of the state space, not of the member type.

### Where to look

**The change-of-basis direction**, in `TensorProductGaugeGroup._factor_change_of_basis`. For each factor the group sets `C_j = factor_basis.create_transform_matrix(model_basis)`, where `model_basis` is the model basis's component on that factor's labels, and the element then computes `C_j @ S_j @ inv(C_j)` before taking the Kronecker product. Getting `C_j` and `inv(C_j)` swapped is the easy mistake here, and it's invisible on qubits in `pp`, because there `C_j` is the identity and gets skipped entirely. The test that would catch a swap is `test_deriv_wrt_params_with_change_of_basis`: two qutrits with `UnitaryGaugeGroup` factors in `l2p1`, assembled into `gm ⊗ gm`. Each `C_j` is a 9-by-9 orthogonal matrix that isn't the identity, so the swapped version would be `C_j.T @ S_j @ C_j` and would disagree with `unitary_to_superop(kron(U_a, U_b), gm ⊗ gm)`. The same test checks the element against conjugating the whole Kronecker product by the full-space `C_1 ⊗ C_2`, and checks the derivative by finite differences along that path, since the conjugation is applied to every derivative column too. If you'd rather not trust one test, `Basis.create_transform_matrix`'s docstring ("transforms a vector from this basis to `to_basis`") is the contract I'm relying on.

**The label-matching rule**, in `_match_factors_to_label_runs`. This is what decides which state-space labels each factor acts on, and therefore whether the Kronecker order matches the model's basis order. The same rule, minus the warning, lines the model basis's components up with the labels in `_model_bases_for_factor_runs`, so it also decides which piece of the model basis each factor's `C_j` is computed against. The rule is: walk the block's labels left to right, and give each factor the shortest run of unclaimed labels whose Hilbert-space dimensions multiply to that factor's `udim`. Two things to check:

- Every factor consumes at least one label, even a factor of dimension 1. Without that clause a `TrivialGaugeGroup` on a dimension-1 label claimed nothing, the next factor started one label too early, and the whole layout shifted. `test_local_constructors_with_dimension_one_label` covers this on a `(2, 1, 3)` space.
- The rule is greedy and has no notion of which labels a factor "meant" to act on. A dimension-2 factor placed where a dimension-1 label sits will claim that label and the next qubit together, since `1 * 2 = 2`. That's dimensionally consistent and I believe it's the right behavior, but it's the one place where the constructor accepts a layout the caller might not have intended. Mismatches that can't be reconciled this way, and leftover labels after the last factor, both raise with the offending labels named.

