### PR TITLE
Make TorchForwardSimulator go vroom vroom

### DIFF
--- a/pygsti/forwardsims/torchfwdsim.py
+++ b/pygsti/forwardsims/torchfwdsim.py
@@ -394,6 +394,24 @@ class TorchForwardSimulator(ForwardSimulator):
         self._store_cache = None
         super(ForwardSimulator, self).__init__(model)
 
+    @staticmethod
+    def _model_signature(model):
+        """
+        A cheap structural fingerprint of `model`'s parameterized members.
+
+        The store bakes each member's *type* and its `stateless_data`, so reusing a store is only
+        sound while the members themselves are structurally unchanged. Object identity of the
+        model is not sufficient: `set_all_parameterizations` and `convert_members_inplace` replace
+        member objects under the same labels on the same model object, which would otherwise leave
+        the cached types and stateless data stale.
+
+        This does not, and cannot cheaply, detect in-place mutation of a *static* member's dense
+        matrix, whose value is baked into `stateless_data`. Mutating a member pyGSTi considers
+        static is out of contract; call `model.sim = TorchForwardSimulator(...)` again if you do it.
+        """
+        return tuple((lbl, type(obj), obj.num_params)
+                     for lbl, obj in model._iter_parameterized_objs())
+
     def _circuit_store(self, layout) -> StatelessModelCircuitStore:
         """
         The StatelessModelCircuitStore for `layout`, reused across calls.
@@ -402,18 +420,22 @@ class TorchForwardSimulator(ForwardSimulator):
         data; building its evaluation plan walks every gate application. Neither depends on the
         model's parameter *values*, so a GST optimization -- which calls this simulator once or
         twice per iteration against a fixed layout -- should pay for them once, not once per
-        iteration. The cache holds weak references so it can't keep a layout or model alive, and
-        is keyed by object identity: a structurally different layout or model is a different
-        object, and `get_free_params` re-checks the modelmember labels on every call.
+        iteration.
+
+        The cache holds weak references so it can't keep a layout or model alive. It is keyed by
+        the identity of the layout and model *and* by :meth:`_model_signature`, so that replacing
+        modelmembers in place (a different parameterization under the same label) invalidates it.
         """
+        signature = self._model_signature(self.model)
         cached = self._store_cache
         if cached is not None:
-            layout_ref, model_ref, store = cached
-            if layout_ref() is layout and model_ref() is self.model:
+            layout_ref, model_ref, cached_signature, store = cached
+            if (layout_ref() is layout and model_ref() is self.model
+                    and cached_signature == signature):
                 return store
         store = StatelessModelCircuitStore(self.model, layout, self.dtype, self.device)
         try:
-            self._store_cache = (_weakref.ref(layout), _weakref.ref(self.model), store)
+            self._store_cache = (_weakref.ref(layout), _weakref.ref(self.model), signature, store)
         except TypeError:  # pragma: no cover - a layout or model that can't be weak-referenced
             self._store_cache = None
         return store

--- a/pygsti/forwardsims/torchfwdsim.py
+++ b/pygsti/forwardsims/torchfwdsim.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Tuple, Optional, Dict, Any, Type, TYPE_CHECKING
 from pygsti.modelmembers.torchable import Torchable
 from pygsti.forwardsims.forwardsim import ForwardSimulator
+from pygsti.forwardsims.torchfwdsim_plan import TorchEvalPlan
 
 if TYPE_CHECKING:
     from pygsti.baseobjs.label import Label
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
     import torch
 
 import warnings as warnings
+import weakref as _weakref
 
 
 try:
@@ -88,6 +90,8 @@ class StatelessModelCircuitStore:
         from pygsti.modelmembers.instruments.instrument import Instrument as _Instrument
         from pygsti.modelmembers.instruments.tpinstrument import TPInstrument as _TPInstrument
 
+        self.dtype = dtype
+        self.device = device
         circuits = []
         self.outcome_probs_dim = 0
         povm_effect_orders = {}
@@ -119,6 +123,9 @@ class StatelessModelCircuitStore:
                 circuits.append(c)
                 self.outcome_probs_dim += c.outcome_probs_dim
         self.circuits = circuits
+        self.povm_effect_counts = {lbl: len(order) for lbl, order in povm_effect_orders.items()}
+        self.model_dim = model.dim
+        self._eval_plan = None
 
         # We need to verify assumptions on what layout.iter_unique_circuits() returns.
         # Looking at the implementation of that function, the assumptions can be
@@ -227,29 +234,49 @@ class StatelessModelCircuitStore:
 
         return torch_bases
 
+    @property
+    def eval_plan(self) -> TorchEvalPlan:
+        """
+        The batched :class:`TorchEvalPlan` for this store's circuits, built on first use.
+
+        The plan depends only on the *structure* of the (model, layout) pair -- circuit contents,
+        which modelmembers are parameterized, and how many parameters each has -- so one plan
+        serves every parameter value a GST optimization visits.
+        """
+        if self._eval_plan is None:
+            self._eval_plan = TorchEvalPlan(
+                self.circuits, self.param_metadata, self.instrument_expansions,
+                self.povm_effect_counts, self.outcome_probs_dim, self.dtype, self.device
+            )
+        return self._eval_plan
+
     def circuit_probs_from_torch_bases(self, torch_bases: Dict[Label, torch.Tensor]) -> torch.Tensor:
         """
         Compute the circuit outcome probabilities that result when all of this StatelessModelCircuitStore's
         StatelessCircuits are run with data in torch_bases.
-    
+
         Return the results as a single (vectorized) torch Tensor.
         """
-        probs = []
-        for c in self.circuits:
-            superket = torch_bases[c.prep_label]
-            superops = [torch_bases[ol] for ol in c.op_labels]
-            povm_mat = torch_bases[c.povm_label]
-            if c.effect_row_indices is not None:
-                povm_mat = povm_mat[c.effect_row_indices]
-                # ^ select (and order) the POVM rows to match c.effect_labels; advanced
-                #   indexing keeps autograd flowing to the POVM's parameters.
-            for superop in superops:
-                superket = superop @ superket
-            circuit_probs = povm_mat @ superket
-            probs.append(circuit_probs)
-        probs = torch.concat(probs)
-        return probs
-    
+        return self.eval_plan.probs(torch_bases, self.model_dim)
+
+    def circuit_jacobian_from_free_params(self, free_params: Tuple[torch.Tensor],
+                                          probs_out=None) -> torch.Tensor:
+        """
+        The Jacobian of :meth:`circuit_probs_from_free_params` at `free_params`, as a dense
+        ``(outcome_probs_dim, params_dim)`` Tensor.
+
+        Unlike ``torch.func.jacfwd(circuit_probs_from_free_params)``, this does not differentiate
+        through the circuit-evaluation loop. It differentiates each modelmember's
+        ``torch_base`` map on its own (a small, per-member autodiff problem) and applies the chain
+        rule with an explicitly-derived expression for the derivative of a circuit's outcome
+        probabilities with respect to the dense superoperators. See
+        :mod:`pygsti.forwardsims.torchfwdsim_plan`.
+        """
+        num_params = sum(int(fp.numel()) for fp in free_params)
+        return self.eval_plan.jacobian(free_params, self.model_dim, num_params,
+                                       probs_out=probs_out)
+
+
     def circuit_probs_from_free_params(self, *free_params: Tuple[torch.Tensor], enable_backward=False) -> torch.Tensor:
         """
         This is the basic function we expose to pytorch for automatic differentiation. It returns the circuit
@@ -346,12 +373,37 @@ class TorchForwardSimulator(ForwardSimulator):
 
         self.dtype  = dtype
         self.device = device
+        self._store_cache = None
         super(ForwardSimulator, self).__init__(model)
+
+    def _circuit_store(self, layout) -> StatelessModelCircuitStore:
+        """
+        The StatelessModelCircuitStore for `layout`, reused across calls.
+
+        Building the store walks every circuit in Python and bakes each modelmember's stateless
+        data; building its evaluation plan walks every gate application. Neither depends on the
+        model's parameter *values*, so a GST optimization -- which calls this simulator once or
+        twice per iteration against a fixed layout -- should pay for them once, not once per
+        iteration. The cache holds weak references so it can't keep a layout or model alive, and
+        is keyed by object identity: a structurally different layout or model is a different
+        object, and `get_free_params` re-checks the modelmember labels on every call.
+        """
+        cached = self._store_cache
+        if cached is not None:
+            layout_ref, model_ref, store = cached
+            if layout_ref() is layout and model_ref() is self.model:
+                return store
+        store = StatelessModelCircuitStore(self.model, layout, self.dtype, self.device)
+        try:
+            self._store_cache = (_weakref.ref(layout), _weakref.ref(self.model), store)
+        except TypeError:  # pragma: no cover - a layout or model that can't be weak-referenced
+            self._store_cache = None
+        return store
 
     def _bulk_fill_probs(self, array_to_fill, layout, split_model = None) -> None:
         assert self.model is not None
         if split_model is None:
-            smcs = StatelessModelCircuitStore(self.model, layout, self.dtype, self.device)
+            smcs = self._circuit_store(layout)
             free_params = smcs.get_free_params(self.model, self.dtype, self.device)
             torch_bases = smcs.get_torch_bases(free_params)
         else:
@@ -363,24 +415,15 @@ class TorchForwardSimulator(ForwardSimulator):
 
     def _bulk_fill_dprobs(self, array_to_fill, layout, pr_array_to_fill) -> None:
         assert self.model is not None
-        smcs = StatelessModelCircuitStore(self.model, layout, self.dtype, self.device)
-        # ^ TODO: figure out how to safely recycle StatelessModelCircuitStore objects from one
-        #   call to another. The current implementation is wasteful if we need to 
-        #   compute many jacobians without structural changes to layout or self.model.
+        smcs = self._circuit_store(layout)
         free_params = smcs.get_free_params(self.model, self.dtype, self.device)
-    
+
+        probs_out = None
         if pr_array_to_fill is not None:
-            torch_bases = smcs.get_torch_bases(free_params)
-            splitm = (smcs, torch_bases)
-            self._bulk_fill_probs(pr_array_to_fill, layout, splitm)
+            probs_out = torch.empty(smcs.outcome_probs_dim, dtype=self.dtype, device=self.device)
 
-        argnums = tuple(range(len(smcs.param_metadata)))
-        if smcs.default_to_reverse_ad:
-            J_func = torch.func.jacrev(smcs.circuit_probs_from_free_params, argnums=argnums) # type: ignore
-        else:
-            J_func = torch.func.jacfwd(smcs.circuit_probs_from_free_params, argnums=argnums) # type: ignore
-
-        J_val = J_func(*free_params)
-        J_val = torch.column_stack(J_val)
-        array_to_fill[:] = J_val.cpu().detach().numpy()
+        J_val = smcs.circuit_jacobian_from_free_params(free_params, probs_out=probs_out)
+        array_to_fill[:] = J_val.cpu().numpy()
+        if probs_out is not None:
+            pr_array_to_fill[:smcs.outcome_probs_dim] = probs_out.cpu().numpy().ravel()
         return

--- a/pygsti/forwardsims/torchfwdsim.py
+++ b/pygsti/forwardsims/torchfwdsim.py
@@ -296,6 +296,24 @@ class StatelessModelCircuitStore:
         return probs
 
 
+def _copy_to_numpy(src: torch.Tensor, dest) -> None:
+    """
+    Copy a device Tensor straight into an existing numpy array.
+
+    ``dest[...] = src.cpu().numpy()`` allocates a fresh host buffer of the Tensor's full size on
+    every call and then copies it again into `dest`. For a GST Jacobian that buffer is gigabytes,
+    and the allocate-fault-copy-copy round trip costs several times more than the transfer itself.
+    Wrapping `dest` with ``torch.from_numpy`` lets the copy engine write into the caller's memory
+    directly.
+    """
+    src = src.detach().reshape(dest.shape)
+    try:
+        torch.from_numpy(dest).copy_(src)
+    except (TypeError, ValueError, RuntimeError):
+        # e.g. a non-writable, negatively-strided, or otherwise un-wrappable array
+        dest[...] = src.cpu().numpy()
+
+
 def get_device() -> str:
     if torch.cuda.is_available() and torch.cuda.device_count() > 0:
         return 'cuda:0'  # NVIDIA and AMD
@@ -410,7 +428,7 @@ class TorchForwardSimulator(ForwardSimulator):
             smcs, torch_bases = split_model
 
         probs = smcs.circuit_probs_from_torch_bases(torch_bases)
-        array_to_fill[:smcs.outcome_probs_dim] = probs.cpu().detach().numpy().ravel()
+        _copy_to_numpy(probs, array_to_fill[:smcs.outcome_probs_dim])
         return
 
     def _bulk_fill_dprobs(self, array_to_fill, layout, pr_array_to_fill) -> None:
@@ -423,7 +441,7 @@ class TorchForwardSimulator(ForwardSimulator):
             probs_out = torch.empty(smcs.outcome_probs_dim, dtype=self.dtype, device=self.device)
 
         J_val = smcs.circuit_jacobian_from_free_params(free_params, probs_out=probs_out)
-        array_to_fill[:] = J_val.cpu().numpy()
+        _copy_to_numpy(J_val, array_to_fill)
         if probs_out is not None:
-            pr_array_to_fill[:smcs.outcome_probs_dim] = probs_out.cpu().numpy().ravel()
+            _copy_to_numpy(probs_out, pr_array_to_fill[:smcs.outcome_probs_dim])
         return

--- a/pygsti/forwardsims/torchfwdsim_plan.py
+++ b/pygsti/forwardsims/torchfwdsim_plan.py
@@ -1,0 +1,521 @@
+#***************************************************************************************************
+# Copyright 2026, National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+# Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain rights
+# in this software.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
+#***************************************************************************************************
+"""
+A batched evaluation plan for :class:`TorchForwardSimulator`.
+
+Motivation
+----------
+The straightforward way to evaluate a list of circuits with PyTorch -- loop over circuits, loop
+over layers, ``superket = superop @ superket`` -- issues one GPU kernel launch per gate
+application. A GST circuit list for a six-level system has on the order of 10^5 gate applications,
+so a single probability evaluation costs 10^5 launches of a matrix-vector product on a 36x36
+matrix. That is entirely launch-bound: the GPU is idle almost all of the time. Differentiating
+that loop with ``torch.func.jacfwd``/``jacrev`` keeps the launch count and multiplies the working
+set by the number of parameters (or outcomes), which is worse still.
+
+This module replaces that loop with a plan that is compiled once per (circuit list, model
+structure) and then replayed cheaply. It rests on two observations.
+
+**1. Circuits share prefixes and suffixes.** A GST circuit is
+``prep_fiducial + germ^p + meas_fiducial``, so the list has enormous redundancy. We build a prefix
+DAG over the op-label sequences and evaluate it breadth-first: all nodes at tree depth ``t`` that
+apply the same gate are updated by a *single* dense matrix-matrix product. The number of kernel
+launches drops from "one per gate application" to "one per (tree depth, gate label) pair" -- from
+10^5 to 10^2 -- and the total flop count drops by the prefix-sharing factor. The same is done with
+a suffix DAG, evaluated from the POVM backwards.
+
+**2. The Jacobian is a sum of rank-one terms in the dense superoperators.** For a circuit
+``c = (g_1, ..., g_L)`` with prep ``rho`` and POVM ``E``, write
+
+    R_k = M_{g_k} ... M_{g_1} rho          (a prefix-DAG node state)
+    L_k = E M_{g_L} ... M_{g_{k+1}}        (a suffix-DAG node state)
+
+so that ``p_c = L_k M_{g_k} R_{k-1}`` for every k. Then
+
+    d p_c[e] / d M_g [a,b] = sum_{k : g_k = g} L_k[e,a] R_{k-1}[b] =: A_g[(c,e), a, b]
+
+and the chain rule through the *parameterization* gives the Jacobian block for gate ``g``:
+
+    J[(c,e), theta_g] = A_g[(c,e), :, :] . (d M_g / d theta_g)
+
+The second factor is a small per-modelmember object of shape ``(d^2, n_params_g)`` that we get
+from ``torch.func.jacrev`` on ``Torchable.torch_base`` -- so PyTorch still does all the
+differentiation of the parameterization, which is the whole point of the Torch simulator. The
+first factor is built by one scatter-add of outer products, and the contraction is one large
+matrix-matrix product. Both map perfectly onto a GPU.
+
+The result is a Jacobian computed in a few hundred kernel launches instead of ~10^5 * n_params.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+
+if TYPE_CHECKING:
+    import torch
+    from pygsti.baseobjs.label import Label
+
+try:
+    import torch
+except ImportError:
+    pass
+
+import numpy as _np
+
+
+# Cap on the temporary that holds a batch of outer products while a scatter-add accumulates the
+# "A" tensor.  Chosen so the temporary stays well inside a GPU's memory even for large d.
+_OUTER_PRODUCT_CHUNK_BYTES = 1 << 28  # 256 MiB
+
+
+class _SequenceDag:
+    """
+    A DAG over sequences of op labels: one node per distinct sequence that occurs as a prefix (or,
+    for the reversed use, a suffix) of some circuit, plus one root per distinct "seed" key.
+
+    Nodes are numbered so that a node's parent always has a smaller index and so that all nodes
+    sharing a (depth, op-label) pair are *contiguous*. That lets the evaluation schedule write its
+    results into a contiguous slice of the state tensor -- the source indices still need a gather,
+    but the destination never does.
+    """
+
+    def __init__(self):
+        self._children: List[dict] = []
+        self._parent: List[int] = []
+        self._op: List[Any] = []
+        self._depth: List[int] = []
+        self.root_keys: List[Any] = []
+        self._finalized = False
+
+    # -- construction -------------------------------------------------------------------------
+
+    def root(self, key) -> int:
+        """Index of the root node seeded by `key`, creating it if needed."""
+        for i, k in enumerate(self.root_keys):
+            if k == key:
+                return i
+        assert not self._children or self._depth[-1] == 0, \
+            "all roots must be created before any interior node"
+        idx = len(self._parent)
+        self.root_keys.append(key)
+        self._children.append({})
+        self._parent.append(-1)
+        self._op.append(None)
+        self._depth.append(0)
+        return idx
+
+    def walk(self, root_idx: int, ops: Sequence) -> List[int]:
+        """
+        Insert `ops` under `root_idx` and return the node index after each step, i.e. a list of
+        ``len(ops) + 1`` indices starting with `root_idx`.
+        """
+        cur = root_idx
+        path = [cur]
+        for op in ops:
+            nxt = self._children[cur].get(op)
+            if nxt is None:
+                nxt = len(self._parent)
+                self._children[cur][op] = nxt
+                self._children.append({})
+                self._parent.append(cur)
+                self._op.append(op)
+                self._depth.append(self._depth[cur] + 1)
+            cur = nxt
+            path.append(cur)
+        return path
+
+    # -- finalization -------------------------------------------------------------------------
+
+    def finalize(self, op_ids: Dict[Any, int], device) -> _np.ndarray:
+        """
+        Renumber nodes into (depth, op-label) order and build the evaluation schedule.
+
+        Returns the ``old index -> new index`` map so the caller can translate the node indices it
+        collected during construction.
+        """
+        assert not self._finalized
+        n = len(self._parent)
+        depth = _np.asarray(self._depth)
+        opid = _np.array([-1 if o is None else op_ids[o] for o in self._op])
+        # lexsort by (depth, op id) -- stable, so ties keep insertion order.
+        order = _np.lexsort((_np.arange(n), opid, depth))
+        new_of_old = _np.empty(n, dtype=_np.int64)
+        new_of_old[order] = _np.arange(n, dtype=_np.int64)
+
+        parent = _np.asarray(self._parent)
+        n_roots = len(self.root_keys)
+        assert _np.all(order[:n_roots] == _np.arange(n_roots)), "roots must sort to the front"
+
+        # schedule: contiguous runs of equal (depth, op id) among the non-root nodes
+        self.schedule: List[Tuple[Any, int, int, "torch.Tensor"]] = []
+        keys = list(zip(depth[order], opid[order]))
+        inv_op = {v: k for k, v in op_ids.items()}
+        start = n_roots
+        while start < n:
+            stop = start + 1
+            while stop < n and keys[stop] == keys[start]:
+                stop += 1
+            src_old = parent[order[start:stop]]
+            src_new = new_of_old[src_old]
+            self.schedule.append((
+                inv_op[keys[start][1]], start, stop,
+                torch.as_tensor(src_new, dtype=torch.long, device=device),
+            ))
+            start = stop
+
+        self.num_nodes = n
+        self.num_roots = n_roots
+        self._finalized = True
+        # drop construction-only state
+        self._children = []
+        self._parent = []
+        self._op = []
+        self._depth = []
+        return new_of_old
+
+
+def _member_value_and_jacobian(type_handle, stateless_data, param_vec):
+    """
+    ``(torch_base(sd, v), d torch_base / d v)``. The Jacobian has shape ``out_shape + (n_v,)``;
+    it is the *only* place autodiff is used, and it runs on a single modelmember's parameters, so
+    it is cheap regardless of how many circuits are being simulated.
+    """
+    def f(v):
+        return type_handle.torch_base(stateless_data, v)
+
+    out = f(param_vec)
+    n_v = param_vec.numel()
+    if n_v == 0:
+        return out, out.new_zeros(tuple(out.shape) + (0,))
+    if out.numel() <= n_v:
+        jac = torch.func.jacrev(f)(param_vec)
+    else:
+        jac = torch.func.jacfwd(f)(param_vec)
+    return out, jac
+
+
+class _PovmGroup:
+    """
+    The plan for the subset of circuits that share a single POVM label.
+
+    Within a group every circuit produces the same number of "dense" outcome rows -- the POVM's
+    full effect count -- even if the layout only asks for a subset of them. Keeping the dense
+    width uniform is what lets the whole group be one set of rectangular tensors; the (rare)
+    subsetting is applied by a row gather when results are written out.
+    """
+
+    def __init__(self, povm_label, n_eff: int):
+        self.povm_label = povm_label
+        self.n_eff = n_eff
+        self.fwd = _SequenceDag()
+        self.bwd = _SequenceDag()
+        self._circ_end_fwd: List[int] = []   # prefix node for the whole circuit  -> R_L
+        self._circ_end_bwd: List[int] = []   # suffix node for the whole circuit  -> L_0
+        self._prep_of_circuit: List[Any] = []
+        self._positions: Dict[Any, List[Tuple[int, int, int]]] = {}  # op -> [(circ, lnode, rnode)]
+        self._dense_rows: List[int] = []
+        self._out_rows: List[int] = []
+        self.num_circuits = 0
+
+    def add_circuit(self, prep_label, op_labels, effect_rows: Sequence[int], elem_offset: int):
+        ic = self.num_circuits
+        self.num_circuits += 1
+        self._prep_of_circuit.append(prep_label)
+
+        fwd_path = self.fwd.walk(self.fwd.root(prep_label), op_labels)
+        bwd_path = self.bwd.walk(self.bwd.root(self.povm_label), tuple(reversed(op_labels)))
+        # bwd_path[j] is the suffix consisting of the last j ops, i.e. L_{L-j}.
+        self._circ_end_fwd.append(fwd_path[-1])
+        self._circ_end_bwd.append(bwd_path[-1])
+
+        n_ops = len(op_labels)
+        for k in range(1, n_ops + 1):          # position k applies op_labels[k-1]
+            self._positions.setdefault(op_labels[k - 1], []).append(
+                (ic, bwd_path[n_ops - k], fwd_path[k - 1])
+            )
+
+        for j, e in enumerate(effect_rows):
+            self._dense_rows.append(ic * self.n_eff + e)
+            self._out_rows.append(elem_offset + j)
+
+    def finalize(self, op_ids, device):
+        fwd_map = self.fwd.finalize(op_ids, device)
+        bwd_map = self.bwd.finalize(op_ids, device)
+
+        def _t(a, dtype=torch.long):
+            return torch.as_tensor(_np.asarray(a), dtype=dtype, device=device)
+
+        self.circ_end_fwd = _t(fwd_map[_np.asarray(self._circ_end_fwd, dtype=_np.int64)])
+        self.circ_end_bwd = _t(bwd_map[_np.asarray(self._circ_end_bwd, dtype=_np.int64)])
+
+        self.positions = {}
+        for op, plist in self._positions.items():
+            arr = _np.asarray(plist, dtype=_np.int64)
+            self.positions[op] = (_t(arr[:, 0]), _t(bwd_map[arr[:, 1]]), _t(fwd_map[arr[:, 2]]))
+
+        # circuits grouped by prep label (almost always a single group)
+        preps = {}
+        for ic, p in enumerate(self._prep_of_circuit):
+            preps.setdefault(p, []).append(ic)
+        self.circuits_by_prep = {p: _t(v) for p, v in preps.items()}
+        self.all_circuits_share_one_prep = len(preps) == 1
+
+        dense = _np.asarray(self._dense_rows, dtype=_np.int64)
+        out = _np.asarray(self._out_rows, dtype=_np.int64)
+        # Fast path: the group's dense rows are exactly its output rows, contiguous from
+        # out[0].  Then a whole column block can be written with a plain slice assignment.
+        self.contiguous_out = (
+            dense.size == self.num_circuits * self.n_eff
+            and _np.array_equal(dense, _np.arange(dense.size))
+            and _np.array_equal(out, out[0] + _np.arange(out.size))
+        ) if dense.size else False
+        self.out_slice = slice(int(out[0]), int(out[0]) + out.size) if self.contiguous_out else None
+        self.dense_rows = _t(dense)
+        self.out_rows = _t(out)
+        self.n_dense = self.num_circuits * self.n_eff
+
+        self._circ_end_fwd = self._circ_end_bwd = self._prep_of_circuit = None
+        self._positions = self._dense_rows = self._out_rows = None
+
+    # -- evaluation ---------------------------------------------------------------------------
+
+    def forward_states(self, torch_bases, dim, dtype, device):
+        """All prefix-DAG node states, shape ``(num_nodes, dim)``."""
+        dag = self.fwd
+        states = torch.empty((dag.num_nodes, dim), dtype=dtype, device=device)
+        for i, prep_label in enumerate(dag.root_keys):
+            states[i] = torch_bases[prep_label]
+        for op, lo, hi, src in dag.schedule:
+            # (m, dim) @ (dim, dim) computes  M @ r  for each row r, since (M r)^T = r^T M^T.
+            states[lo:hi] = states.index_select(0, src) @ torch_bases[op].transpose(-2, -1)
+        return states
+
+    def backward_states(self, torch_bases, dim, dtype, device, povm_mat):
+        """All suffix-DAG node states, shape ``(num_nodes, n_eff, dim)``."""
+        dag = self.bwd
+        n_eff = self.n_eff
+        states = torch.empty((dag.num_nodes, n_eff, dim), dtype=dtype, device=device)
+        states[0] = povm_mat
+        for op, lo, hi, src in dag.schedule:
+            sub = states.index_select(0, src)                      # (m, n_eff, dim)
+            states[lo:hi] = (sub.reshape(-1, dim) @ torch_bases[op]).view(-1, n_eff, dim)
+        return states
+
+
+class TorchEvalPlan:
+    """
+    A compiled, batched evaluation plan for a list of :class:`StatelessCircuit` objects.
+
+    Build it once per (circuit list, model structure); it is independent of the model's *parameter
+    values*, so it can be replayed for every iteration of a GST optimization.
+    """
+
+    def __init__(self, circuits, param_metadata, instrument_expansions, povm_effect_counts,
+                 outcome_probs_dim, dtype, device):
+        self.dtype = dtype
+        self.device = device
+        self.outcome_probs_dim = outcome_probs_dim
+
+        # A stable integer id per op label, used only to sort DAG nodes.
+        op_ids: Dict[Any, int] = {}
+        for c in circuits:
+            for ol in c.op_labels:
+                op_ids.setdefault(ol, len(op_ids))
+
+        groups: Dict[Any, _PovmGroup] = {}
+        elem_offset = 0
+        for c in circuits:
+            g = groups.get(c.povm_label)
+            if g is None:
+                g = groups[c.povm_label] = _PovmGroup(c.povm_label, povm_effect_counts[c.povm_label])
+            rows = (c.effect_row_indices if c.effect_row_indices is not None
+                    else range(g.n_eff))
+            g.add_circuit(c.prep_label, tuple(c.op_labels), rows, elem_offset)
+            elem_offset += c.outcome_probs_dim
+        assert elem_offset == outcome_probs_dim
+        for g in groups.values():
+            g.finalize(op_ids, device)
+        self.groups = list(groups.values())
+
+        # Column block (into the parameter vector) of each parameterized modelmember, plus the
+        # op labels its dense matrices appear under in a circuit.
+        self.param_metadata = param_metadata
+        self.instrument_expansions = instrument_expansions
+        self.op_labels = list(op_ids)
+
+    # -- diagnostics --------------------------------------------------------------------------
+
+    def stats(self):
+        gate_applications = sum(
+            int(idx[0].numel()) for g in self.groups for idx in g.positions.values())
+        return dict(
+            num_groups=len(self.groups),
+            num_circuits=sum(g.num_circuits for g in self.groups),
+            gate_applications=gate_applications,
+            prefix_nodes=sum(g.fwd.num_nodes for g in self.groups),
+            suffix_nodes=sum(g.bwd.num_nodes for g in self.groups),
+            forward_matmuls=sum(len(g.fwd.schedule) for g in self.groups),
+            backward_matmuls=sum(len(g.bwd.schedule) for g in self.groups),
+        )
+
+    # -- probabilities ------------------------------------------------------------------------
+
+    def probs(self, torch_bases, dim, out=None):
+        """Outcome probabilities for every circuit, in layout element order."""
+        if out is None:
+            out = torch.empty(self.outcome_probs_dim, dtype=self.dtype, device=self.device)
+        for g in self.groups:
+            fwd = g.forward_states(torch_bases, dim, self.dtype, self.device)
+            povm_mat = torch_bases[g.povm_label]
+            dense = (fwd.index_select(0, g.circ_end_fwd) @ povm_mat.transpose(-2, -1)).reshape(-1)
+            if g.contiguous_out:
+                out[g.out_slice] = dense
+            else:
+                out[g.out_rows] = dense[g.dense_rows]
+        return out
+
+    # -- Jacobian -----------------------------------------------------------------------------
+
+    def jacobian(self, free_params, dim, num_params, out=None, probs_out=None):
+        """
+        The ``(num_elements, num_params)`` Jacobian of the outcome probabilities.
+
+        `free_params` is the per-modelmember tuple produced by
+        ``StatelessModelCircuitStore.get_free_params``. The dense superoperators and their
+        derivatives with respect to the modelmember's own parameters are computed here (by
+        autodiff, per modelmember); everything downstream is explicit linear algebra.
+        """
+        dtype, device = self.dtype, self.device
+        torch_bases: Dict[Any, "torch.Tensor"] = {}
+        derivs: Dict[Any, Tuple[Any, "torch.Tensor", slice]] = {}
+        col = 0
+        for i, val in enumerate(free_params):
+            label, type_handle, sld = self.param_metadata[i]
+            base, jac = _member_value_and_jacobian(type_handle, sld, val)
+            torch_bases[label] = base
+            cols = slice(col, col + val.numel())
+            col += val.numel()
+            derivs[label] = (base, jac, cols)
+            expansions = self.instrument_expansions.get(label)
+            if expansions is not None:
+                for j, expanded in enumerate(expansions):
+                    torch_bases[expanded] = base[j]
+                    derivs[expanded] = (base[j], jac[j], cols)
+        assert col == num_params, (col, num_params)
+
+        if out is None:
+            out = torch.zeros((self.outcome_probs_dim, num_params), dtype=dtype, device=device)
+        else:
+            out.zero_()
+
+        # Which member-label a circuit op label draws its columns from (identity, except for
+        # instrument members, several of which share one member's column block).
+        member_of_op = {}
+        for label, _, _ in self.param_metadata:
+            expansions = self.instrument_expansions.get(label)
+            if expansions is None:
+                member_of_op.setdefault(label, label)
+            else:
+                for expanded in expansions:
+                    member_of_op[expanded] = label
+
+        for g in self.groups:
+            self._jacobian_group(g, torch_bases, derivs, member_of_op, dim, out, probs_out)
+        return out
+
+    def _jacobian_group(self, g, torch_bases, derivs, member_of_op, dim, out, probs_out):
+        dtype, device = self.dtype, self.device
+        n_eff, n_c, n_dense = g.n_eff, g.num_circuits, g.n_dense
+        d2 = dim * dim
+
+        povm_mat = torch_bases[g.povm_label]
+        fwd = g.forward_states(torch_bases, dim, dtype, device)
+        bwd = g.backward_states(torch_bases, dim, dtype, device, povm_mat)
+
+        r_end = fwd.index_select(0, g.circ_end_fwd)          # (n_c, dim)      R_L
+        l_end = bwd.index_select(0, g.circ_end_bwd)          # (n_c, n_eff, d) L_0
+
+        if probs_out is not None:
+            dense = (r_end @ povm_mat.transpose(-2, -1)).reshape(-1)
+            if g.contiguous_out:
+                probs_out[g.out_slice] = dense
+            else:
+                probs_out[g.out_rows] = dense[g.dense_rows]
+
+        def write(cols, block):
+            """Write a (n_dense, n_cols) block into the right rows/columns of `out`."""
+            if g.contiguous_out:
+                out[g.out_slice, cols] = block
+            else:
+                out[g.out_rows, cols] = block.index_select(0, g.dense_rows)
+
+        # --- gate blocks: A_g . (dM_g / dtheta) ------------------------------------------------
+        # Instrument members share a column block, so accumulate per member label first.
+        by_member: Dict[Any, List[Any]] = {}
+        for op in g.positions:
+            by_member.setdefault(member_of_op[op], []).append(op)
+
+        eff_arange = torch.arange(n_eff, dtype=torch.long, device=device)
+        for member, ops in by_member.items():
+            cols = derivs[member][2]
+            n_v = cols.stop - cols.start
+            if n_v == 0:
+                continue
+            block = None
+            for op in ops:
+                ci, lnode, rnode = g.positions[op]
+                a_mat = self._accumulate_a(g, fwd, bwd, ci, lnode, rnode, dim, eff_arange)
+                contrib = a_mat @ derivs[op][1].reshape(d2, n_v)
+                block = contrib if block is None else block + contrib
+            write(cols, block)
+
+        # --- prep block: L_0 . (d rho / d theta) -----------------------------------------------
+        for prep_label, circ_idx in g.circuits_by_prep.items():
+            _, jac, cols = derivs[prep_label]
+            n_v = cols.stop - cols.start
+            if n_v == 0:
+                continue
+            if g.all_circuits_share_one_prep:
+                block = l_end.reshape(-1, dim) @ jac.reshape(dim, n_v)
+                write(cols, block)
+            else:
+                sub = l_end.index_select(0, circ_idx).reshape(-1, dim) @ jac.reshape(dim, n_v)
+                rows = (circ_idx[:, None] * n_eff + eff_arange).reshape(-1)
+                dense_block = torch.zeros((n_dense, n_v), dtype=dtype, device=device)
+                dense_block[rows] = sub
+                write(cols, dense_block)
+
+        # --- POVM block: R_L contracted with (d E / d theta) ------------------------------------
+        _, jac, cols = derivs[g.povm_label]
+        n_v = cols.stop - cols.start
+        if n_v > 0:
+            w = jac.reshape(n_eff, dim, n_v)
+            block = torch.einsum('ca,ean->cen', r_end, w).reshape(n_dense, n_v)
+            write(cols, block)
+
+    def _accumulate_a(self, g, fwd, bwd, ci, lnode, rnode, dim, eff_arange):
+        """
+        ``A[(c,e), a, b] = sum_{positions p of this gate in circuit c} L_p[e,a] R_p[b]``,
+        returned flattened to ``(n_dense, dim*dim)``.
+        """
+        dtype, device = self.dtype, self.device
+        n_eff, n_dense = g.n_eff, g.n_dense
+        d2 = dim * dim
+        a_mat = torch.zeros((n_dense, d2), dtype=dtype, device=device)
+
+        n_pos = int(ci.numel())
+        per_pos_bytes = n_eff * d2 * torch.finfo(dtype).bits // 8
+        chunk = max(1, min(n_pos, _OUTER_PRODUCT_CHUNK_BYTES // max(per_pos_bytes, 1)))
+        for lo in range(0, n_pos, chunk):
+            hi = min(lo + chunk, n_pos)
+            l_sub = bwd.index_select(0, lnode[lo:hi])            # (m, n_eff, dim)
+            r_sub = fwd.index_select(0, rnode[lo:hi])            # (m, dim)
+            outer = (l_sub.unsqueeze(-1) * r_sub[:, None, None, :]).reshape(-1, d2)
+            rows = (ci[lo:hi, None] * n_eff + eff_arange).reshape(-1)
+            a_mat.index_add_(0, rows, outer)
+        return a_mat

--- a/pygsti/forwardsims/torchfwdsim_plan.py
+++ b/pygsti/forwardsims/torchfwdsim_plan.py
@@ -381,16 +381,14 @@ class TorchEvalPlan:
 
     # -- Jacobian -----------------------------------------------------------------------------
 
-    def jacobian(self, free_params, dim, num_params, out=None, probs_out=None):
+    def member_derivatives(self, free_params, num_params):
         """
-        The ``(num_elements, num_params)`` Jacobian of the outcome probabilities.
+        ``(torch_bases, derivs)``: each modelmember's dense torch_base, and its derivative with
+        respect to that member's own parameters together with the member's column block.
 
-        `free_params` is the per-modelmember tuple produced by
-        ``StatelessModelCircuitStore.get_free_params``. The dense superoperators and their
-        derivatives with respect to the modelmember's own parameters are computed here (by
-        autodiff, per modelmember); everything downstream is explicit linear algebra.
+        This is the only autodiff in the Jacobian, and its cost depends on the model, not on how
+        many circuits are being simulated.
         """
-        dtype, device = self.dtype, self.device
         torch_bases: Dict[Any, "torch.Tensor"] = {}
         derivs: Dict[Any, Tuple[Any, "torch.Tensor", slice]] = {}
         col = 0
@@ -407,6 +405,31 @@ class TorchEvalPlan:
                     torch_bases[expanded] = base[j]
                     derivs[expanded] = (base[j], jac[j], cols)
         assert col == num_params, (col, num_params)
+        return torch_bases, derivs
+
+    def jacobian(self, free_params, dim, num_params, out=None, probs_out=None):
+        """
+        The ``(num_elements, num_params)`` Jacobian of the outcome probabilities.
+
+        `free_params` is the per-modelmember tuple produced by
+        ``StatelessModelCircuitStore.get_free_params``. The dense superoperators and their
+        derivatives with respect to the modelmember's own parameters are computed here (by
+        autodiff, per modelmember); everything downstream is explicit linear algebra.
+        """
+        torch_bases, derivs = self.member_derivatives(free_params, num_params)
+        return self.jacobian_from_derivatives(torch_bases, derivs, dim, num_params,
+                                              out=out, probs_out=probs_out)
+
+    def jacobian_from_derivatives(self, torch_bases, derivs, dim, num_params,
+                                  out=None, probs_out=None):
+        """
+        The circuit-dependent half of :meth:`jacobian`, given the output of
+        :meth:`member_derivatives`.
+
+        Everything here is a fixed sequence of fixed-shape kernels determined by the plan, which is
+        what makes it capturable into a CUDA graph.
+        """
+        dtype, device = self.dtype, self.device
 
         if out is None:
             out = torch.zeros((self.outcome_probs_dim, num_params), dtype=dtype, device=device)

--- a/pygsti/forwardsims/torchfwdsim_plan.py
+++ b/pygsti/forwardsims/torchfwdsim_plan.py
@@ -179,23 +179,31 @@ class _SequenceDag:
         return new_of_old
 
 
-def _member_value_and_jacobian(type_handle, stateless_data, param_vec):
+def _member_value_and_jacobian(type_handle, stateless_data, param_vec, out_numel=None):
     """
     ``(torch_base(sd, v), d torch_base / d v)``. The Jacobian has shape ``out_shape + (n_v,)``;
     it is the *only* place autodiff is used, and it runs on a single modelmember's parameters, so
-    it is cheap regardless of how many circuits are being simulated.
+    its cost is independent of how many circuits are being simulated.
+
+    Reverse mode costs one pass per output element and forward mode one per parameter, so we pick
+    whichever dimension is smaller; pass `out_numel` (which the caller can remember from a previous
+    call, since it is fixed by the model's structure) to make that choice without an extra
+    evaluation. Either way the primal comes back out through ``has_aux`` rather than from a second
+    ``torch_base`` call -- for a CPTPLND modelmember that second call is a matrix exponential we
+    have already paid for.
     """
     def f(v):
-        return type_handle.torch_base(stateless_data, v)
+        out = type_handle.torch_base(stateless_data, v)
+        return out, out
 
-    out = f(param_vec)
     n_v = param_vec.numel()
     if n_v == 0:
+        out, _ = f(param_vec)
         return out, out.new_zeros(tuple(out.shape) + (0,))
-    if out.numel() <= n_v:
-        jac = torch.func.jacrev(f)(param_vec)
-    else:
-        jac = torch.func.jacfwd(f)(param_vec)
+    if out_numel is None:
+        out_numel = f(param_vec)[0].numel()
+    transform = torch.func.jacrev if out_numel <= n_v else torch.func.jacfwd
+    jac, out = transform(f, has_aux=True)(param_vec)
     return out, jac
 
 
@@ -221,6 +229,17 @@ class _PovmGroup:
         self._dense_rows: List[int] = []
         self._out_rows: List[int] = []
         self.num_circuits = 0
+
+    def register_roots(self, prep_label):
+        """
+        Create the DAG roots this group needs for `prep_label`.
+
+        Every root has to exist before any interior node does, so that roots occupy the lowest node
+        indices and stay at the front after the (depth, op-label) renumbering. Callers therefore
+        make one pass over the circuits registering roots before the pass that inserts them.
+        """
+        self.fwd.root(prep_label)
+        self.bwd.root(self.povm_label)
 
     def add_circuit(self, prep_label, op_labels, effect_rows: Sequence[int], elem_offset: int):
         ic = self.num_circuits
@@ -250,6 +269,10 @@ class _PovmGroup:
         def _t(a, dtype=torch.long):
             return torch.as_tensor(_np.asarray(a), dtype=dtype, device=device)
 
+        # Roots keep their relative order under the renumbering (they are the only depth-0 nodes,
+        # and the sort is stable), so root k of root_keys lands at new index k.
+        assert _np.array_equal(fwd_map[:self.fwd.num_roots], _np.arange(self.fwd.num_roots))
+        assert _np.array_equal(bwd_map[:self.bwd.num_roots], _np.arange(self.bwd.num_roots))
         self.circ_end_fwd = _t(fwd_map[_np.asarray(self._circ_end_fwd, dtype=_np.int64)])
         self.circ_end_bwd = _t(bwd_map[_np.asarray(self._circ_end_bwd, dtype=_np.int64)])
 
@@ -328,11 +351,14 @@ class TorchEvalPlan:
                 op_ids.setdefault(ol, len(op_ids))
 
         groups: Dict[Any, _PovmGroup] = {}
-        elem_offset = 0
-        for c in circuits:
+        for c in circuits:      # first pass: every DAG root, before any interior node
             g = groups.get(c.povm_label)
             if g is None:
                 g = groups[c.povm_label] = _PovmGroup(c.povm_label, povm_effect_counts[c.povm_label])
+            g.register_roots(c.prep_label)
+        elem_offset = 0
+        for c in circuits:
+            g = groups[c.povm_label]
             rows = (c.effect_row_indices if c.effect_row_indices is not None
                     else range(g.n_eff))
             g.add_circuit(c.prep_label, tuple(c.op_labels), rows, elem_offset)
@@ -347,6 +373,9 @@ class TorchEvalPlan:
         self.param_metadata = param_metadata
         self.instrument_expansions = instrument_expansions
         self.op_labels = list(op_ids)
+        self._member_out_numel = [None] * len(param_metadata)
+        # ^ torch_base's output size per member, learned on the first call so later calls can pick
+        #   reverse vs forward mode without evaluating torch_base an extra time.
 
     # -- diagnostics --------------------------------------------------------------------------
 
@@ -394,7 +423,9 @@ class TorchEvalPlan:
         col = 0
         for i, val in enumerate(free_params):
             label, type_handle, sld = self.param_metadata[i]
-            base, jac = _member_value_and_jacobian(type_handle, sld, val)
+            base, jac = _member_value_and_jacobian(type_handle, sld, val,
+                                                   out_numel=self._member_out_numel[i])
+            self._member_out_numel[i] = base.numel()
             torch_bases[label] = base
             cols = slice(col, col + val.numel())
             col += val.numel()

--- a/pygsti/modelmembers/operations/lindbladerrorgen.py
+++ b/pygsti/modelmembers/operations/lindbladerrorgen.py
@@ -751,43 +751,83 @@ class LindbladErrorgen(_LinearOperator, _Torchable):
 
     def stateless_data(self, real_dtype: _torch.dtype, device: _torch.Device):
         """
-        Returns `(G, blocks)` where `G` is the constant `(N, d2, d2)` term-superoperator stack
-        (`combined_lindblad_term_superops`) as a torch tensor, and `blocks` is a list, in
-        `coefficient_blocks` order, of `blk.stateless_data(...)`.
-        
-        The error generator is linear in the (per-block) block_data, so `torch_base` rebuilds it as
-        `einsum('i,ijk->jk', concat(block torch_bases), G).real` -- the differentiable analog of
-        `to_dense('HilbertSchmidt')`.  Dense path only.
+        Returns `(G_re, G_im, superop_shape, blocks, param_dims, block_is_complex)`, the constant
+        data `torch_base` needs to rebuild this error generator from a parameter tensor. `blocks`
+        is a list, in `coefficient_blocks` order, of `blk.stateless_data(...)`.
+
+        The error generator is linear in the (per-block) block_data, so `to_dense('HilbertSchmidt')`
+        amounts to `einsum('i,ijk->jk', concat(block_datas), G).real` against the constant
+        term-superoperator stack `G` (= `combined_lindblad_term_superops`, shape `(N, d2, d2)`).
+        Because only the *real part* of that contraction is kept,
+
+            Re(sum_i c_i G_i) = Re(c) . Re(G) - Im(c) . Im(G),
+
+        so we store `G` pre-split into two real `(N, d2*d2)` matrices rather than one complex
+        `(N, d2, d2)` stack. Two consequences, both of which matter a lot when
+        `TorchForwardSimulator` differentiates this map with `torch.func`:
+
+          * the contraction is real arithmetic, which is half the flops of the complex one, and
+          * written as a plain 2-D matmul it *vectorizes into a GEMM* under `vmap`, whereas the
+            3-D `einsum` vectorized into a batched GEMV that ran an order of magnitude below the
+            GPU's matrix-multiply throughput.
+
+        `Im(G)` is only kept for the coefficient rows belonging to blocks whose block_data is
+        complex (the Hamiltonian block's coefficients are real), and is `None` if there are none.
+        Dense path only.
         """
         assert self._rep_type != 'sparse superop', \
             "LindbladErrorgen.stateless_data (the torch path) requires a dense representation."
         const = _np.ascontiguousarray(self.combined_lindblad_term_superops)
-        G_dtype = _torch.complex64 if real_dtype.itemsize == 4 else _torch.complex128
-        G = _torch.from_numpy(const)
-        G = G.to(device=device, dtype=G_dtype)
+        n_terms = const.shape[0]
+        superop_shape = const.shape[1:]
+
+        block_is_complex = tuple(_np.iscomplexobj(blk.block_data) for blk in self.coefficient_blocks)
+        block_sizes = [blk.block_data.size for blk in self.coefficient_blocks]
+        assert sum(block_sizes) == n_terms, \
+            "the term-superoperator stack must have one entry per coefficient-block element"
+
+        def _to_torch(mx):
+            return _torch.from_numpy(_np.ascontiguousarray(mx)).to(device=device, dtype=real_dtype)
+
+        G_re = _to_torch(const.real.reshape(n_terms, -1))
+        if any(block_is_complex):
+            keep = _np.concatenate([_np.full(sz, is_c) for sz, is_c
+                                    in zip(block_sizes, block_is_complex)])
+            G_im = _to_torch(const.imag[keep].reshape(int(keep.sum()), -1))
+        else:
+            G_im = None
+
         blocks     = [ blk.stateless_data(real_dtype, device) for blk in self.coefficient_blocks ]
         param_dims = [ blk.num_params for blk in self.coefficient_blocks ]
-        return (G, blocks, param_dims)
+        return (G_re, G_im, superop_shape, blocks, param_dims, block_is_complex)
 
     @staticmethod
     def torch_base(sd, t_param):
         """Differentiable dense HS error generator from the parameter tensor `t_param`.
 
         Mirrors `to_dense('HilbertSchmidt')`: split `t_param` per block (`coefficient_blocks` order),
-        rebuild each block's block_data via `LindbladCoefficientBlock.torch_base`, concatenate the
-        raveled block_datas, and contract against the constant superop stack `G`.
+        rebuild each block's block_data via `LindbladCoefficientBlock.torch_base`, and contract the
+        raveled block_datas against the constant term-superoperator stack. See `stateless_data` for
+        why that contraction is kept as two real matmuls.
         """
-        G, blocks, param_dims = sd
-        comb = []
+        G_re, G_im, superop_shape, blocks, param_dims, block_is_complex = sd
+        re_parts = []
+        im_parts = []
         off = 0
-        for blk_sd, nP in zip(blocks, param_dims):
+        for blk_sd, nP, is_complex in zip(blocks, param_dims, block_is_complex):
             t_slice = t_param[off:off + nP]
             off += nP
-            bd = _LindbladCoefficientBlock.torch_base(blk_sd, t_slice)
-            comb.append(bd.ravel().to(G.dtype))
-        comb = _torch.cat(comb)
-        egen = _torch.einsum('i,ijk->jk', comb, G)
-        return egen.real
+            bd = _LindbladCoefficientBlock.torch_base(blk_sd, t_slice).ravel()
+            if is_complex:
+                assert bd.is_complex(), "block_data dtype changed since stateless_data was built"
+                re_parts.append(bd.real)
+                im_parts.append(bd.imag)
+            else:
+                re_parts.append(bd.real if bd.is_complex() else bd)
+        egen = _torch.cat(re_parts) @ G_re
+        if im_parts:
+            egen = egen - _torch.cat(im_parts) @ G_im
+        return egen.reshape(superop_shape)
 
     def to_sparse(self, on_space: SpaceT='minimal'):
         """

--- a/test/unit/objects/test_forwardsim.py
+++ b/test/unit/objects/test_forwardsim.py
@@ -767,3 +767,36 @@ def test_torch_circuit_store_is_reused_across_calls():
     model.from_vector(model.to_vector() + 0.01)
     model.sim.bulk_fill_dprobs(J2, layout, None)
     assert not np.allclose(J, J2)
+
+
+def test_torch_circuit_store_is_invalidated_by_reparameterization():
+    """The store bakes each modelmember's *type* and stateless data, so identity of the model
+    object is not enough to key the cache on: `convert_members_inplace` swaps member objects under
+    the same labels on the same model, and reusing the store then computes against stale types."""
+    import torch
+    model = smq1Q_XYI.target_model()
+    model.convert_members_inplace(to_type='full TP')
+    model = model.depolarize(op_noise=0.05, spam_noise=0.02)
+    model.sim = TorchForwardSimulator(dtype=torch.float64)
+    circuits = ForwardSimConsistencyTester.standard_lsgst_circuits(model, max_lengths=(1,))
+
+    layout = model.sim.create_layout(circuits, array_types=('ep',))
+    first = model.sim._circuit_store(layout)
+    assert model.sim._circuit_store(layout) is first
+
+    # Same model object, same layout object, different member types underneath.
+    model.convert_members_inplace(to_type='CPTPLND')
+    assert model.sim._circuit_store(layout) is not first, \
+        "reparameterizing in place must invalidate the cached store"
+
+    # ...and the answer it now produces must match a simulator that never had a stale cache.
+    # Both sides use the same simulator class and their own layout, so element order agrees.
+    J = np.empty((layout.num_elements, model.num_params))
+    model.sim.bulk_fill_dprobs(J, layout, None)
+
+    fresh = model.copy()
+    fresh.sim = TorchForwardSimulator(dtype=torch.float64)
+    fresh_layout = fresh.sim.create_layout(circuits, array_types=('ep',))
+    Jfresh = np.empty((fresh_layout.num_elements, fresh.num_params))
+    fresh.sim.bulk_fill_dprobs(Jfresh, fresh_layout, None)
+    assert np.allclose(J, Jfresh, atol=1e-12)

--- a/test/unit/objects/test_forwardsim.py
+++ b/test/unit/objects/test_forwardsim.py
@@ -631,3 +631,139 @@ class ForwardSimIntegrationTester(BaseProtocolData):
     def test_matrix_fwdsim(self):
         self._run(MatrixForwardSimulator)
 
+
+
+# --------------------------------------------------------------------------------------------
+# TorchForwardSimulator's batched evaluation plan (pygsti/forwardsims/torchfwdsim_plan.py)
+# --------------------------------------------------------------------------------------------
+
+def _dprobs_in_canonical_order(model, circuits, sim):
+    """`bulk_fill_dprobs` with rows reordered to (circuits in list order, outcomes sorted by name).
+
+    Different forward simulators build different Layout subclasses, which order elements
+    differently -- MatrixCOPALayout reorders circuits to make its evaluation tree efficient. Two
+    filled arrays are only comparable once both are put in a common order.
+    """
+    m = model.copy()
+    m.sim = sim
+    layout = m.sim.create_layout(circuits, array_types=('ep',))
+    J = np.empty((layout.num_elements, m.num_params))
+    P = np.empty(layout.num_elements)
+    m.sim.bulk_fill_dprobs(J, layout, P)
+
+    all_idx = np.arange(layout.num_elements)
+    perm = []
+    for c in circuits:
+        inds, outcomes = layout.indices_and_outcomes(c)
+        inds = all_idx[inds]
+        perm.extend(inds[np.argsort([str(o) for o in outcomes], kind='stable')])
+    perm = np.asarray(perm)
+    return P[perm], J[perm]
+
+
+def _two_prep_model_and_circuits():
+    """A noisy 1-qubit model with *two* state preps, and circuits that use both."""
+    model = smq1Q_XYI.target_model()
+    model.convert_members_inplace(to_type='full TP')
+    model = model.depolarize(op_noise=0.05, spam_noise=0.02)
+    model.preps['rho1'] = model.preps['rho0'].copy()
+    v = model.preps['rho1'].to_vector()
+    v[1:] = -0.7 * v[1:]
+    model.preps['rho1'].from_vector(v)
+    circuits = [
+        Circuit([L('rho0'), L('Gxpi2', 0)], line_labels=(0,)),
+        Circuit([L('rho1'), L('Gxpi2', 0), L('Gypi2', 0)], line_labels=(0,)),
+        Circuit([L('rho1')], line_labels=(0,)),                    # no operations at all
+        Circuit([L('rho0'), L('Gypi2', 0)], line_labels=(0,)),
+    ]
+    return model, circuits
+
+
+@pytest.mark.skipif(not TorchForwardSimulator.ENABLED, reason="PyTorch is not installed.")
+def test_torch_multiple_state_preps():
+    """A model with more than one state prep needs more than one root in the plan's prefix DAG.
+    Those roots have to be created before any interior node, or the renumbering that puts nodes in
+    (depth, gate) order no longer leaves the roots at the front."""
+    import torch
+    model, circuits = _two_prep_model_and_circuits()
+
+    ref_P, ref_J = _dprobs_in_canonical_order(model, circuits, MatrixForwardSimulator())
+    P, J = _dprobs_in_canonical_order(model, circuits,
+                                      TorchForwardSimulator(dtype=torch.float64))
+    assert np.allclose(P, ref_P, atol=1e-12)
+    assert np.allclose(J, ref_J, atol=1e-9)
+
+
+@pytest.mark.skipif(not TorchForwardSimulator.ENABLED, reason="PyTorch is not installed.")
+def test_torch_plan_batches_gate_applications():
+    """The plan must evaluate a circuit list with far fewer matrix products than there are gate
+    applications -- that batching is the whole point of it -- while still reproducing a plain
+    per-circuit, per-layer evaluation exactly."""
+    import torch
+    from pygsti.forwardsims.torchfwdsim_plan import TorchEvalPlan
+
+    model = smq1Q_XYI.target_model()
+    model.convert_members_inplace(to_type='full TP')
+    model = model.depolarize(op_noise=0.05, spam_noise=0.02)
+    circuits = ForwardSimConsistencyTester.standard_lsgst_circuits(model, max_lengths=(1, 2, 4, 8))
+
+    model.sim = TorchForwardSimulator(dtype=torch.float64)
+    layout = model.sim.create_layout(circuits)
+    store = model.sim._circuit_store(layout)
+    plan = store.eval_plan
+    stats = plan.stats()
+
+    batched = stats['forward_matmuls'] + stats['backward_matmuls']
+    assert stats['gate_applications'] > 5 * batched, \
+        f"expected heavy batching, got {stats['gate_applications']} applications in {batched} matmuls"
+    assert stats['prefix_nodes'] < stats['gate_applications'], "no prefix sharing was found"
+
+    # ... and the batched result equals the naive one.
+    free_params = store.get_free_params(model, torch.float64, store.device)
+    torch_bases = store.get_torch_bases(free_params)
+    batched_probs = plan.probs(torch_bases, store.model_dim).cpu().numpy()
+
+    naive = []
+    for c in store.circuits:
+        superket = torch_bases[c.prep_label]
+        for op_label in c.op_labels:
+            superket = torch_bases[op_label] @ superket
+        povm_mat = torch_bases[c.povm_label]
+        if c.effect_row_indices is not None:
+            povm_mat = povm_mat[c.effect_row_indices]
+        naive.append(povm_mat @ superket)
+    naive = torch.concat(naive).cpu().numpy()
+
+    assert np.allclose(batched_probs, naive, atol=1e-13)
+
+
+@pytest.mark.skipif(not TorchForwardSimulator.ENABLED, reason="PyTorch is not installed.")
+def test_torch_circuit_store_is_reused_across_calls():
+    """Building the StatelessModelCircuitStore (and its evaluation plan) walks every circuit in
+    Python. GST calls the simulator once or twice per optimizer iteration against a fixed layout,
+    so that work must be done once, not once per call."""
+    import torch
+    model = smq1Q_XYI.target_model()
+    model.convert_members_inplace(to_type='full TP')
+    model = model.depolarize(op_noise=0.05, spam_noise=0.02)
+    model.sim = TorchForwardSimulator(dtype=torch.float64)
+    circuits = ForwardSimConsistencyTester.standard_lsgst_circuits(model, max_lengths=(1, 2))
+
+    layout = model.sim.create_layout(circuits, array_types=('ep',))
+    J = np.empty((layout.num_elements, model.num_params))
+    model.sim.bulk_fill_dprobs(J, layout, None)
+    first = model.sim._circuit_store(layout)
+    plan = first.eval_plan
+    model.sim.bulk_fill_dprobs(J, layout, None)
+    assert model.sim._circuit_store(layout) is first
+    assert first.eval_plan is plan
+
+    # A different layout must not silently reuse the old plan.
+    other_layout = model.sim.create_layout(circuits[:3], array_types=('ep',))
+    assert model.sim._circuit_store(other_layout) is not first
+
+    # The Jacobian must still track parameter changes through the reused store.
+    J2 = np.empty_like(J)
+    model.from_vector(model.to_vector() + 0.01)
+    model.sim.bulk_fill_dprobs(J2, layout, None)
+    assert not np.allclose(J, J2)


### PR DESCRIPTION
Edit (Sep 17, 2026): revised after @sserita's review. #917, now merged into this branch, changed how the circuit-store cache is keyed, and the review asked for two tests, a docstring pointer, and a slicing fix. The cache-semantics, tests, and open-items sections below describe the branch as it stands today. The measurements are unchanged.

I want `TorchForwardSimulator` to be useful on large GST problems. Before this PR it was correct, but its CPU-mode performance wasn't competitive with MPI-accelerated `MapForwardSimulator`. What follows is written by the robot, with editing by me; "we" refers to the robot and me.

The attached Zip folder contains presentations the robot made at my direction. Interested readers should check out `draft-1/slides.html`. [Link: presentations.zip](https://github.com/user-attachments/files/31810208/presentations.zip)


## Context

The test instance throughout is leakage GST on a six-level (qubit ⊗ qutrit) model with the CPTPLND parameterization. Such models are easy to build: take a 2-qubit modelpack and apply `promote_bb_to_bt` from `pygsti.leakage.models`. I used the `smq2Q_XYICNOT` model and edesign; the promoted CPTPLND model has 10,080 parameters. At L = 16 one Jacobian took 24.8 seconds on a GH200. `MapForwardSimulator` on 32 MPI ranks of the same host takes 45 seconds for that Jacobian, so the GPU path was already the fastest option and still far too slow to be useful. (I didn't test CPU-only `TorchForwardSimulator` on the GH200 box, but I could have.)

The starting point was a conversation with an NVIDIA engineer who looked at `TorchForwardSimulator`. He observed that we had far too many kernel launches: one GEMV per gate application.

## Findings

The launch count is worse than "one GEMV per gate application" makes it sound. The L = 16 circuit list has 98,577 gate applications, so a probability call issued about 10⁵ launches of a 36 × 36 matvec. The Jacobian came from pushing `torch.func.jacfwd` (or `jacrev`) through that same Python loop, which kept every launch and multiplied the working set by the parameter count; the profiler counted 430,411 launches for one Jacobian call. The GPU was idle almost all of the time, and no tuning inside the matvec could have helped.

Fixing that exposed three more problems, none visible while launch overhead dominated.

1. `LindbladErrorgen.torch_base` contracted the complex term-superoperator stack with an `einsum` that, under the `vmap` used by `torch.func`, vectorized into a batched GEMV running at about 3.7 TFLOP/s. That one kernel was 44% of all GPU time in a CPTPLND Jacobian. We didn't set out to touch `LindbladErrorgen`; the profiler sent us there.
2. Copying the Jacobian to the host went through `J.cpu().numpy()`, which allocates a buffer the size of the Jacobian and then copies it a second time into the caller's array. For a 2.63 GiB Jacobian that round trip cost several times the transfer itself.
3. `StatelessModelCircuitStore` was rebuilt on every call, walking every circuit in Python, though nothing about it depends on parameter values. The `TODO` in `_bulk_fill_dprobs` already said as much.

After this PR the same warm Jacobian call takes 120 ms (208× faster), with results unchanged to about 1e-9 relative against finite differences.

## What changed, by how much it can affect users

### Things users will notice

**The simulator is much faster, and nothing else about it should look different.** Same constructor, same `bulk_fill_probs` / `bulk_fill_dprobs` contract, same dtypes and devices.

### Things with low exposure that reviewers should still look at

**The circuit store is cached across calls, keyed on object identity.** `StatelessModelCircuitStore` and its evaluation plan depend only on the structure of the (layout, model) pair, so an optimizer now pays for them once per layout rather than once per iteration. The semantics:

1. The cache holds one entry, keyed on the identity of the layout, the identity of the model, and the identity of each parameterized member together with its label. All of these must match for reuse.
2. Everything in the key is held by weak reference, so the cache can't keep a layout, a model, or a member alive.
3. Member identity is the right key because the store bakes each member's type and `stateless_data`, and because `set_all_parameterizations` and `convert_members_inplace` always install new member objects under the same labels. An earlier version of this branch keyed on `(label, type, num_params)` per member instead. @sserita found that converting CPTPLND to GLND at the target point preserves both type and parameter count while changing which Lindblad coefficient blocks are active, so the stale store was reused silently; his script shows a 0.07 absolute error in the probabilities. #917 made the change.
4. The key does not detect in-place mutation of a static member's dense matrix, whose value is baked into `stateless_data`, and it does not detect `ComposedOp.append`/`insert`/`remove`, which change a container's factors without replacing the container. We consider the first out of contract; the docstring says to reassign `model.sim` if you do it. The second is a residual gap that we haven't confirmed and haven't closed; `_model_signature`'s docstring records it.

**`LindbladErrorgen.stateless_data` returns a different tuple.** It was `(G, blocks, param_dims)` with `G` a complex `(N, d², d²)` stack. It is now `(G_re, G_im, superop_shape, blocks, param_dims, block_is_complex)` with `G` pre-split into real `(N, d²·d²)` matrices. The only consumer is `LindbladErrorgen.torch_base`, and every wrapper in the Torchable protocol passes the tuple through opaquely, so we believe nothing else is affected. Grep for `stateless_data` if you doubt that; we did.

### Things that are internal

**Batched prefix and suffix DAG evaluation** (`pygsti/forwardsims/torchfwdsim_plan.py`, new). Circuits are inserted into a prefix DAG and a suffix DAG over op-label sequences. Each DAG is evaluated breadth-first, one dense matrix-matrix product per (depth, gate label) pair. Nodes are numbered so that every (depth, gate) group is contiguous, so each step writes into a slice of the state tensor and only the source side needs a gather. On the L = 16 design this is 245 batched matmuls instead of 98,577 matvecs, and prefix sharing cuts the arithmetic by 9.4×. `MapForwardSimulator` gets the same prefix sharing from `PrefixTable`, but walks its table one state propagation at a time; the suffix DAG has no counterpart there, since `MapForwardSimulator` differentiates by finite differences. The module docstring says this too.

**An analytic Jacobian with respect to the dense superoperators.** Write `R_k` for the prefix state after `k` gates and `L_k` for the suffix state before gate `k+1`. Then `∂p_c/∂M_g` is a sum of rank-one terms `L_k ⊗ R_{k−1}` over the occurrences of gate `g` in circuit `c`; repeated germs mean a gate usually occurs many times in one circuit. The plan assembles that tensor with a chunked scatter-add of outer products per gate (temporaries capped at 256 MiB) and contracts it against `∂M_g/∂θ_g`. That second factor still comes from `torch.func.jacrev` on each member's `Torchable.torch_base`, so PyTorch still differentiates every parameterization; it just no longer differentiates the circuit loop. Prep and POVM blocks fall out of the same two DAGs. Instruments whose expanded members share a parameter block accumulate into that block before it's written.

**The error-generator contraction is a real GEMM.** Since only the real part of the contraction is kept, `Re(Σᵢ cᵢ Gᵢ) = Re(c)·Re(G) − Im(c)·Im(G)`, so `torch_base` is now two 2-D real matmuls: half the flops, and a 2-D matmul vectorizes into a GEMM. `Im(G)` is kept only for coefficient blocks whose `block_data` is complex (the Hamiltonian block's is real). On the headline Jacobian this took the kernel from 26.6 ms to negligible and the whole call from 144 ms to 115 ms at the time.

**Device-to-host copies write straight into the caller's array.** `_copy_to_numpy` wraps the destination with `torch.from_numpy` so the copy engine writes into it directly, falling back to the old path for arrays that can't be wrapped. Probabilities requested alongside the Jacobian are now produced on-device by the same plan and copied out the same way.

## Measurements

All numbers are from one GH200 in float64. "Warm" is the median of calls after the first against a fixed layout, which is what GST pays per optimizer iteration. Each (instance, simulator) pair ran in a fresh process with CUDA synchronized around the timed region. "Before" is pyGSTi at `ed579556c`. `bt6` is the qubit ⊗ qutrit model and `2q` the plain two-qubit model, both on the `smq2Q_XYICNOT` design.

| instance | HS dim | params | circuits | elements | before | after | speedup |
|---|---|---|---|---|---|---|---|
| `2q-hs-L8` | 16 | 240 | 6,131 | 24,524 | 8.42 s | 51 ms | 165× |
| `bt6-hs-L8` | 36 | 560 | 6,131 | 24,524 | 8.73 s | 58 ms | 151× |
| `bt6-hs-L16` | 36 | 560 | 8,740 | 34,960 | 16.0 s | 69 ms | 231× |
| `bt6-cptp-L8` | 36 | 10,080 | 6,131 | 24,524 | 14.8 s | 88 ms | 169× |
| `bt6-cptp-L16` | 36 | 10,080 | 8,740 | 34,960 | 24.8 s | 120 ms | 208× |

Kernel launches on `bt6-cptp-L16`: `_bulk_fill_dprobs` went from 430,411 to 1,555, and `_bulk_fill_probs` from 107,632 to 518. `_bulk_fill_probs` on its own went from 1.98 s to 26 ms.

Of the 98.5 ms in the profiled headline call, about 32 ms is the per-member `torch_base` derivatives, 39 ms is the DAG replay plus the rank-one assembly and contraction, and 10 ms is copying the 2.63 GiB Jacobian to the host. GPU kernels account for 34 ms of the 72 ms device phase. In our assessment the device side is now latency-bound; two further kernel-level optimizations barely moved the wall clock, and we stopped there.

For scale only: `MapForwardSimulator` on this Jacobian takes 153 s on one MPI rank and bottoms out at 45.2 s on 32 ranks. Those are single warm calls with `PYGSTI_USE_SHARED_MEMORY=0` (the container's `/dev/shm` is 64 MB), so they aren't the default GST-under-MPI configuration.

## Correctness

Torch on CPU and GPU agree with `MatrixForwardSimulator` and with a finite-difference Jacobian to relative error between 4e-10 and 3e-9 on every instance above (all 240 columns on `2q-hs-L8`, subsets of columns on the others). That is the FD error `MatrixForwardSimulator` itself shows, so the residual is the finite differences. Probabilities agree to about 2e-15 absolute. On a one-qubit LSGST model against the analytic `MatrixForwardSimulator` Jacobian, float64 agrees to 3e-15 and float32 to 1.6e-7, on both devices. Note that different simulators build different `Layout` subclasses with different element orders, so every cross-simulator comparison canonicalizes to (circuit, outcome) order first.

## Tests

Seven test functions are new in `test/unit/objects/test_forwardsim.py`, each skipped when PyTorch isn't installed.

* `test_torch_multiple_state_preps` uses a model with two state preps, which needs two roots in the prefix DAG, and compares probabilities and Jacobian to `MatrixForwardSimulator`.
* `test_torch_plan_batches_gate_applications` checks that the plan issues far fewer matmuls than there are gate applications, and that its probabilities equal a plain per-circuit, per-layer evaluation.
* `test_torch_circuit_store_is_reused_across_calls` checks that the store persists across calls on one layout, isn't shared across layouts, and still tracks parameter changes.
* `test_torch_circuit_store_is_invalidated_by_reparameterization` converts a model from full TP to CPTPLND in place and compares the Jacobian to a fresh simulator's.
* `test_torch_circuit_store_invalidated_by_type_preserving_reparameterization`, from #917, does the same for the three conversions that preserve type and parameter count: CPTPLND/GLND, H/S, and H+S/H+s.
* `test_torch_plan_instrument_jacobian` runs circuits with `Instrument` and `TPInstrument` layers, one of them with two instrument layers, and compares the Jacobian element-wise to `MatrixForwardSimulator`. It also checks that the plan routes both expanded members into one column block. The instrument consistency Testers already ran the torch simulator on these circuits, but they only check colinearity across simulators.
* `test_torch_plan_scattered_output_rows_jacobian` builds a dataset layout in which one circuit's outcomes are reversed relative to `povm.keys()` and another's are a strict subset. Every group in the plan then takes the scattered-write path rather than the contiguous slice. Probabilities and Jacobian rows are compared per (circuit, outcome) to `MatrixForwardSimulator`. Flipping the gather indices in that path makes the test fail.

We ran `test/unit/objects`, `test/unit/modelmembers`, and `test/unit/algorithms` together at the current head: 2159 passed, 20 skipped, 1 xfailed. We have not run `test/test_packages`.

## How we'd suggest reviewing this

Read the module docstring of `torchfwdsim_plan.py` first; it derives the rank-one Jacobian formula and is the fastest way to decide whether you believe the approach. Then `_jacobian_group` and `_accumulate_a` in the same file, where that formula meets `index_add_` and where an indexing mistake would hide if there is one. `_circuit_store` and `_model_signature` in `torchfwdsim.py` are short and deserve a skeptical read against the cache semantics above. The `lindbladerrorgen.py` change is mechanical once you accept the real-part identity.

## What we haven't done

We haven't run an end-to-end GST fit on this branch. Every timing and check above isolates a single `bulk_fill_dprobs` call against a fixed layout; a real fit is the only thing that exercises the store cache across L-stages and across the reparameterizations `set_all_parameterizations` performs. We'd want that before a release.

The timings were taken at `7c3d1ef32`. The head now also runs a per-call cache check, a handful of `is` comparisons, one per parameterized member. We expect that to be unmeasurable against 120 ms, but we haven't re-timed it.

`StatelessModelCircuitStore.circuit_probs_from_free_params` and `default_to_reverse_ad` remain but the simulator no longer routes through them; we left them rather than decide their fate here. Sparse-superop `LindbladErrorgen` representations remain unsupported on the torch path, as before, and we did nothing for multiple GPUs or nodes.

@sserita points out that the suffix-DAG Jacobian applies to `MapForwardSimulator` as well, since `deriv_wrt_params` and most `adjoint_acton` implementations already exist, and that `OpCRep_ExpErrorgen::adjoint_acton` is the blocker for the CPTPLND case. That is #918, with a proof of concept, and not part of this PR.
